### PR TITLE
updates auto-snatch Rtorrent remote torrent downloads to work in python3 + small image retrieval improvements

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -1485,7 +1485,7 @@ def filesafe(comic):
 
     return comicname_filesafe
 
-def IssueDetails(filelocation, IssueID=None, justinfo=False):
+def IssueDetails(filelocation, IssueID=None, justinfo=False, comicname=None):
     import zipfile
     from xml.dom.minidom import parseString
 
@@ -1498,7 +1498,7 @@ def IssueDetails(filelocation, IssueID=None, justinfo=False):
     else:
         filelocation = urllib.parse.unquote_plus(filelocation)
     if justinfo is False:
-        file_info = getimage.extract_image(filelocation, single=True, imquality='issue')
+        file_info = getimage.extract_image(filelocation, single=True, imquality='issue', comicname=comicname)
         IssueImage = file_info['ComicImage']
         data = file_info['metadata']
         if data:
@@ -1515,7 +1515,7 @@ def IssueDetails(filelocation, IssueID=None, justinfo=False):
                         break
         except:
             logger.info('ERROR. Unable to properly retrieve the cover for displaying. It\'s probably best to re-tag this file.')
-            return
+            return {'IssueImage': IssueImage, 'datamode': 'file', 'metadata': None}
 
 
     if issuetag is None:
@@ -2712,11 +2712,11 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
         cinfo = myDB.selectone('SELECT a.Issue_Number, a.ComicName, a.Status, b.Hash from issues as a inner join snatched as b ON a.IssueID=b.IssueID WHERE a.IssueID=?', [issueid]).fetchone()
         if cinfo is None:
             logger.warn('Unable to locate IssueID of : ' + issueid)
-            snatch_status = 'ERROR'
+            snatch_status = 'MONITOR ERROR'
 
         if cinfo['Status'] != 'Snatched' or cinfo['Hash'] is None:
             logger.warn(cinfo['ComicName'] + ' #' + cinfo['Issue_Number'] + ' is currently in a ' + cinfo['Status'] + ' Status.')
-            snatch_status = 'ERROR'
+            snatch_status = 'MONITOR ERROR'
 
         torrent_hash = cinfo['Hash']
 
@@ -2726,7 +2726,7 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
 
     if not len(torrent_hash) == 40:
        logger.error("Torrent hash is missing, or an invalid hash value has been passed")
-       snatch_status = 'ERROR'
+       snatch_status = 'MONITOR ERROR'
     else:
         if mylar.USE_RTORRENT:
             from . import test
@@ -2741,14 +2741,14 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
 
             torrent_info = dp.get_torrent(torrent_hash)
         else:
-            snatch_status = 'ERROR'
+            snatch_status = 'MONITOR ERROR'
             return
 
     logger.info('torrent_info: %s' % torrent_info)
 
     if torrent_info is False or len(torrent_info) == 0:
         logger.warn('torrent returned no information. Check logs - aborting auto-snatch at this time.')
-        snatch_status = 'ERROR'
+        snatch_status = 'MONITOR ERROR'
     else:
         if mylar.USE_DELUGE:
             torrent_status = torrent_info['is_finished']
@@ -2766,7 +2766,7 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
 
         if all([torrent_status is True, download is True]):
             if not issueid: 
-                torrent_info['snatch_status'] = 'STARTING...'
+                torrent_info['snatch_status'] = 'MONITOR STARTING'
                 #yield torrent_info
 
             import shlex, subprocess
@@ -2783,15 +2783,15 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
 
             curScriptName = shell_cmd + ' ' + str(mylar.CONFIG.AUTO_SNATCH_SCRIPT) #.decode("string_escape")
             if torrent_files > 1:
-                downlocation = torrent_folder.encode('utf-8')
+                downlocation = torrent_folder
             else:
                 if mylar.USE_DELUGE:
-                    downlocation = os.path.join(torrent_folder.encode('utf-8'), torrent_info['files'][0]['path'])
+                    downlocation = os.path.join(torrent_folder, torrent_info['files'][0]['path'])
                 else:
-                    downlocation = torrent_info['files'][0].encode('utf-8')
+                    downlocation = torrent_info['files'][0]
 
             autosnatch_env = os.environ.copy()
-            autosnatch_env['downlocation'] = re.sub("'", "\\'",downlocation)
+            autosnatch_env['downlocation'] = downlocation.replace("'", "\\'")
 
             #these are pulled from the config and are the ssh values to use to retrieve the data
             autosnatch_env['host'] = mylar.CONFIG.PP_SSHHOST
@@ -2813,24 +2813,25 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
             #downlocation = re.sub("&", "\&", downlocation)
 
             script_cmd = shlex.split(curScriptName, posix=False) # + [downlocation]
-            logger.fdebug("Executing command " +str(script_cmd))
+            logger.fdebug('Executing command %s' % script_cmd)
             try:
                 p = subprocess.Popen(script_cmd, env=dict(autosnatch_env), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=mylar.PROG_DIR)
                 out, err = p.communicate()
-                logger.fdebug("Script result: " + out)
+                logger.fdebug('Script result: %s' % out)
             except OSError as e:
-                logger.warn("Unable to run extra_script: " + e)
-                snatch_status = 'ERROR'
+                logger.warn('Unable to run extra_script: %s' % e)
+                snatch_status = 'MONITOR ERROR'
             else:
-                if 'Access failed: No such file' in out:
+                if 'Access failed: No such file' in str(out):
                     logger.fdebug('Not located in location it is supposed to be in - probably has been moved by some script and I got the wrong location due to timing. Trying again...')
                     snatch_status = 'IN PROGRESS'
                 else:
