### PR TITLE
booktype enhancements

### DIFF
--- a/data/interfaces/default/comicdetails.html
+++ b/data/interfaces/default/comicdetails.html
@@ -109,7 +109,7 @@
                                     <label><big>Status: </big><norm>${comic['Status']}</norm></label>
                                 </div>
                                 <%
-                                      if any([comic['Type'] == 'None', comic['Type'] is None, comic['Type'] == 'Print']) and comic['Corrected_Type'] != 'TPB':
+                                      if any([comic['Type'] == 'None', comic['Type'] is None, comic['Type'] == 'Print']) and comic['Corrected_Type'] is None:
                                           comictype = 'Print'
                                       else:
                                           if comic['Corrected_Type'] is not None:
@@ -218,14 +218,40 @@
                                    <a href="#" title="Will forcibly mark this series as 'Continuing' regardless of actual status"><img src="interfaces/default/images/info32.png" height="16" alt="" /></a>
                                 </div>
                                 <div class="row checkbox right clearfix">
+                                                <label>Force-Type (original:${comic['Type']})</label>
+                                                <select name="force_type">
+                                                <%
+                                                    ftt_list = ['Select', 'TPB', 'Digital', 'One-Shot', 'Print']
+                                                %>
+                                                %for ftt in ftt_list:
+                                                        <%
+                                                                if comicConfig['force_type'] == ftt:
+                                                                        outputselect = 'selected'
+                                                                else:
+                                                                        outputselect = ''
+                                                        %>
+                                                        %if comicConfig['force_type'] is None:
+                                                            %if ftt == 'Select':
+                                                                <option value='' selected disabled hidden>Select...</option>
+                                                            %elif comic['Type'] == ftt:
+                                                                <option value=${ftt} disabled>${ftt}</option>
+                                                            %else:
+                                                                <option value=${ftt} ${outputselect}>${ftt}</option>
+                                                            %endif
+                                                        %elif comicConfig['force_type'] == ftt:
+                                                            <option value=${ftt} selected disabled>${ftt}</option>
+                                                        %else:
+                                                            <option value=${ftt} ${outputselect}>${ftt}</option>
+                                                        %endif
+                                                %endfor
+                                                </select>
+                                                <a href="#" title="Will forcibly mark this series as selected in those instances where it assumes it's a ${comic['Type']}-based series"><img src="interfaces/default/images/info32.png" height="16" alt="" /></a>
+                                </div>
+                                <div class="row checkbox right clearfix">
                                    %if comic['Type'] != 'TPB':
-                                       <label>Forcibly Mark series as TPB/GN</label>
-                                       <input type="checkbox" style="vertical-align: bottom; margin: 3px; margin-top: -3px;" name="force_type" value="1" ${comicConfig['force_type']} />
-                                       <a href="#" title="Will forcibly mark this series as TPB/GN in those instances where it assumes it's a normal issue-based series"><img src="interfaces/default/images/info32.png" height="16" alt="" /></a>
-                                   %else:
-                                       <label>Forcibly Mark series as Print</label>
-                                       <input type="checkbox" style="vertical-align: bottom; margin: 3px; margin-top: -3px;" name="force_type" value="2" ${comicConfig['force_type']} />
-                                       <a href="#" title="Will forcibly mark this series as an Issue-Based series in those instances where it assumes it's a TPB/GN series"><img src="interfaces/default/images/info32.png" height="16" alt="" /></a>
+                                       <label>Accept all booktype search matches</label>
+                                       <input type="checkbox" style="vertical-align: bottom; margin: 3px; margin-top: -3px;" name="ignore_type" value="1" ${comicConfig['ignore_type']} />
+                                       <a href="#" title="Will not restrict search matches to just being a matching Edition type (ie. One-Shots/Digitals will match against normal Issues."><img src="interfaces/default/images/info32.png" height="16" alt="" /></a>
                                    %endif
                                 </div>
                                 %if any([comic['ComicYear'] == '2099',comic['ComicYear'] == '0000', comic['ComicYear'] == '', comic['Corrected_SeriesYear']]):
