### PR TITLE
FIX: fix for simultaneous searches firing off when done using different search methods

### DIFF
--- a/mylar/config.py
+++ b/mylar/config.py
@@ -57,6 +57,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'LOWERCASE_FILENAMES': (bool, 'General', False),
     'IGNORE_HAVETOTAL': (bool, 'General', False),
     'IGNORE_TOTAL': (bool, 'General', False),
+    'IGNORE_COVERS': (bool, 'General', True),
     'SNATCHED_HAVETOTAL': (bool, 'General', False),
     'FAILED_DOWNLOAD_HANDLING': (bool, 'General', False),
     'FAILED_AUTO': (bool, 'General',False),


### PR DESCRIPTION
Should fix #217,
Possible fixes for: #210, #212 
Might also resolve some previously stated problems regarding high CPU usage.