### PR TITLE
Fix regex parsing crash parsing search results

### DIFF
--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -352,6 +352,7 @@ class FileChecker(object):
         if len(wrds) > 1:
             for i in list(wrds):
                 if i != '':
+                    logger.warn('regex i: %s', i)
                     tmpfilename = re.sub(i, 'XCV', tmpfilename)
 
         tmpfilename = ''.join(tmpfilename)

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -352,8 +352,7 @@ class FileChecker(object):
         if len(wrds) > 1:
             for i in list(wrds):
                 if i != '':
-                    logger.warn('regex i: %s', i)
-                    tmpfilename = re.sub(i, 'XCV', tmpfilename)
+                    tmpfilename = tmpfilename.replace(i, 'XCV')
 
         tmpfilename = ''.join(tmpfilename)
         modfilename = tmpfilename


### PR DESCRIPTION
the argument 'i' is never a regex and yet sometimes it contains regex special characters like parentheses. In this case it usually crashes because the parens are unmatched, but there's a chance it could behave strangely by interpreting matched parens or other characters as a regex instruction.

Change this to a string replace operation to fix the crash or undefined behavior

Currently testing.