@@ -759,6 +785,7 @@
                  data: { filelocation: filelink, comicname: comicname, issue: issue, date: date, title: title, issueid: issueid },
                  success: function(response) {
                    $('#responsethis').html(response);
+                   $("#issue-box").draggable();
                  },
                  error: function(data)
                  {

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -677,7 +677,7 @@ def dbcheck():
         except sqlite3.OperationalError:
             logger.warn('Unable to update readinglist table to new storyarc table format.')
 
-    c.execute('CREATE TABLE IF NOT EXISTS comics (ComicID TEXT UNIQUE, ComicName TEXT, ComicSortName TEXT, ComicYear TEXT, DateAdded TEXT, Status TEXT, IncludeExtras INTEGER, Have INTEGER, Total INTEGER, ComicImage TEXT, ComicPublisher TEXT, ComicLocation TEXT, ComicPublished TEXT, NewPublish TEXT, LatestIssue TEXT, LatestDate TEXT, Description TEXT, QUALalt_vers TEXT, QUALtype TEXT, QUALscanner TEXT, QUALquality TEXT, LastUpdated TEXT, AlternateSearch TEXT, UseFuzzy TEXT, ComicVersion TEXT, SortOrder INTEGER, DetailURL TEXT, ForceContinuing INTEGER, ComicName_Filesafe TEXT, AlternateFileName TEXT, ComicImageURL TEXT, ComicImageALTURL TEXT, DynamicComicName TEXT, AllowPacks TEXT, Type TEXT, Corrected_SeriesYear TEXT, Corrected_Type TEXT, TorrentID_32P TEXT, LatestIssueID TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS comics (ComicID TEXT UNIQUE, ComicName TEXT, ComicSortName TEXT, ComicYear TEXT, DateAdded TEXT, Status TEXT, IncludeExtras INTEGER, Have INTEGER, Total INTEGER, ComicImage TEXT, ComicPublisher TEXT, ComicLocation TEXT, ComicPublished TEXT, NewPublish TEXT, LatestIssue TEXT, LatestDate TEXT, Description TEXT, QUALalt_vers TEXT, QUALtype TEXT, QUALscanner TEXT, QUALquality TEXT, LastUpdated TEXT, AlternateSearch TEXT, UseFuzzy TEXT, ComicVersion TEXT, SortOrder INTEGER, DetailURL TEXT, ForceContinuing INTEGER, ComicName_Filesafe TEXT, AlternateFileName TEXT, ComicImageURL TEXT, ComicImageALTURL TEXT, DynamicComicName TEXT, AllowPacks TEXT, Type TEXT, Corrected_SeriesYear TEXT, Corrected_Type TEXT, TorrentID_32P TEXT, LatestIssueID TEXT, IgnoreType INTEGER)')
     c.execute('CREATE TABLE IF NOT EXISTS issues (IssueID TEXT, ComicName TEXT, IssueName TEXT, Issue_Number TEXT, DateAdded TEXT, Status TEXT, Type TEXT, ComicID TEXT, ArtworkURL Text, ReleaseDate TEXT, Location TEXT, IssueDate TEXT, DigitalDate TEXT, Int_IssueNumber INT, ComicSize TEXT, AltIssueNumber TEXT, IssueDate_Edit TEXT, ImageURL TEXT, ImageURL_ALT TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS snatched (IssueID TEXT, ComicName TEXT, Issue_Number TEXT, Size INTEGER, DateAdded TEXT, Status TEXT, FolderName TEXT, ComicID TEXT, Provider TEXT, Hash TEXT, crc TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS upcoming (ComicName TEXT, IssueNumber TEXT, ComicID TEXT, IssueID TEXT, IssueDate TEXT, Status TEXT, DisplayComicName TEXT)')
@@ -817,6 +817,11 @@ def dbcheck():
         c.execute('SELECT Collects from comics')
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE comics ADD COLUMN Collects CLOB')
+
+    try:
+        c.execute('SELECT IgnoreType from comics')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE comics ADD COLUMN IgnoreType INTEGER')
 
     try:
         c.execute('SELECT DynamicComicName from comics')

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -975,6 +975,7 @@ class FileChecker(object):
                     issue_year = None
                 elif len(volume_found) > 0:
                     logger.fdebug('UNKNOWN TPB/GN detected. Volume assumption is number: %s' % (volume_found))
+                    booktype = 'TPB'
                 else:
                     logger.fdebug('No issue number present in filename.')
         else:

--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -17,6 +17,8 @@
 
 import re
 import os
+import pathlib
+import json
 import mylar
 from mylar import helpers, db, logger
 
@@ -45,11 +47,32 @@ class FileHandlers(object):
             self.issue = None
             self.issueid = None
 
-    def folder_create(self, booktype=None):
-        # dictionary needs to passed called comic with {'ComicPublisher', 'CorrectedType, 'Type', 'ComicYear', 'ComicName', 'ComicVersion'}
+    def folder_create(self, booktype=None, update_loc=None):
+        # dictionary needs to passed called comic with 
+        #  {'ComicPublisher', 'CorrectedType, 'Type', 'ComicYear', 'ComicName', 'ComicVersion'}
         # or pass in comicid value from __init__
 
         # setup default location here
+        if update_loc is not None:
+            comic_location = update_loc['temppath']
+            enforce_format = update_loc['tempff']
+            folder_format = update_loc['tempformat']
+            comicid = update_loc['comicid']
+        else:
+            comic_location = mylar.CONFIG.DESTINATION_DIR
+            enforce_format = False
+            folder_format = mylar.CONFIG.FOLDER_FORMAT
+
+        if folder_format is None:
+            folder_format = '$Series ($Year)'
+
+        if mylar.OS_DETECT == 'Windows':
+            if '/' in folder_format:
+                folder_format = re.sub('/', '\\', folder_format).strip()
+        else:
+            if '\\' in folder_format:
+                folder_format = folder_format.replace('\\', '/').strip()
+
         u_comicnm = self.comic['ComicName']
         # let's remove the non-standard characters here that will break filenaming / searching.
         comicname_filesafe = helpers.filesafe(u_comicnm)
@@ -64,18 +87,22 @@ class FileHandlers(object):
 
         if booktype is not None:
             if self.comic['Corrected_Type'] is not None:
-                booktype = self.comic['Corrected_Type']
+                if self.comic['Corrected_Type'] != booktype:
+                    booktype = booktype
+                else:
+                    booktype = self.comic['Corrected_Type']
             else:
                 booktype = booktype
         else:
             booktype = self.comic['Type']
 
         if any([booktype is None, booktype == 'None', booktype == 'Print']) or all([booktype != 'Print', mylar.CONFIG.FORMAT_BOOKTYPE is False]):
-            chunk_fb = re.sub('\$Type', '', mylar.CONFIG.FOLDER_FORMAT)
+            chunk_fb = re.sub('\$Type', '', folder_format)
             chunk_b = re.compile(r'\s+')
             chunk_folder_format = chunk_b.sub(' ', chunk_fb)
+            booktype = 'None'
         else:
-            chunk_folder_format = mylar.CONFIG.FOLDER_FORMAT
+            chunk_folder_format = folder_format
 
         if any([self.comic['ComicVersion'] is None, booktype != 'Print']):
             comicVol = 'None'
@@ -87,8 +114,14 @@ class FileHandlers(object):
             chunk_f_f = re.sub('\$VolumeN', '', chunk_folder_format)
             chunk_f = re.compile(r'\s+')
             chunk_folder_format = chunk_f.sub(' ', chunk_f_f)
-            logger.fdebug('No version # found for series, removing from folder format')
-            logger.fdebug("new folder format: " + str(chunk_folder_format))
+
+        chunk_folder_format = re.sub("[()|[]]", '', chunk_folder_format).strip()
+        ccf = chunk_folder_format.find('/ ')
+        if ccf != -1:
+            chunk_folder_format = chunk_folder_format[:ccf+1] + chunk_folder_format[ccf+2:]
+        ccf = chunk_folder_format.find('\ ')
+        if ccf != -1:
+            chunk_folder_format = chunk_folder_format[:ccf+1] + chunk_folder_format[ccf+2:]
 
         #do work to generate folder path
         values = {'$Series':        series,
@@ -101,41 +134,134 @@ class FileHandlers(object):
                   '$Annual':        'Annual',
                   '$Type':          booktype
                   }
-        try:
-            if mylar.CONFIG.FOLDER_FORMAT == '':
-                comlocation = os.path.join(mylar.CONFIG.DESTINATION_DIR, comicdir, " (" + comic['SeriesYear'] + ")")
+
+        if update_loc is not None:
+            #set the paths here with the seperator removed allowing for cross-platform altering.
+            ccdir = pathlib.PurePath(comic_location)
+            ddir = pathlib.PurePath(mylar.CONFIG.DESTINATION_DIR)
+            dlc = pathlib.PurePath(self.comic['ComicLocation'])
+            path_convert = True
+            i = 0
+            bb = []
+            while i < len(dlc.parts):
+                try:
+                    if dlc.parts[i] == ddir.parts[i]:
+                        i+=1
+                        continue
+                    else:
+                        bb.append(dlc.parts[i])
+                        i+=1 #print('d.parts: %s' % ccdir.parts[i])
+                except IndexError:
+                    bb.append(dlc.parts[i])
+                    i+=1
+            bb_tuple = pathlib.PurePath(os.path.sep.join(bb))
+            try:
+                com_base = pathlib.PurePath(dlc).relative_to(ddir)
+            except ValueError as e:
+                #if the original path is not located in the same path as the ComicLocation (destination_dir).
+                #this can happen when manually altered to a new path, or thru various changes to the ComicLocation path over time.
+                #ie. ValueError: '/mnt/Comics/Death of Wolverine The Logan Legacy-(2014)' does not start with '/mnt/mediavg/Comics/Comics-2'
+                dir_fix = []
+                dir_parts = pathlib.PurePath(dlc).parts
+                for dp in dir_parts:
+                    try:
+                        if self.comic['ComicYear'] is not None:
+                            if self.comic['ComicYear'] in dp:
+                                break
+                        if self.comic['ComicName'] is not None:
+                            if self.comic['ComicName'] in dp:
+                                break
+                        if self.comic['ComicPublisher'] is not None:
+                            if self.comic['ComicPublisher'] in dp:
+                                break
+                        if self.comic['ComicVersion'] is not None:
+                            if self.comic['ComicVersion'] in dp:
+                                break
+                        dir_fix.append(dp)
+                    except:
+                        pass
+
+                if len(dir_fix) > 0:
+                    spath = ''
+                    t=0
+                    while (t < len(dir_parts)):
+                        newpath = os.path.join(spath, dir_parts[t])
+                        t+=1
+                    com_base = newpath
+                    #path_convert = False
+            #print('com_base: %s' % com_base)
+            #detect comiclocation path based on OS so that the path seperators are correct
+            #have to figure out how to determine OS of original location...
+            if mylar.OS_DETECT == 'Windows':
+                p_path = pathlib.PureWindowsPath(ccdir)
             else:
-                chunk_folder_format = re.sub('[()|[]]', '', chunk_folder_format).strip()
-                comlocation = os.path.join(mylar.CONFIG.DESTINATION_DIR, helpers.replace_all(chunk_folder_format, values))
-
-        except TypeError as e:
-            if mylar.CONFIG.DESTINATION_DIR is None:
-                logger.error('[ERROR] %s' % e)
-                logger.error('No Comic Location specified. This NEEDS to be set before anything can be added successfully.')
-                return
+                p_path = pathlib.PurePosixPath(ccdir)
+            if enforce_format is True:
+                first = helpers.replace_all(chunk_folder_format, values)
+                if mylar.CONFIG.REPLACE_SPACES:
+                    #mylar.CONFIG.REPLACE_CHAR ...determines what to replace spaces with underscore or dot
+                    first = first.replace(' ', mylar.CONFIG.REPLACE_CHAR)
+                comlocation = str(p_path.joinpath(first))
             else:
-                logger.error('[ERROR] %s' % e)
+                comlocation = str(p_path.joinpath(com_base))
+
+            return {'comlocation':  comlocation,
+                    'path_convert': path_convert,
+                    'comicid':      comicid}
+        else:
+            ddir = pathlib.PurePath(mylar.CONFIG.DESTINATION_DIR)
+            i = 0
+            bb = []
+            while i < len(ddir.parts):
+                try:
+                    bb.append(ddir.parts[i])
+                    i+=1
+                except IndexError:
+                    break
+
+            bb2 = bb[0]
+            bb.pop(0)
+            bb_tuple = pathlib.PurePath(os.path.sep.join(bb))
+            logger.fdebug('bb_tuple: %s' % bb_tuple)
+            if mylar.OS_DETECT == 'Windows':
+                p_path = pathlib.PureWindowsPath(pathlib.PurePath(bb2).joinpath(bb_tuple))
+            else:
+                p_path = pathlib.PurePosixPath(pathlib.PurePath(bb2).joinpath(bb_tuple))
+
+            logger.fdebug('p_path: %s' % p_path)
+
+            first = helpers.replace_all(chunk_folder_format, values)
+            logger.fdebug('first-1: %s' % first)
+
+            if mylar.CONFIG.REPLACE_SPACES:
+                first = first.replace(' ', mylar.CONFIG.REPLACE_CHAR)
+            logger.fdebug('first-2: %s' % first)
+            comlocation = str(p_path.joinpath(first))
+            logger.fdebug('comlocation: %s' % comlocation)
+
+            #try:
+            #    if folder_format == '':
+            #        #comlocation = pathlib.PurePath(comiclocation).joinpath(comicdir, '(%s)') % comic['SeriesYear']
+            #        comlocation = os.path.join(comic_location, comicdir, " (" + comic['SeriesYear'] + ")")
+            #    else:
+            #except TypeError as e:
+            #    if comic_location is None:
+            #        logger.error('[ERROR] %s' % e)
+            #        logger.error('No Comic Location specified. This NEEDS to be set before anything can be added successfully.')
+            #        return
+            #    else:
+            #        logger.error('[ERROR] %s' % e)
+            #        return
+            #except Exception as e:
+            #    logger.error('[ERROR] %s' % e)
+            #    logger.error('Cannot determine Comic Location path properly. Check your Comic Location and Folder Format for any errors.')
+            #    return
+
+            if comlocation == "":
+                logger.error('There is no Comic Location Path specified - please specify one in Config/Web Interface.')
                 return
-        except Exception as e:
-            logger.error('[ERROR] %s' % e)
-            logger.error('Cannot determine Comic Location path properly. Check your Comic Location and Folder Format for any errors.')
-            return
 
-        if mylar.CONFIG.DESTINATION_DIR == "":
-            logger.error('There is no Comic Location Path specified - please specify one in Config/Web Interface.')
-            return
-
-        #enforce proper slashes here..
-        cnt1 = comlocation.count('\\')
-        cnt2 = comlocation.count('/')
-        if cnt1 > cnt2 and '/' in chunk_folder_format:
-            comlocation = re.sub('/', '\\', comlocation)
-
-        if mylar.CONFIG.REPLACE_SPACES:
-            #mylar.CONFIG.REPLACE_CHAR ...determines what to replace spaces with underscore or dot
-            comlocation = comlocation.replace(' ', mylar.CONFIG.REPLACE_CHAR)
-
-        return comlocation
+            return comlocation
 
     def rename_file(self, ofilename, issue=None, annualize=None, arc=False, file_format=None): #comicname, issue, comicyear=None, issueid=None)
             comicid = self.comicid   # it's coming in unicoded...

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -38,7 +38,7 @@ from base64 import b16encode, b32decode
 from operator import itemgetter
 from wsgiref.handlers import format_date_time
 
-def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, IssueID, AlternateSearch=None, UseFuzzy=None, ComicVersion=None, SARC=None, IssueArcID=None, mode=None, rsscheck=None, ComicID=None, manualsearch=None, filesafe=None, allow_packs=None, oneoff=False, manual=False, torrentid_32p=None, digitaldate=None, booktype=None):
+def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, IssueID, AlternateSearch=None, UseFuzzy=None, ComicVersion=None, SARC=None, IssueArcID=None, mode=None, rsscheck=None, ComicID=None, manualsearch=None, filesafe=None, allow_packs=None, oneoff=False, manual=False, torrentid_32p=None, digitaldate=None, booktype=None, ignore_booktype=False):
 
     mylar.COMICINFO = []
     unaltered_ComicName = None
