### PR TITLE
image extraction fixes

### DIFF
--- a/mylar/getimage.py
+++ b/mylar/getimage.py
@@ -87,13 +87,14 @@ def extract_image(location, single=False, imquality=None):
                         break
 
                 tmp_infile = re.sub("[^0-9]","", infile.filename).strip()
-                if tmp_infile == '':
+                if tmp_infile == '' or not getattr(infile, dir_opt):
                     continue
                 extension = infile.filename[-4:]
                 #logger.fdebug('[%s]issue_ends: %s' % (tmp_infile, tmp_infile.endswith(issue_ends)))
                 #logger.fdebug('ext_ends: %s' % infile.filename.lower().endswith(pic_extensions))
                 #logger.fdebug('(%s) < (%s) == %s' % (int(tmp_infile), int(low_infile), int(tmp_infile)<int(low_infile)))
-                if all([infile.filename.lower().endswith(pic_extensions), int(tmp_infile) < int(low_infile), not getattr(infile, dir_opt)]):
+                #logger.fdebug('is_dir == %s' % (not getattr(infile, dir_opt)))
+                if all([infile.filename.lower().endswith(pic_extensions), int(tmp_infile) < int(low_infile)]):
                     low_infile = tmp_infile
                     low_infile_name = infile.filename
                 elif any(['00a' in infile.filename, '00b' in infile.filename, '00c' in infile.filename, '00d' in infile.filename, '00e' in infile.filename, '00fc' in infile.filename.lower()]) and infile.filename.endswith(pic_extensions) and cover == "notfound":
@@ -107,9 +108,9 @@ def extract_image(location, single=False, imquality=None):
                 elif all([tmp_infile.endswith(issue_ends), infile.filename.lower().endswith(pic_extensions), int(tmp_infile) < int(low_infile), cover == 'notfound']):
                     cb_filenames.append(infile.filename)
                     #logger.fdebug('filename set to: %s' % infile.filename)
-                    low_infile_name = infile.filename
-                    low_infile = tmp_infile
-            if cover != "found" and len(cb_filenames) > 0:
+                    #low_infile_name = infile.filename
+                    #low_infile = tmp_infile
+            if cover != "found" and any([len(cb_filenames) > 0, low_infile != 9999999999999]):
                 logger.fdebug('Invalid naming sequence for jpgs discovered. Attempting to find the lowest sequence and will use as cover (it might not work). Currently : %s' % (low_infile_name))
                 cb_filename = low_infile_name
                 cover = "found"
@@ -130,7 +131,10 @@ def extract_image(location, single=False, imquality=None):
                 img = img.resize((600, hsize), Image.ANTIALIAS)
                 output = BytesIO()
                 img.save(output, format="JPEG")
-                ComicImage = str(base64.b64encode(output.getvalue()), 'utf-8')
+                try:
+                    ComicImage = str(base64.b64encode(output.getvalue()), 'utf-8')
+                except Exception as e:
+                    ComicImage = str(base64.b64encode(output.getvalue() + "==="), 'utf-8')
                 output.close()
 
             except Exception as e:

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -1524,8 +1524,8 @@ def IssueDetails(filelocation, IssueID=None, justinfo=False):
             dz = zipfile.ZipFile(filelocation, 'r')
             data = dz.comment
         except:
-            logger.warn('Unable to extract comment field from zipfile.')
-            return {'IssueImage': IssueImage, 'datamode': 'file'}
+            logger.warn('Unable to extract any metadata from within file.')
+            return {'IssueImage': IssueImage, 'datamode': 'file', 'metadata': None}
         else:
             if data:
                 issuetag = 'comment'

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5750,7 +5750,10 @@ class WebInterface(object):
             issueinfo = myDB.selectone('SELECT * FROM issues where IssueID=?', [issueid]).fetchone()
             seriestitle = issueinfo['ComicName']
             issuenumber = issueinfo['Issue_Number']
-            issuetitle = issueinfo['IssueName']
+            try:
+                issuetitle = issueinfo['IssueName'].decode('utf-8')
+            except:
+                issuetitle = issueinfo['IssueName']
             issue_rls = issueinfo['IssueDate']
             if issue_rls is None:
                 issue_rls = issueinfo['StoreDate']
@@ -5798,7 +5801,7 @@ class WebInterface(object):
             else:
                 issueinfo += '<h1><center><b>%s</b></center></h1>' % (seriestitle)
             if all([issuetitle is not None, issuetitle != 'None']):
-                issueinfo += '<center>"' + issuetitle + '"</center></br>'
+                issueinfo += '<center>"%s"</center></br>' % (issuetitle)
             if all([pagecount is not None, pagecount != 'None']):
                 issueinfo += '</br><p class="alignleft">' + pagecount + ' pages</p>'
             if all([issueday is None, issuemonth is None, issueyear is None]):


### PR DESCRIPTION
- Added possible fix for invalid padding when encoding images. 
- Updated cover retrieval to account for files that don't have images starting at a 0/1 digit. 
- Make sure IssueName is properly encoded when displaying