### PR TITLE
fix a search crash

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -1404,7 +1404,7 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                         else:
                             pc_in = helpers.issuedigits(filecomic['justthedigits'])
                         #issue comparison now as well
-                        if int(intIss) == int(comintIss) or all([cmloopit == 4, findcomiciss is None, pc_in is None]) or all([cmloopit == 4, findcomiciss is None, pc_in == 1]):
+                        if intIss is not None and comintIss is not None and int(intIss) == int(comintIss) or all([cmloopit == 4, findcomiciss is None, pc_in is None]) or all([cmloopit == 4, findcomiciss is None, pc_in == 1]):
                             nowrite = False
                             if all([nzbprov == 'torznab', 'worldwidetorrents' in entry['link']]):
                                 nzbid = generate_id(nzbprov, entry['id'])


### PR DESCRIPTION
check issue numbers for none before converting to int. This a dumb patch which just prevents the crash. I didn't look hard upstream to figure out why one of these values got set to None 

```
15-Apr-2020 04:26:10 - INFO :: mylar.NZB_SEARCH.514 : ThreadPoolExecutor-0_0 : Shhh be very quiet...I'm looking for XXXXXXXX XXXX issue: 10-02 (2019) using ddl [RSS].
Job "RSS Feeds (trigger: interval[6:00:00], next run at: 2020-04-15 10:26:02 UTC)" raised an exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/apscheduler/executors/base.py", line 125, in run_job
    retval = job.func(*job.args, **job.kwargs)
  File "/app/mylar/mylar/rsscheckit.py", line 110, in run
    mylar.search.searchforissue(rsscheck='yes')
 File "/app/mylar/mylar/search.py", line 1776, in searchforissue
    foundNZB, prov = search_init(comic['ComicName'], result['Issue_Number'], str(ComicYear), SeriesYear, Publisher, IssueDate, StoreDate, result['IssueID'], AlternateSearch, UseFuzzy, ComicVersion, SARC=result['SARC'], IssueArcID=result['IssueArcID'], mode=mode, rsscheck=rsscheck, ComicID=result['ComicID'], filesafe=Comicname_filesafe, allow_packs=AllowPacks, oneoff=OneOff, torrentid_32p=TorrentID_32p, digitaldate=DigitalDate, booktype=booktype)
  File "/app/mylar/mylar/search.py", line 340, in search_init
    findit = NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="yes", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=unaltered_ComicName, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, digitaldate=digitaldate, booktype=booktype)
  File "/app/mylar/mylar/search.py", line 1407, in NZB_SEARCH
    if int(intIss) == int(comintIss) or all([cmloopit == 4, findcomiciss is None, pc_in is None]) or all([cmloopit == 4, findcomiciss is None, pc_in == 1]):
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```