@@ -274,6 +274,9 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
             else:
                 cmloopit = 1
 
+        chktpb = 0
+        if booktype == 'TPB':
+            chktpb = 1
 
         if findit['status'] is True:
             logger.fdebug('Found result on first run, exiting search module now.')
@@ -337,7 +340,7 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
                     #if searchprov.lower() == 'ddl':
                     #    prov_count+=1
                     #    continue
-                    findit = NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="yes", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=unaltered_ComicName, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, digitaldate=digitaldate, booktype=booktype)
+                    findit = NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="yes", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=unaltered_ComicName, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, digitaldate=digitaldate, booktype=booktype, chktpb=chktpb, ignore_booktype=ignore_booktype)
                     if findit['status'] is False:
                         if AlternateSearch is not None and AlternateSearch != "None":
                             chkthealt = AlternateSearch.split('##')
@@ -347,7 +350,7 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
                             for calt in chkthealt:
                                 AS_Alternate = re.sub('##', '', calt)
                                 logger.info('Alternate Search pattern detected...re-adjusting to : %s' % AS_Alternate)
-                                findit = NZB_SEARCH(AS_Alternate, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="yes", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=AS_Alternate, allow_packs=allow_packs, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, digitaldate=digitaldate, booktype=booktype)
+                                findit = NZB_SEARCH(AS_Alternate, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="yes", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=AS_Alternate, allow_packs=allow_packs, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, digitaldate=digitaldate, booktype=booktype, chktpb=chktpb, ignore_booktype=ignore_booktype)
                                 if findit['status'] is True:
                                     break
                             if findit['status'] is True:
