### PR TITLE
define custom sort methods only if there's a dataTable element

### DIFF
--- a/data/js/plugins.js
+++ b/data/js/plugins.js
@@ -6,33 +6,35 @@ window.log = function(){
 };
 (function(b){function c(){}for(var d="assert,count,debug,dir,dirxml,error,exception,group,groupCollapsed,groupEnd,info,log,markTimeline,profile,profileEnd,time,timeEnd,trace,warn".split(","),a;a=d.pop();)b[a]=b[a]||c})(window.console=window.console||{});
 
-jQuery.fn.dataTableExt.oSort['title-string-asc']  = function(a,b) {
-	var x = a.match(/title="(.*?)"/)[1].toLowerCase();
-	var y = b.match(/title="(.*?)"/)[1].toLowerCase();
-	return ((x < y) ? -1 : ((x > y) ?  1 : 0));
-};
+if (typeof jQuery.fn.dataTableExt !== 'undefined') {
+    jQuery.fn.dataTableExt.oSort['title-string-asc']  = function(a,b) {
+        var x = a.match(/title="(.*?)"/)[1].toLowerCase();
+        var y = b.match(/title="(.*?)"/)[1].toLowerCase();
+        return ((x < y) ? -1 : ((x > y) ?  1 : 0));
+    };
 
-jQuery.fn.dataTableExt.oSort['title-string-desc'] = function(a,b) {
-	var x = a.match(/title="(.*?)"/)[1].toLowerCase();
-	var y = b.match(/title="(.*?)"/)[1].toLowerCase();
-	return ((x < y) ?  1 : ((x > y) ? -1 : 0));
-};
+    jQuery.fn.dataTableExt.oSort['title-string-desc'] = function(a,b) {
+        var x = a.match(/title="(.*?)"/)[1].toLowerCase();
+        var y = b.match(/title="(.*?)"/)[1].toLowerCase();
+        return ((x < y) ?  1 : ((x > y) ? -1 : 0));
+    };
 
-jQuery.fn.dataTableExt.oSort['title-numeric-asc']  = function(a,b) {
-	var x = a.match(/title="*(-?[0-9]+)/)[1];
-	var y = b.match(/title="*(-?[0-9]+)/)[1];
-	x = parseFloat( x );
-	y = parseFloat( y );
-	return ((x < y) ? -1 : ((x > y) ?  1 : 0));
-};
+    jQuery.fn.dataTableExt.oSort['title-numeric-asc']  = function(a,b) {
+        var x = a.match(/title="*(-?[0-9]+)/)[1];
+        var y = b.match(/title="*(-?[0-9]+)/)[1];
+        x = parseFloat( x );
+        y = parseFloat( y );
+        return ((x < y) ? -1 : ((x > y) ?  1 : 0));
+    };
 
-jQuery.fn.dataTableExt.oSort['title-numeric-desc'] = function(a,b) {
-	var x = a.match(/title="*(-?[0-9]+)/)[1];
-	var y = b.match(/title="*(-?[0-9]+)/)[1];
-	x = parseFloat( x );
-	y = parseFloat( y );
-	return ((x < y) ?  1 : ((x > y) ? -1 : 0));
-};
+    jQuery.fn.dataTableExt.oSort['title-numeric-desc'] = function(a,b) {
+        var x = a.match(/title="*(-?[0-9]+)/)[1];
+        var y = b.match(/title="*(-?[0-9]+)/)[1];
+        x = parseFloat( x );
+        y = parseFloat( y );
+        return ((x < y) ?  1 : ((x > y) ? -1 : 0));
+    };
+}
 
 function toggle(source) {
   checkboxes = document.getElementsByClassName('checkbox');


### PR DESCRIPTION
If a page doesn't have a dataTable class then defining a custom sorting method throws a javascript error. The Manage page is has no dataTable when it loads and throws this error today.