-                    snatch_status = 'COMPLETED'
+                    snatch_status = 'MONITOR COMPLETE' #COMPLETED
                 torrent_info['completed'] = torrent_status
                 torrent_info['files'] = torrent_files
                 torrent_info['folder'] = torrent_folder
-
+                torrent_info['copied_filepath'] = os.path.join(mylar.CONFIG.PP_SSHLOCALCD, torrent_info['name'])
+                torrent_info['snatch_status'] = snatch_status
         else:
             if download is True:
                 snatch_status = 'IN PROGRESS'
@@ -2858,7 +2859,7 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
             else:
                 snatch_status = 'NOT SNATCHED'
 
-    torrent_info['snatch_status'] = snatch_status
+    #torrent_info['snatch_status'] = snatch_status
     return torrent_info
 
 def weekly_info(week=None, year=None, current=None):
@@ -3125,18 +3126,25 @@ def worker_main(queue):
     while True:
         if queue.qsize() >= 1:
             item = queue.get(True)
-            logger.info('Now loading from queue: ' + item)
+            logger.info('Now loading from queue: %s' % item)
             if item == 'exit':
                 logger.info('Cleaning up workers for shutdown')
                 break
-            snstat = torrentinfo(torrent_hash=item, download=True)
+            snstat = torrentinfo(torrent_hash=item['hash'], download=True)
             if snstat['snatch_status'] == 'IN PROGRESS':
                 logger.info('Still downloading in client....let us try again momentarily.')
                 time.sleep(30)
                 mylar.SNATCHED_QUEUE.put(item)
             elif any([snstat['snatch_status'] == 'MONITOR FAIL', snstat['snatch_status'] == 'MONITOR COMPLETE']):
                 logger.info('File copied for post-processing - submitting as a direct pp.')
-                threading.Thread(target=self.checkFolder, args=[os.path.abspath(os.path.join(snstat['copied_filepath'], os.pardir))]).start()
+                mylar.PP_QUEUE.put({'nzb_name':     os.path.basename(snstat['copied_filepath']),
+                                    'nzb_folder':   snstat['copied_filepath'], #os.path.abspath(os.path.join(snstat['copied_filepath'], os.pardir)),
+                                    'failed':       False,
+                                    'issueid':      item['issueid'],
+                                    'comicid':      item['comicid'],
+                                    'apicall':      True,
+                                    'ddl':          False})
+                #threading.Thread(target=self.checkFolder, args=[os.path.abspath(os.path.join(snstat['copied_filepath'], os.pardir))]).start()
         else:
             time.sleep(15)
 

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -2438,9 +2438,9 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
             rcheck.update({'torrent_filename': nzbname})
 
             if any([mylar.USE_RTORRENT, mylar.USE_DELUGE]) and mylar.CONFIG.AUTO_SNATCH:
-                mylar.SNATCHED_QUEUE.put(rcheck['hash'])
+                mylar.SNATCHED_QUEUE.put({'issueid': IssueID, 'comicid': ComicID, 'hash': rcheck['hash']})
             elif any([mylar.USE_RTORRENT, mylar.USE_DELUGE]) and mylar.CONFIG.LOCAL_TORRENT_PP:
-                mylar.SNATCHED_QUEUE.put(rcheck['hash'])
+                mylar.SNATCHED_QUEUE.put({'issueid': IssueID, 'comicid': ComicID, 'hash': rcheck['hash']})
             else:
                 if mylar.CONFIG.ENABLE_SNATCH_SCRIPT:
                     try:

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5803,19 +5803,23 @@ class WebInterface(object):
             issueyear = issue_rls[:4]
             issuesummary = None
         else:
+            myDB = db.DBConnection()
+            metadata_db = myDB.selectone('SELECT * FROM issues where IssueID=?', [issueid]).fetchone()
             seriestitle = meta_data['series']
             if any([seriestitle == 'None', seriestitle is None]):
                 seriestitle = urllib.parse.unquote_plus(comicname)
+                seriestitle = metadata_db['ComicName']
 
             issuenumber = meta_data['issue_number']
             if any([issuenumber == 'None', issuenumber is None]):
                 issuenumber = urllib.parse.unquote_plus(issue)
+                issuenumber = metadata_db['Issue_Number']
 
             issuetitle = meta_data['title']
             if any([issuetitle == 'None', issuetitle is None]):
-                issuetitle = urllib.parse.unquote_plus(title)
-            if re.sub('[\s\.\!\-\?\'\&\and\%\$\#\@\(\)\*\+\=\;\:\,]', '', issuetitle, re.I) != re.sub('[\s\.\!\-\?\'\&\and\%\$\#\@\(\)\*\+\=\;\:\,]', '', title, re.I):
-                issuetitle = urllib.parse.unquote_plus(title)
+                issuetitle = metadata_db['IssueName']
+            else:
+                issuetitle = issuetitle
             try:
                 pagecount = meta_data['pagecount']
             except:


### PR DESCRIPTION
- fixes some encoding errors that were present from py2 resulting in traceback errors.
- updated the auto-snatch queue to include the ComicID & IssueID
- with above change, direct post-processing can be accomplished instead of relying solely on filename parsing.

Also updated getimage retrieval to allow for:
- always taking the jpg that ends in a 0 or 1, dependent on which is lower
- remove common scanner jpgs from being included (ie. zzzXXXXX, or similar)
- make sure to allow for Series that may start with the letter z so they're able to be displayed.
- include the RawImage in the json response (which might be abit too much payload, and adds slightly more time to the overall execution). This might need to be fine-tuned later at some point.