@@ -357,7 +360,7 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
                         break
 
                 else:
-                    findit = NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="no", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=unaltered_ComicName, allow_packs=allow_packs, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, torrentid_32p=torrentid_32p, digitaldate=digitaldate, booktype=booktype)
+                    findit = NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="no", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=unaltered_ComicName, allow_packs=allow_packs, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, torrentid_32p=torrentid_32p, digitaldate=digitaldate, booktype=booktype, chktpb=chktpb, ignore_booktype=ignore_booktype)
                     if all([searchprov == '32P', checked_once is False]) or all([searchprov.lower() == 'ddl', checked_once is False]) or all([searchprov == 'Public Torrents', checked_once is False]) or all([searchprov == 'experimental', checked_once is False]):
                         checked_once = True
                     if findit['status'] is False:
@@ -369,7 +372,7 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
                             for calt in chkthealt:
                                 AS_Alternate = re.sub('##', '', calt)
                                 logger.info('Alternate Search pattern detected...re-adjusting to : %s' % AS_Alternate)
-                                findit = NZB_SEARCH(AS_Alternate, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="no", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=unaltered_ComicName, allow_packs=allow_packs, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, torrentid_32p=torrentid_32p, digitaldate=digitaldate, booktype=booktype)
+                                findit = NZB_SEARCH(AS_Alternate, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="no", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=unaltered_ComicName, allow_packs=allow_packs, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, torrentid_32p=torrentid_32p, digitaldate=digitaldate, booktype=booktype, chktpb=chktpb, ignore_booktype=ignore_booktype)
                                 if findit['status'] is True:
                                     break
                             if findit['status'] is True:
