### PR TITLE
cast maxyear as an int for range()

### DIFF
--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -4539,7 +4539,7 @@ class WebInterface(object):
                             if str(maxyear) not in yearRANGE:
                                 #logger.info('maxyear:' + str(maxyear))
                                 #logger.info('yeartop:' + str(yearTOP))
-                                for i in range(maxyear, int(yearTOP),1):
+                                for i in range(int(maxyear), int(yearTOP),1):
                                     if not any(int(x) == int(i) for x in yearRANGE):
                                         yearRANGE.append(str(i))
                         else:


### PR DESCRIPTION
Occasionally maxyear ends up as a float, probably a result of an automagic string conversion. Casting it to int makes range() not throw an exception.
I ran into it with a value of 2004.0 which casts nicely