### PR TITLE
Fix crash if Mylar sees book that's a symlink to a nonexistant file

### DIFF
--- a/mylar/librarysync.py
+++ b/mylar/librarysync.py
@@ -66,6 +66,10 @@ def libraryScan(dir=None, append=False, ComicID=None, ComicName=None, cron=None,
                         continue
 
                 comic = files
+                if not os.path.exists(comicpath):
+                    logger.fdebug(f'''Comic: {comic} doesn't actually exist - assuming it is a symlink to a nonexistant path.''')
+                    continue
+
                 comicsize = os.path.getsize(comicpath)
                 logger.fdebug('Comic: ' + comic + ' [' + comicpath + '] - ' + str(comicsize) + ' bytes')
 


### PR DESCRIPTION
I had a few broken links in my comic share that were causing Mylar to stop processing my comics.

To reproduce:

cd /path/to/comics
ln -s /path/to/nothing

[python]
for fn in os.listdir('/path/to/comics'):
     if fn == 'nothing':
         exist = "Yes" if os.path.exists(fn) else "No"
         print(f'''Filename {fn} exists: {exist}''')

Without my patch, it chokes on the getsize call.