### PR TITLE
FIX: provider_order would not respect ini settings 

### DIFF
--- a/mylar/config.py
+++ b/mylar/config.py
@@ -1178,9 +1178,9 @@ class Config(object):
             if self.ENABLE_32P:
                 PR.append('32p')
                 PR_NUM +=1
-            if self.ENABLE_PUBLIC:
-                PR.append('public torrents')
-                PR_NUM +=1
+            #if self.ENABLE_PUBLIC:
+            #    PR.append('public torrents')
+            #    PR_NUM +=1
         if self.NZBSU:
             PR.append('nzb.su')
             PR_NUM +=1
@@ -1195,7 +1195,7 @@ class Config(object):
             PR.append('DDL')
             PR_NUM +=1
 
-        PPR = ['32p', 'public torrents', 'nzb.su', 'dognzb', 'Experimental', 'DDL']
+        PPR = ['32p', 'nzb.su', 'dognzb', 'Experimental', 'DDL']
         if self.NEWZNAB:
             for ens in self.EXTRA_NEWZNABS:
                 if str(ens[5]) == '1': # if newznabs are enabled
@@ -1259,9 +1259,9 @@ class Config(object):
                     logger.fdebug('%s entries are enabled.' % PR_NUM)
 
             NEW_PROV_ORDER = []
-            i = 0
+            i = len(PR)-1
             #this should loop over ALL possible entries
-            while i < len(PR):
+            while i >= 0:
                 found = False
                 for d in PPR:
                     #logger.fdebug('checking entry %s against %s' % (PR[i], d) #d['provider'])
@@ -1270,25 +1270,25 @@ class Config(object):
                         if x:
                             ord = x[0]
                         else:
-                            ord = i
+                            #if x isn't found, the provider was not in the OG list. So we add it to the end.
+                            ord = len(PR)
                         found = {'provider': PR[i],
-                                 'order':    ord} 
+                                 'order':    ord}
                         break
                     else:
                         found = False
 
                 if found is not False:
                     new_order_seqnum = len(NEW_PROV_ORDER)
-                    if new_order_seqnum <= int(found['order']):
+                    if new_order_seqnum != int(found['order']):
                         seqnum = int(found['order'])
                     else:
                         seqnum = new_order_seqnum
-                    NEW_PROV_ORDER.append({"order_seq":  len(NEW_PROV_ORDER),
+                    NEW_PROV_ORDER.append({"order_seq":  int(seqnum),
                                            "provider":   found['provider'],
                                            "orig_seq":   int(seqnum)})
-                i+=1
+                i-=1
  
-
             #now we reorder based on priority of orig_seq, but use a new_order seq
             xa = 0
             NPROV = []


### PR DESCRIPTION
Provider_Order sequence would not be respected when loading from the config.ini. 

Seems Mylar would tend to reorder based on code priority vs ini priority. 

This PR should load the values from the config.ini properly, as well when items are removed/added while keeping the existing order as much as possible (ie. new provider enabling would add to the end of the existing order, removal of provider would move everything higher in the order sequence to be lowered accordingly).

Reference is from a forum post [here](https://forum.mylarcomics.com/viewtopic.php?f=8&t=2257)