### PR TITLE
fix imports for torrent clients

### DIFF
--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6065,7 +6065,7 @@ class WebInterface(object):
     testrtorrent.exposed = True
 
     def testqbit(self, host, username, password):
-        from torrent.clients import qbittorrent as QbitClient
+        from mylar.torrent.clients import qbittorrent as QbitClient
         qc = QbitClient.TorrentClient()
         qclient = qc.connect(host, username, password, True)
         if not qclient:
@@ -6081,7 +6081,7 @@ class WebInterface(object):
     testqbit.exposed = True
 
     def testdeluge(self, host, username, password):
-        from torrent.clients import deluge as DelugeClient
+        from mylar.torrent.clients import deluge as DelugeClient
         client = DelugeClient.TorrentClient()
         dclient = client.connect(host, username, password, True)
         if not dclient:


### PR DESCRIPTION
Testing torrent clients would crash with the old way of importing the torrent module.
More explicit import lets you test torrent clients successfully.