### PR TITLE
Fix writing strings in binary mode crash

### DIFF
--- a/mylar/weeklypull.py
+++ b/mylar/weeklypull.py
@@ -100,7 +100,7 @@ def pullit(forcecheck=None, weeknumber=None, year=None):
     if mylar.CONFIG.ALT_PULL != 2 or mylar.PULLBYFILE is True:
         newfl = os.path.join(mylar.CONFIG.CACHE_DIR, 'Clean-newreleases.txt')
 
-        newtxtfile = open(newfl, 'wb')
+        newtxtfile = open(newfl, 'w')
 
         if check(newrl, 'Service Unavailable'):
             logger.info('Retrieval site is offline at the moment.Aborting pull-list update amd will try again later.')


### PR DESCRIPTION
Fixes this crash
```
Job "Weekly Pullist (trigger: interval[4:00:00], next run at: 2020-02-25 21:11:59 UTC)" raised an exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/apscheduler/executors/base.py", line 125, in run_job
    retval = job.func(*job.args, **job.kwargs)
  File "/app/mylar/mylar/weeklypullit.py", line 30, in run
    weeklypull.pullit()
  File "/app/mylar/mylar/weeklypull.py", line 427, in pullit
    newtxtfile.write(str(shipdate) + '\t' + str(pub) + '\t' + str(issue) + '\t' + str(comicnm) + '\t' + str(comicrm) + '\tSkipped' + '\n')
TypeError: a bytes-like object is required, not 'str'
```