### PR TITLE
Rtorrent verify option fixes

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -2345,7 +2345,7 @@
                     var username = document.getElementById("rtorrent_username").value;
                     var password = document.getElementById("rtorrent_password").value;
                     var auth = document.getElementById("rtorrent_authentication").value;
-                    var verify = document.getElementById("rtorrent_verify").value;
+                    var verify = document.getElementById("rtorrent_verify").checked;
                     var rpc_url = document.getElementById("rtorrent_rpc_url").value;
                     $.get("testrtorrent",
                         { host: host, username: username, password: password, auth: auth, verify: verify, rpc_url: rpc_url },

--- a/mylar/torrent/clients/rtorrent.py
+++ b/mylar/torrent/clients/rtorrent.py
@@ -72,7 +72,7 @@ class TorrentClient(object):
                 self.conn = RTorrent(
                     url, authinfo,
                     verify_server=True,
-                    verify_ssl=False #self.getVerifySsl(verify, ca_bundle)
+                    verify_ssl=self.getVerifySsl(verify, ca_bundle)
             )
             except Exception as err:
                 logger.error('Make sure you have the right protocol specified for the rtorrent host. Failed to connect to rTorrent - error: %s.' % err)

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6052,6 +6052,10 @@ class WebInterface(object):
     testemail.exposed = True
 
     def testrtorrent(self, host, username, password, auth, verify, rpc_url):
+        if verify == 'true':
+            verify = True
+        elif verify == 'false':
+            verify = False
         from mylar.torrent.clients import rtorrent as TorClient
         client = TorClient.TorrentClient()
         ca_bundle = None


### PR DESCRIPTION
- FIX:(#138) RTorrent test option would always default verify to True.
- Sending torrents via RTorrent would default the verify option to False.