### PR TITLE
globalize the SETTINGS module variable

### DIFF
--- a/lib/comictaggerlib/comicvinecacher.py
+++ b/lib/comictaggerlib/comicvinecacher.py
@@ -21,14 +21,16 @@ import datetime
 #from pprint import pprint
 
 from . import ctversion
-from .settings import ComicTaggerSettings
+#from .settings import ComicTaggerSettings
 from . import utils
 
+from . import main
 
 class ComicVineCacher:
 
     def __init__(self):
-        self.settings_folder = ComicTaggerSettings.getSettingsFolder()
+        #print('SETTINGS.folder = %s' % main.SETTINGS.folder)
+        self.settings_folder = main.SETTINGS.folder
         self.db_file = os.path.join(self.settings_folder, "cv_cache.db")
         self.version_file = os.path.join(
             self.settings_folder, "cache_version.txt")

--- a/lib/comictaggerlib/main.py
+++ b/lib/comictaggerlib/main.py
@@ -29,7 +29,10 @@ from . import cli
 from .options import Options
 from .comicvinetalker import ComicVineTalker
 
+SETTINGS = None
+
 def ctmain():
+    global SETTINGS
     opts = Options()
     opts.parseCmdLineArgs()
     if not opts.configfolder:


### PR DESCRIPTION
In doing so, the entire settings module becomes available to use throughout CT instead of having to reload the config whenever settings need to be loaded in a new module.