@@ -439,7 +442,7 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
 
     return findit, 'None'
 
-def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, nzbprov, prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host=None, ComicVersion=None, SARC=None, IssueArcID=None, RSS=None, ComicID=None, issuetitle=None, unaltered_ComicName=None, allow_packs=None, oneoff=False, cmloopit=None, manual=False, torznab_host=None, torrentid_32p=None, digitaldate=None, booktype=None):
+def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, nzbprov, prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host=None, ComicVersion=None, SARC=None, IssueArcID=None, RSS=None, ComicID=None, issuetitle=None, unaltered_ComicName=None, allow_packs=None, oneoff=False, cmloopit=None, manual=False, torznab_host=None, torrentid_32p=None, digitaldate=None, booktype=None, chktpb=0, ignore_booktype=False):
 
     if any([allow_packs is None, allow_packs == 'None', allow_packs == 0, allow_packs == '0']) and all([mylar.CONFIG.ENABLE_TORRENT_SEARCH, mylar.CONFIG.ENABLE_32P]):
         allow_packs = False
@@ -573,7 +576,6 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
     #---issue problem
     # if issue is '011' instead of '11' in nzb search results, will not have same
     # results. '011' will return different than '11', as will '009' and '09'.
-
     while (findloop < findcount):
         logger.fdebug('findloop: %s / findcount: %s' % (findloop, findcount))
         comsrc = comsearch
