### PR TITLE
ruTorrent SSL fix

### DIFF
--- a/lib/rtorrent/connection.py
+++ b/lib/rtorrent/connection.py
@@ -49,9 +49,7 @@ class Connection(object):
 
         # Construct RPC Client
         self.sp = self._get_sp(self.scheme, sp)
-        print('self.sp: %s' % self.sp)
         self.sp_kwargs = sp_kwargs or {}
-        print('self.kwargs: %s' % self.sp_kwargs)
         self._client = None
         self._client_version_tuple = ()
         self._rpc_methods = []
@@ -66,7 +64,7 @@ class Connection(object):
         return self._client
 
     def connect(self):
-        # log.debug('Connecting to server: %r', self.uri)
+        #print('Connecting to server: %s' % self.uri)
 
         if self.auth:
             #print('self.uri: %s' % self.uri)
@@ -104,8 +102,9 @@ class Connection(object):
 
         # Construct transport with authentication details
         method = self.auth[0]
-        secure = 'https'
-        self.scheme = secure
+        secure = self.scheme == 'https'
+
+        log.debug('Constructing transport for scheme: %r, authentication method: %r', self.scheme, method)
 
         # Use requests transport (if available)
         if RQT is True and method in ['basic', 'digest']:

--- a/mylar/torrent/clients/rtorrent.py
+++ b/mylar/torrent/clients/rtorrent.py
@@ -67,7 +67,7 @@ class TorrentClient(object):
                     newurl = url.replace('http://', 'http://%s:%s@' % (username, password))
                 else:
                     newurl = url
-                logger.fdebug('NEWURL: %s' % newurl.replace(password, '[REDACTED]'))
+                #logger.fdebug('NEWURL: %s' % newurl.replace(password, '[REDACTED]'))
                 authinfo = tuple(([auth, username, password]))
                 self.conn = RTorrent(
                     url, authinfo,
@@ -78,10 +78,11 @@ class TorrentClient(object):
                 logger.error('Make sure you have the right protocol specified for the rtorrent host. Failed to connect to rTorrent - error: %s.' % err)
                 return {'status': False, 'error': err}
         else:
-            logger.fdebug('NO username %s / NO password %s' % (username, password))
+            #logger.fdebug('NO username %s / NO password %s' % (username, password))
             try:
+                authinfo = tuple(([auth, username, password]))
                 self.conn = RTorrent(
-                    url, (auth, username, password),
+                    url, authinfo,
                     verify_server=True,
                     verify_ssl=self.getVerifySsl(verify, ca_bundle)
             )


### PR DESCRIPTION
- FIX:(#138) Using ruTorrent instance with no SSL would still test for SSL and fail. 
- Using ruTorrent instance with SSL enabled would work incorrectly when given an http url.