### PR TITLE
Fix datatables error on ImportResults

### DIFF
--- a/data/interfaces/default/importresults.html
+++ b/data/interfaces/default/importresults.html
@@ -75,8 +75,6 @@
         </div>
 
         <table class="display" id="impresults_table">
-                <tr/><tr/>
-                <tr><center><h3>To be Imported</h3></center></tr>
                 <thead>
                         <tr>
                                 <th id="select" align="left"><input type="checkbox" onClick="toggle(this)" name="results" class="checkbox" /></th>


### PR DESCRIPTION
error due to extra, out-of-place table rows. solution was found here: https://www.datatables.net/forums/discussion/comment/112718/

error causes datatables to not load, which prevents any of the useful features for sorting, paging, etc.

<img width="502" alt="Screen Shot 2020-04-10 at 6 04 17 PM" src="https://user-images.githubusercontent.com/26156755/79033923-d3070a00-7b77-11ea-8767-e06c7e95345e.png">



3rd times a charm?!