### PR TITLE
fix a version checking crash

### DIFF
--- a/mylar/versioncheck.py
+++ b/mylar/versioncheck.py
@@ -110,23 +110,22 @@ def getVersion():
             except Exception as e:
                 logger.warn('[ERROR] %s' % e)
                 pass
-            else:
-                if git[0]['name'] is not None:
-                    for x in git:
-                        if x['name'] == output[:opp]:
-                            current_version_name = x['name']
-                            cur_commit_hash = x['commit']['sha']
-                            break
-                    logger.info('version_name: %s' % current_version_name)
-                    url3 = 'https://api.github.com/repos/%s/mylar3/releases/tags/%s' % (mylar.CONFIG.GIT_USER, current_version_name)
-                    logger.info('url3: %s' % url3)
-                    try:
-                        repochk = requests.get(url3, verify=True)
-                        repo_resp = repochk.json()
-                        logger.info('repo_resp: %s' % repo_resp)
-                        current_release_name = repo_resp['name']
-                    except Exception as e:
-                        pass
+            elif git and git[0].get('name') is not None:
+                for x in git:
+                    if x['name'] == output[:opp]:
+                        current_version_name = x['name']
+                        cur_commit_hash = x['commit']['sha']
+                        break
+                logger.info('version_name: %s' % current_version_name)
+                url3 = 'https://api.github.com/repos/%s/mylar3/releases/tags/%s' % (mylar.CONFIG.GIT_USER, current_version_name)
+                logger.info('url3: %s' % url3)
+                try:
+                    repochk = requests.get(url3, verify=True)
+                    repo_resp = repochk.json()
+                    logger.info('repo_resp: %s' % repo_resp)
+                    current_release_name = repo_resp['name']
+                except Exception as e:
+                    pass
 
         logger.info('cur_commit_hash: %s' % cur_commit_hash)
         logger.info('cur_branch: %s' % cur_branch)


### PR DESCRIPTION
Running mylar3 on python3-dev branch it looks like sometimes this `git` json array is empty when it returns from github.
```
Traceback (most recent call last):
  File "/app/mylar/Mylar.py", line 386, in <module>
    main()
  File "/app/mylar/Mylar.py", line 356, in main
    versioncheck.versionload()
  File "/app/mylar/mylar/versioncheck.py", line 364, in versionload
    version_info = getVersion()
  File "/app/mylar/mylar/versioncheck.py", line 114, in getVersion
    if git[0]['name'] is not None:
```