@@ -603,6 +605,11 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
             elif cmloopit == 1:
                 comsearch = comsrc + "%20" + str(isssearch) #+ "%20" + str(filetype)
                 issdig = ''
+                if chktpb == 1:
+                    #this will open end the search based on just the series title, no issue number, no volume.
+                    #putting it at the last search option and ONLY for tpb items hopefully will help it not retrieve thousands.
+                    comsearch = comsrc
+                    chktpb+=1
             else:
                 foundc['status'] = False
                 done = True
@@ -610,6 +617,8 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
             mod_isssearch = str(issdig) + str(isssearch)
         else:
             if cmloopit == 4:
+                if booktype == 'TPB':
+                    comsearch = comsrc + "%20v" + str(isssearch)
                 mod_isssearch = ''
             else:
                 comsearch = StoreDate
@@ -1128,7 +1137,8 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                 parsed_comic = p_comic.listFiles()
 
                 logger.fdebug('parsed_info: %s' % parsed_comic)
-                if parsed_comic['parse_status'] == 'success' and (all([booktype is None, parsed_comic['booktype'] == 'issue']) or all([booktype == 'Print', parsed_comic['booktype'] == 'issue']) or all([booktype == 'One-Shot', parsed_comic['booktype'] == 'issue']) or booktype == parsed_comic['booktype']):
+                logger.info('booktype: %s / parsed_booktype: %s [ignore_booktype: %s]' % (booktype, parsed_comic['booktype'], ignore_booktype))
+                if parsed_comic['parse_status'] == 'success' and (all([booktype is None, parsed_comic['booktype'] == 'issue']) or all([booktype == 'Print', parsed_comic['booktype'] == 'issue']) or all([booktype == 'One-Shot', parsed_comic['booktype'] == 'issue']) or all([booktype != parsed_comic['booktype'], ignore_booktype is True]) or booktype == parsed_comic['booktype']):
                     try:
                         fcomic = filechecker.FileChecker(watchcomic=ComicName)
                         filecomic = fcomic.matchIT(parsed_comic)
