### PR TITLE
Eliminate endless loop in sabnzb queue

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3160,8 +3160,10 @@ def nzb_monitor(queue):
 
             if any([nzstat['status'] == 'file not found', nzstat['status'] == 'double-pp']):
                 logger.warn('Unable to complete post-processing call due to not finding file in the location provided. [%s]' % item)
+            elif nzstat['status'] == 'nzb removed':
+                logger.warn('NZB seems to have been removed from queue: %s' % item['nzo_id'])
             elif nzstat['status'] is False:
-                logger.info('Could not find NZBID %s in the downloader\'s queue. I will requeue this item for post-processing...' % item['NZBID'])
+                logger.info('Download %s failed. Requeue NZB to check later...' % item['nzo_id'])
                 time.sleep(5)
                 mylar.NZB_QUEUE.put(item)
             elif nzstat['status'] is True:

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3158,12 +3158,13 @@ def nzb_monitor(queue):
                 logger.warn('There are no NZB Completed Download handlers enabled. Not sending item to completed download handling...')
                 break
 
+            known_nzb_id = item['nzo_id'] if (mylar.USE_SABNZBD is True) else item['NZBID']
             if any([nzstat['status'] == 'file not found', nzstat['status'] == 'double-pp']):
                 logger.warn('Unable to complete post-processing call due to not finding file in the location provided. [%s]' % item)
             elif nzstat['status'] == 'nzb removed':
-                logger.warn('NZB seems to have been removed from queue: %s' % item['nzo_id'])
+                logger.warn('NZB seems to have been removed from queue: %s' % known_nzb_id)
             elif nzstat['status'] is False:
-                logger.info('Download %s failed. Requeue NZB to check later...' % item['nzo_id'])
+                logger.info('Download %s failed. Requeue NZB to check later...' % known_nzb_id)
                 time.sleep(5)
                 mylar.NZB_QUEUE.put(item)
             elif nzstat['status'] is True:

--- a/mylar/sabnzbd.py
+++ b/mylar/sabnzbd.py
@@ -79,7 +79,11 @@ class SABnzbd(object):
                 #logger.fdebug('queue: %s' % queueinfo)
                 logger.fdebug('Queue status : %s' % queueinfo['status'])
                 logger.fdebug('Queue mbleft : %s' % queueinfo['mbleft'])
-                while any([str(queueinfo['status']) == 'Downloading', str(queueinfo['status']) == 'Idle', str(queueinfo['status']) == 'Paused']) and float(queueinfo['mbleft']) > 0:
+
+                if str(queueinfo['status']) == 'Paused':
+                    logger.warn('[WARNING] SABnzbd has the active queue Paused. CDH will not work in this state.')
+                    return {'status': False, 'failed': False}
+                while any([str(queueinfo['status']) == 'Downloading', str(queueinfo['status']) == 'Idle']) and float(queueinfo['mbleft']) > 0:
                     #if 'comicrn' in queueinfo['script'].lower():
                     #    logger.warn('ComicRN has been detected as being active for this category & download. Completed Download Handling will NOT be performed due to this.')
                     #    logger.warn('Either disable Completed Download Handling for SABnzbd within Mylar, or remove ComicRN from your category script in SABnzbd.')


### PR DESCRIPTION
clean up some issues in the nzb queue monitoring which:
1.  Fix the broken reference in the log line within helpers.py which was breaking things, and forcing the re-queueing to fail
2.  Fix the endless loop:
In this case, if an nzb was no longer found in the queue within sab, it'd be loop endlessly looking for it.   Solved by adding a quick check to see if the nzb we're looking for exists in the result set at all, and if not, return with a new status and log it.  Eliminating the while loop altogether seems fine, as it was only ever looping through the same result from sabnzbd history.