### PR TITLE
merged #2409 from mylar2.  Updated to use extract_image instead of URL call.

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -1368,6 +1368,9 @@
                              <div class="row checkbox">
                                  <input type="checkbox" name="pushover_onsnatch" value="1" ${config['pushover_onsnatch']} /><label>Notify on snatch?</label>
                              </div>
+                             <div class="row checkbox">
+                                 <input type="checkbox" name="pushover_image" title="Include cover image when sending post-processing notifs" value="1" ${config['pushover_image']} /><label>Post-processing with cover?</label>
+                             </div>
                              <div class="row">
                                  <label>Priority (-2,-1,0,1 or 2):</label>
                                  <input type="text" name="pushover_priority" value="${config['pushover_priority']}" size="2">
@@ -1446,6 +1449,9 @@
                              </div>
                              <div class="row checkbox">
                                  <input type="checkbox" name="telegram_onsnatch" value="1" ${config['telegram_onsnatch']} /><label>Notify on snatch?</label>
+                             </div>
+                             <div class="row checkbox">
+                                 <input type="checkbox" name="telegram_image" title="Include cover image when sending post-processing notifs" value="1" ${config['telegram_image']} /><label>Post-processing with cover?</label>
                              </div>
                              <div align="center" class="row">
                                  <img name="telegram_statusicon" id="telegram_statusicon" src="interfaces/default/images/success.png" style="float:right;visibility:hidden;" height="20" width="20" />

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -162,6 +162,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'PUSHOVER_DEVICE': (str, 'PUSHOVER', None),
     'PUSHOVER_USERKEY': (str, 'PUSHOVER', None),
     'PUSHOVER_ONSNATCH': (bool, 'PUSHOVER', False),
+    'PUSHOVER_IMAGE': (bool, 'PUSHOVER', False),
 
     'BOXCAR_ENABLED': (bool, 'BOXCAR', False),
     'BOXCAR_ONSNATCH': (bool, 'BOXCAR', False),
@@ -177,6 +178,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'TELEGRAM_TOKEN': (str, 'TELEGRAM', None),
     'TELEGRAM_USERID': (str, 'TELEGRAM', None),
     'TELEGRAM_ONSNATCH': (bool, 'TELEGRAM', False),
+    'TELEGRAM_IMAGE': (bool, 'TELEGRAM', False),
 
     'SLACK_ENABLED': (bool, 'SLACK', False),
     'SLACK_WEBHOOK_URL': (str, 'SLACK', None),

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -519,7 +519,7 @@ class FileChecker(object):
                 for x in list(wrds):
                     if x != '':
                         tmpissue_number = re.sub('XCV', x, split_file[split_file.index(sf)])
-                logger.info('[SPECIAL-CHARACTER ISSUE] Possible issue # : %s' % tmpissue_number)
+                logger.fdebug('[SPECIAL-CHARACTER ISSUE] Possible issue # : %s' % tmpissue_number)
                 possible_issuenumbers.append({'number':       sf,
                                               'position':     split_file.index(sf),
                                               'mod_position': self.char_file_position(modfilename, sf, lastmod_position),
@@ -736,7 +736,7 @@ class FileChecker(object):
                     except ValueError as e:
                        #10-20-2018 - to detect issue numbers such as #000.0000½
                         if lastissue_label is not None and lastissue_position == int(split_file.index(sf))-1 and sf == 'XCV':
-                            logger.info('this should be: %s%s' % (lastissue_label, sf))
+                            logger.fdebug('this should be: %s%s' % (lastissue_label, sf))
                             pi = []
                             for x in possible_issuenumbers:
                                 if (x['number'] == lastissue_label and x['position'] == lastissue_position) or (x['number'] == sf and x['position'] == split_file.index(sf, lastissue_position)):
@@ -757,10 +757,10 @@ class FileChecker(object):
                                 possible_issuenumbers = pi
 
                         elif sf.lower() == 'of' and lastissue_label is not None and lastissue_position == int(split_file.index(sf))-1:
-                            logger.info('MINI-SERIES DETECTED')
+                            logger.fdebug('MINI-SERIES DETECTED')
                         else:
                             if any([re.sub('[\(\)]', '', sf.lower()).strip() == 'tpb', re.sub('[\(\)]', '', sf.lower()).strip() == 'digital tpb']):
-                                logger.info('TRADE PAPERBACK DETECTED. NOT DETECTING ISSUE NUMBER - ASSUMING VOLUME')
+                                logger.fdebug('TRADE PAPERBACK DETECTED. NOT DETECTING ISSUE NUMBER - ASSUMING VOLUME')
                                 booktype = 'TPB'
                                 try:
                                     if volume_found['volume'] is not None:
@@ -775,7 +775,7 @@ class FileChecker(object):
                                                                   'validcountchk': validcountchk})
 
                             elif any([sf.lower() == 'gn', sf.lower() == 'graphic novel']):