@@ -1140,11 +1150,11 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                         if filecomic['process_status'] == 'fail':
                             logger.fdebug('%s was not a match to %s (%s)' % (cleantitle, ComicName, SeriesYear))
                             continue
-                elif booktype != parsed_comic['booktype']:
+                elif booktype != parsed_comic['booktype'] and ignore_booktype is False:
                     logger.fdebug('Booktypes do not match. Looking for %s, this is a %s. Ignoring this result.' % (booktype, parsed_comic['booktype']))
                     continue
                 else:
-                    logger.fdebug('Unable to parse name properly: %s. Ignoring this result' % filecomic)
+                    logger.fdebug('Unable to parse name properly: %s. Ignoring this result' % parsed_comic)
                     continue
 
                 #adjust for covers only by removing them entirely...
@@ -1287,11 +1297,16 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                     # instead of the Series they belong to (V2012 vs V2013)
                     if annualize == "true" and int(ComicYear) == int(F_ComicVersion):
                         logger.fdebug("We matched on versions for annuals %s" % fndcomicversion)
-                    elif int(F_ComicVersion) == int(D_ComicVersion) or int(F_ComicVersion) == int(S_ComicVersion):
+                    elif booktype != 'TPB' and (int(F_ComicVersion) == int(D_ComicVersion) or int(F_ComicVersion) == int(S_ComicVersion)):
                         logger.fdebug("We matched on versions...%s" %fndcomicversion)
                     else:
-                        logger.fdebug("Versions wrong. Ignoring possible match.")
-                        continue
+                        if booktype == 'TPB' and int(F_ComicVersion) == int(findcomiciss) and filecomic['justthedigits'] is None:
+                            logger.fdebug('TPB detected - reassigning volume %s to match as the issue number based on Volume' % fndcomicversion)
+                        elif all([int(F_ComicVersion) == int(findcomiciss), fndcomicversion is not None, booktype == 'TPB', filecomic['booktype'] == 'TPB', filecomic['justthedigits'] is None]):
+                            logger.fdebug('TPB detected - reassigning volume %s to match as the issue number' % fndcomicversion)
+                        else:
+                            logger.fdebug("Versions wrong. Ignoring possible match.")
+                            continue
 
                 downloadit = False
 #-------------------------------------fix this!
@@ -1404,7 +1419,7 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                         else:
                             pc_in = helpers.issuedigits(filecomic['justthedigits'])
                         #issue comparison now as well
-                        if intIss is not None and comintIss is not None and int(intIss) == int(comintIss) or all([cmloopit == 4, findcomiciss is None, pc_in is None]) or all([cmloopit == 4, findcomiciss is None, pc_in == 1]):
+                        if all([intIss is not None, comintIss is not None]) and int(intIss) == int(comintIss) or all([chktpb !=0, filecomic['booktype'] == 'TPB', pc_in is None, helpers.issuedigits(F_ComicVersion) == intIss]) or all([chktpb == 2, filecomic['booktype'] == 'TPB', pc_in is None, cmloopit == 1]) or all([cmloopit == 4, findcomiciss is None, pc_in is None]) or all([cmloopit == 4, findcomiciss is None, pc_in == 1]):
                             nowrite = False
                             if all([nzbprov == 'torznab', 'worldwidetorrents' in entry['link']]):
                                 nzbid = generate_id(nzbprov, entry['id'])
@@ -1531,8 +1546,11 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
         #    logger.info("Alphanumerics detected within IssueNumber. Seperating from Issue # and re-trying.")
         #    cmloopit = origcmloopit
         #    seperatealpha = "yes"
-
-        findloop+=1
+        logger.info('booktype:%s / chktpb: %s / findloop: %s' % (booktype, chktpb, findloop))
+        if booktype == 'TPB' and chktpb == 1 and findloop+1 > findcount:
+            pass #findloop=-1
+        else:
+            findloop+=1
 
     if foundc['status'] is True:
         if 'Public Torrents' in tmpprov and any([nzbprov == 'WWT', nzbprov == 'DEM']):
@@ -1731,6 +1749,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                     ComicVersion = comic['Volume']
                     TorrentID_32p = None
                     booktype = comic['Type']
+                    ignore_booktype = False
                 else:
                     Comicname_filesafe = comic['ComicName_Filesafe']
                     SeriesYear = comic['ComicYear']
@@ -1740,6 +1759,9 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                     ComicVersion = comic['ComicVersion']
                     TorrentID_32p = comic['TorrentID_32P']
                     booktype = comic['Type']
+                    if comic['Corrected_Type'] is not None and comic['Type'] != comic['Corrected_Type']:
+                        booktype = comic['Corrected_Type']
+                    ignore_booktype = bool(comic['IgnoreType'])
                     if any([comic['AllowPacks'] == 1, comic['AllowPacks'] == '1']):
                         AllowPacks = True
 
