### PR TITLE
include_comicrack_style_issue_id setting to add CVDBXX Issue ID to Notes

### DIFF
--- a/lib/comictaggerlib/comicvinetalker.py
+++ b/lib/comictaggerlib/comicvinetalker.py
@@ -513,7 +513,11 @@ class ComicVineTalker(QObject):
         if settings.use_series_start_as_volume:
             metadata.volume = volume_results['start_year']
 
-        metadata.notes = "Tagged with the {0} fork of ComicTagger {1} using info from Comic Vine on {2}.  [Issue ID {3}]".format(
+        notes_format = "Tagged with the {0} fork of ComicTagger {1} using info from Comic Vine on {2}.  [Issue ID {3}]"
+        if settings.include_comicrack_style_issue_id:
+            notes_format += " [CVDB{3}]"
+
+        metadata.notes = notes_format.format(
             ctversion.fork,
             ctversion.version,
             datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),

--- a/lib/comictaggerlib/settings.py
+++ b/lib/comictaggerlib/settings.py
@@ -97,6 +97,7 @@ class ComicTaggerSettings:
         self.clear_form_before_populating_from_cv = False
         self.remove_html_tables = False
         self.cv_api_key = ""
+        self.include_comicrack_style_issue_id = False
 
         # CBL Tranform settings
 
@@ -264,6 +265,10 @@ class ComicTaggerSettings:
                 'comicvine', 'remove_html_tables')
         if self.config.has_option('comicvine', 'cv_api_key'):
             self.cv_api_key = self.config.get('comicvine', 'cv_api_key')
+        if self.config.has_option(
+                'comicvine', 'include_comicrack_style_issue_id'):
+            self.include_comicrack_style_issue_id = self.config.getboolean(
+                'comicvine', 'include_comicrack_style_issue_id')            
 
         if self.config.has_option(
                 'cbl_transform', 'assume_lone_credit_is_primary'):
@@ -417,6 +422,8 @@ class ComicTaggerSettings:
         self.config.set(
             'comicvine', 'remove_html_tables', self.remove_html_tables)
         self.config.set('comicvine', 'cv_api_key', self.cv_api_key)
+        self.config.set('comicvine', 'include_comicrack_style_issue_id', 
+                        self.include_comicrack_style_issue_id)        
 
         if not self.config.has_section('cbl_transform'):
             self.config.add_section('cbl_transform')


### PR DESCRIPTION
Add an option to CT settings [comicvine] section include_comicrack_style_issue_id. Default value False. mylar3 behavior does not change when value is False.

When set to true, Notes field will include [CVDBXXXXX]. XXXX is issue ID. This is the format that the ComicVine Scraper for ComicRack reads. It will allow CR to automatically pick up the issue ID and not prompt user on first scrape in CR.

example output when set to true.

Tagged with the ninjas.walk.alone fork of ComicTagger 1.25.2 using info from Comic Vine on 2020-03-28 13:00:47. [Issue ID 721150] [CVDB721150]