-                                logger.info('GRAPHIC NOVEL DETECTED. NOT DETECTING ISSUE NUMBER - ASSUMING VOLUME')
+                                logger.fdebug('GRAPHIC NOVEL DETECTED. NOT DETECTING ISSUE NUMBER - ASSUMING VOLUME')
                                 booktype = 'GN'
                             else:
                                 if 'could not convert string to float' not in str(e):
@@ -835,7 +835,7 @@ class FileChecker(object):
             else:
                 if len(possible_issuenumbers) > 0:
                     for x in possible_years:
-                        logger.info('yearposition[%s] -- dc[position][%s]' % (yearposition, x['yearposition']))
+                        logger.fdebug('yearposition[%s] -- dc[position][%s]' % (yearposition, x['yearposition']))
                         if yearposition < x['yearposition']:
                             if all([len(possible_issuenumbers) == 1, possible_issuenumbers[0]['number'] == x['year'], x['yearposition'] != possible_issuenumbers[0]['position']]):
                                 issue2year = True
@@ -911,7 +911,7 @@ class FileChecker(object):
                             continue
                         #2019-10-05 fix - if decimal-spaced filename has a series title with a hyphen will include issue # as part of series title
                         elif yearposition == pis['position']:
-                            logger.info('Already validated year, ignoring as possible issue number: %s' % pis['number'])
+                            logger.fdebug('Already validated year, ignoring as possible issue number: %s' % pis['number'])
                             continue
                         #end 2019-10-05
                     elif yearposition == pis['position']:
@@ -959,12 +959,12 @@ class FileChecker(object):
 
         if issue_number is None:
             if any([booktype == 'TPB', booktype == 'GN']):
-                logger.info('%s detected. Volume assumption is number: %s' % (booktype, volume_found))
+                logger.fdebug('%s detected. Volume assumption is number: %s' % (booktype, volume_found))
             else:
                 if len(volume_found) > 0:
-                    logger.info('UNKNOWN TPB/GN detected. Volume assumption is number: %s' % (volume_found))
+                    logger.fdebug('UNKNOWN TPB/GN detected. Volume assumption is number: %s' % (volume_found))
                 else:
-                    logger.info('No issue number present in filename.')
+                    logger.fdebug('No issue number present in filename.')
         else:
             logger.fdebug('issue verified as : %s' % issue_number)
         issue_volume = None
@@ -1187,7 +1187,7 @@ class FileChecker(object):
         if (any([issue_number is None, series_name is None]) and booktype == 'issue'):
 
             if all([issue_number is None, booktype == 'issue', issue_volume is not None]):
-                logger.info('Possible UKNOWN TPB/GN detected - no issue number present, no clarification in filename, but volume present with series title')
+                logger.fdebug('Possible UKNOWN TPB/GN detected - no issue number present, no clarification in filename, but volume present with series title')
             else:
                 logger.fdebug('Cannot parse the filename properly. I\'m going to make note of this filename so that my evil ruler can make it work.')
 
@@ -1215,7 +1215,6 @@ class FileChecker(object):
                         'reading_order':       None}
 
         if self.justparse:
-            logger.info('justparsed.')
             return {'parse_status':           'success',
                     'type':                   re.sub('\.','', filetype).strip(),
                     'sub':                    path_list,

--- a/mylar/getimage.py
+++ b/mylar/getimage.py
@@ -1,0 +1,117 @@
+#  This file is part of Mylar.
+# -*- coding: utf-8 -*-
+#
+#  Mylar is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Mylar is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.rarfile import rarfile
+import zipfile
+from io import BytesIO
+
+try:
+    from PIL import Image
+    from PIL import ImageFile
+    ImageFile.LOAD_TRUNCATED_IMAGES = True
+    PIL_Found = True
+except Exception as e:
+    logger.warn('[WARNING] PIL is not available - it\'s used to resize images for notifications, and other things.')
+    logger.warn('[WARNING] Using fallback method of URL / no image - install PIL with pip: pip install PIL')
+    PIL_Found = False
+
+import os
+import re
+import base64
+from operator import itemgetter
+
+import mylar
+from mylar import logger, helpers
+
+
+def extract_image(location, single=False, imquality=None):
+    #location = full path to the cbr/cbz (filename included in path)
+    #single = should be set to True so that a single file can have the coverfile
+    #        extracted and have the cover location returned to the calling function
+    #imquality = the calling function ('notif' for notifications will initiate a resize image before saving the cover)
+    if PIL_Found is False:
+        return
+    cover = "notfound"
+    pic_extensions = ('.jpg','.png','.webp')
+    modtime = os.path.getmtime(location)
+    low_infile = 999999
+    local_filename = os.path.join(mylar.CONFIG.CACHE_DIR, 'temp_notif')
+    cb_filename= None
+    cb_filenames=[]
+    metadata = None
+    if single is True:
+        if location.endswith(".cbz"):
+            location_in = zipfile.ZipFile(location)
+        else:
+            location_in = rarfile.RarFile(location)
+        try:
+            for infile in location_in.infolist():
+                #if cover == 'found': break
+
+                tmp_infile = re.sub("[^0-9]","", infile.filename).strip()
+                extension = infile.filename[-4:]
+                if tmp_infile == '':
+                    pass
+                elif int(tmp_infile) < int(low_infile):
+                    low_infile = tmp_infile
+                    low_infile_name = infile.filename
+                if infile.filename == 'ComicInfo.xml':
+                    logger.fdebug('Extracting ComicInfo.xml to display.')
+                    metadata = location_in.read(infile.filename)
+                    if cover == 'found': break
+                if any(['000.' in infile.filename, '00.' in infile.filename]) and infile.filename.endswith(pic_extensions) and cover == "notfound":
+                    cb_filename = infile.filename
+                    cover = "found"
+                elif any(['00a' in infile.filename, '00b' in infile.filename, '00c' in infile.filename, '00d' in infile.filename, '00e' in infile.filename]) and infile.filename.endswith(pic_extensions) and cover == "notfound":
+                    altlist = ('00a', '00b', '00c', '00d', '00e')
+                    for alt in altlist:
+                        if alt in infile.filename:
+                            cb_filename = infile.filename
+                            cover = "found"
+                        break
+
+                elif (any(['001.jpg' in infile.filename, '001.png' in infile.filename, '001.webp' in infile.filename, '01.jpg' in infile.filename, '01.png' in infile.filename, '01.webp' in infile.filename]) or all(['0001' in infile.filename,  infile.filename.endswith(pic_extensions)]) or all(['01' in infile.filename, infile.filename.endswith(pic_extensions)])) and cover == "notfound":
+                    cb_filenames.append(infile.filename)
+                    #cover = "found"
+            if cover != "found" and len(cb_filenames) > 0:
+                logger.fdebug('Invalid naming sequence for jpgs discovered. Attempting to find the lowest sequence and will use as cover (it might not work). Currently : %s' % (low_infile_name))
+                cb_filename = low_infile_name
+                cover = "found"
+
+        except Exception as e:
+            logger.error('[ERROR] Unable to properly retrieve the cover. It\'s probably best to re-tag this file : %s' % e)
+            return
+
+        logger.info('cb_filename set to : %s' % cb_filename)
+
+        if extension is not None:
+            ComicImage = local_filename + extension
+            try:
+                insidefile = location_in.getinfo(cb_filename)
+                img = Image.open( BytesIO( location_in.read(insidefile) ))
+                wpercent = (600/float(img.size[0]))
+                hsize = int((float(img.size[1])*float(wpercent)))
+                img = img.resize((600, hsize), Image.ANTIALIAS)
+                output = BytesIO()
+                img.save(output, format="JPEG")
+                ComicImage = str(base64.b64encode(output.getvalue()), 'utf-8')
+                output.close()
+
+            except Exception as e:
+                logger.warn('[WARNING] Unable to resize existing image: %s' % e)
+        else:
+            ComicImage = local_filename
+    return {'ComicImage': ComicImage, 'metadata': metadata}

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5076,6 +5076,7 @@ class WebInterface(object):
                     "prowl_priority": mylar.CONFIG.PROWL_PRIORITY,
                     "pushover_enabled": helpers.checked(mylar.CONFIG.PUSHOVER_ENABLED),
                     "pushover_onsnatch": helpers.checked(mylar.CONFIG.PUSHOVER_ONSNATCH),
+                    "pushover_image": helpers.checked(mylar.CONFIG.PUSHOVER_IMAGE),
                     "pushover_apikey": mylar.CONFIG.PUSHOVER_APIKEY,
                     "pushover_userkey": mylar.CONFIG.PUSHOVER_USERKEY,
                     "pushover_device": mylar.CONFIG.PUSHOVER_DEVICE,
@@ -5090,6 +5091,7 @@ class WebInterface(object):
                     "pushbullet_channel_tag": mylar.CONFIG.PUSHBULLET_CHANNEL_TAG,
                     "telegram_enabled": helpers.checked(mylar.CONFIG.TELEGRAM_ENABLED),
                     "telegram_onsnatch": helpers.checked(mylar.CONFIG.TELEGRAM_ONSNATCH),
+                    "telegram_image": helpers.checked(mylar.CONFIG.TELEGRAM_IMAGE),
                     "telegram_token": mylar.CONFIG.TELEGRAM_TOKEN,
                     "telegram_userid": mylar.CONFIG.TELEGRAM_USERID,
                     "slack_enabled": helpers.checked(mylar.CONFIG.SLACK_ENABLED),
@@ -5390,8 +5392,8 @@ class WebInterface(object):
                            'failed_auto', 'post_processing', 'enable_check_folder', 'enable_pre_scripts', 'enable_snatch_script', 'enable_extra_scripts',
                            'enable_meta', 'cbr2cbz_only', 'ct_tag_cr', 'ct_tag_cbl', 'ct_cbz_overwrite', 'rename_files', 'replace_spaces', 'zero_level',
                            'lowercase_filenames', 'autowant_upcoming', 'autowant_all', 'comic_cover_local', 'alternate_latest_series_covers', 'cvinfo', 'snatchedtorrent_notify',
-                           'prowl_enabled', 'prowl_onsnatch', 'pushover_enabled', 'pushover_onsnatch', 'boxcar_enabled',
-                           'boxcar_onsnatch', 'pushbullet_enabled', 'pushbullet_onsnatch', 'telegram_enabled', 'telegram_onsnatch', 'slack_enabled', 'slack_onsnatch',
+                           'prowl_enabled', 'prowl_onsnatch', 'pushover_enabled', 'pushover_onsnatch', 'pushover_image', 'boxcar_enabled',
+                           'boxcar_onsnatch', 'pushbullet_enabled', 'pushbullet_onsnatch', 'telegram_enabled', 'telegram_onsnatch', 'telegram_image', 'slack_enabled', 'slack_onsnatch',
                            'email_enabled', 'email_enc', 'email_ongrab', 'email_onpost', 'opds_enable', 'opds_authentication', 'opds_metainfo', 'opds_pagesize', 'enable_ddl', 'deluge_pause'] #enable_public
 
         for checked_config in checked_configs:
@@ -5710,7 +5712,8 @@ class WebInterface(object):
         issuedetails = helpers.IssueDetails(filelocation)
         if issuedetails:
             issueinfo = '<table width="500"><tr><td>'
-            issueinfo += '<img style="float: left; padding-right: 10px" src=' + issuedetails[0]['IssueImage'] + ' height="400" width="263">'
+            #imagebytes = bytes("data:image/jpeg;base64,", encoding='utf-8') + issuedetails[0]['IssueImage']
+            issueinfo += '<img style="float: left; padding-right: 10px" src="data:image/jpeg;base64,%s" height="400" width="263">' % issuedetails[0]['IssueImage']
             seriestitle = issuedetails[0]['series']
             if any([seriestitle == 'None', seriestitle is None]):
                 seriestitle = comicname


### PR DESCRIPTION
- Added config options for sending cover in notif for Telegram & Pushover. 
- Instead of using URL, will extract downloaded cover and send that as a notif, or fallback to no cover if in error. 
- Updated seriesdetail page cover extraction to use new getimage code (no file extraction).
- Removed several INFO logging lines when filechecking.