@@ -1773,7 +1795,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                     continue
 
                 mode = result['mode']
-                foundNZB, prov = search_init(comic['ComicName'], result['Issue_Number'], str(ComicYear), SeriesYear, Publisher, IssueDate, StoreDate, result['IssueID'], AlternateSearch, UseFuzzy, ComicVersion, SARC=result['SARC'], IssueArcID=result['IssueArcID'], mode=mode, rsscheck=rsscheck, ComicID=result['ComicID'], filesafe=Comicname_filesafe, allow_packs=AllowPacks, oneoff=OneOff, torrentid_32p=TorrentID_32p, digitaldate=DigitalDate, booktype=booktype)
+                foundNZB, prov = search_init(comic['ComicName'], result['Issue_Number'], str(ComicYear), SeriesYear, Publisher, IssueDate, StoreDate, result['IssueID'], AlternateSearch, UseFuzzy, ComicVersion, SARC=result['SARC'], IssueArcID=result['IssueArcID'], mode=mode, rsscheck=rsscheck, ComicID=result['ComicID'], filesafe=Comicname_filesafe, allow_packs=AllowPacks, oneoff=OneOff, torrentid_32p=TorrentID_32p, digitaldate=DigitalDate, booktype=booktype, ignore_booktype=ignore_booktype)
                 if foundNZB['status'] is True:
                     updater.foundsearch(result['ComicID'], result['IssueID'], mode=mode, provider=prov, SARC=result['SARC'], IssueArcID=result['IssueArcID'], hash=foundNZB['info']['t_hash'])
 
@@ -1826,6 +1848,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                 DigitalDate = result['DigitalDate']
                 TorrentID_32p = None
                 booktype = result['Type']
+                ignore_booktype = False
             elif mode == 'pullwant':
                 ComicName = result['COMIC']
                 Comicname_filesafe = helpers.filesafe(ComicName)
@@ -1843,6 +1866,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                 StoreDate = IssueDate
                 DigitalDate = '0000-00-00'
                 booktype = result['format']
+                ignore_booktype = False
             else:
                 comic = myDB.selectone('SELECT * FROM comics where ComicID=?', [ComicID]).fetchone()
                 if mode == 'want_ann':
@@ -1866,6 +1890,9 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                 actissueid = issueid
                 TorrentID_32p = comic['TorrentID_32P']
                 booktype = comic['Type']
+                if comic['Corrected_Type'] is not None and comic['Type'] != comic['Corrected_Type']:
+                    booktype = comic['Corrected_Type']
+                ignore_booktype = bool(comic['IgnoreType'])
                 if any([comic['AllowPacks'] == 1, comic['AllowPacks'] == '1']):
                     allow_packs = True
 
@@ -1874,7 +1901,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
             else:
                 IssueYear = str(IssueDate)[:4]
 
-            foundNZB, prov = search_init(ComicName, IssueNumber, str(IssueYear), SeriesYear, Publisher, IssueDate, StoreDate, actissueid, AlternateSearch, UseFuzzy, ComicVersion, SARC=SARC, IssueArcID=IssueArcID, mode=mode, rsscheck=rsscheck, ComicID=ComicID, filesafe=Comicname_filesafe, allow_packs=allow_packs, oneoff=oneoff, manual=manual, torrentid_32p=TorrentID_32p, digitaldate=DigitalDate, booktype=booktype)
+            foundNZB, prov = search_init(ComicName, IssueNumber, str(IssueYear), SeriesYear, Publisher, IssueDate, StoreDate, actissueid, AlternateSearch, UseFuzzy, ComicVersion, SARC=SARC, IssueArcID=IssueArcID, mode=mode, rsscheck=rsscheck, ComicID=ComicID, filesafe=Comicname_filesafe, allow_packs=allow_packs, oneoff=oneoff, manual=manual, torrentid_32p=TorrentID_32p, digitaldate=DigitalDate, booktype=booktype, ignore_booktype=ignore_booktype)
             if manual is True:
                 mylar.SEARCHLOCK = False
                 return foundNZB


### PR DESCRIPTION
- FIX:(#279) Option to ignore booktype matches for specific series when searching

- FIX: (#183) Added Force Type dropdown to series detail page - can change the Edition/Type of a given series to any of the available options (TPB, One-Shot, Digital, Print). 

- When using Force Type option above, if ```$Type``` is enabled in Folder Format configuration, will rename existing folder to new Edition/Type as per the Folder Format string, to show the change at the folder-level