### PR TITLE
Auto proxy support

### DIFF
--- a/mylar/webstart.py
+++ b/mylar/webstart.py
@@ -74,8 +74,8 @@ def initialize(options):
 
     conf = {
         '/': {
-            'tools.staticdir.root': os.path.join(mylar.PROG_DIR, 'data')
-            #'tools.proxy.on': True  # pay attention to X-Forwarded-Proto header
+            'tools.staticdir.root': os.path.join(mylar.PROG_DIR, 'data'),
+            'tools.proxy.on': True  # pay attention to X-Forwarded-Proto header
         },
         '/interfaces': {
             'tools.staticdir.on': True,


### PR DESCRIPTION
The way many ajax buttons are implemented in mylar is through server side redirects. This is nice and easy but if the server doesn't peep at the headers to see that SSL is terminated somewhere else, it redirects to http instead of https  and causes a UI error.
The button "worked" it just doesn't redirect to the proper success notification and appears to have failed until you do a manual client side refresh.

This fixes about a hundred apparent bugs for people using SSL termination.