### PR TITLE
FIX:(#337)(#149) Partial fix for stalled importer throwing a DB exception

### DIFF
--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -4788,13 +4788,21 @@ class WebInterface(object):
                     if len(search_matches) > 1:
                        # if we matched on more than one series above, just save those results instead of the entire search result set.
                         for sres in search_matches:
+                            try:
+                                if type(sres['haveit']) is dict:
+                                    imp_cid = sres['haveit']['comicid']
+                                else:
+                                    imp_cid = sres['haveit']
+                            except Exception as e:
+                                imp_cid = sres['haveit']
+
                             cVal = {"SRID":        SRID,
                                     "comicid":     sres['comicid']}
                             #should store ogcname in here somewhere to account for naming conversions above.
                             nVal = {"Series":      ComicName,
                                     "results":     len(search_matches),
                                     "publisher":   sres['publisher'],
-                                    "haveit":      sres['haveit'],
+                                    "haveit":      imp_cid,
                                     "name":        sres['name'],
                                     "deck":        sres['deck'],
                                     "url":         sres['url'],
@@ -4815,13 +4823,21 @@ class WebInterface(object):
                         # store the search results for series that returned more than one result for user to select later / when they want.
                         # should probably assign some random numeric for an id to reference back at some point.
                         for sres in sresults:
+                            try:
+                                if type(sres['haveit']) == dict:
+                                    imp_cid = sres['haveit']['comicid']
+                                else:
+                                    imp_cid = sres['haveit']
+                            except Exception as e:
+                                imp_cid = sres['haveit']
+
                             cVal = {"SRID":        SRID,
                                     "comicid":     sres['comicid']}
                             #should store ogcname in here somewhere to account for naming conversions above.
                             nVal = {"Series":      ComicName,
                                     "results":     len(sresults),
                                     "publisher":   sres['publisher'],
-                                    "haveit":      sres['haveit'],
+                                    "haveit":      imp_cid,
                                     "name":        sres['name'],
                                     "deck":        sres['deck'],
                                     "url":         sres['url'],


### PR DESCRIPTION
This is a partial fix for the importer stalling and throwing a DB exception due to datatype. There are upcoming updates that will address #337 and #149 fully, but this is the simplest of ones to patch to get the importer working.

This will allow it to continue in most cases, but subsequent errors are a possibility as a result. Note that this *might* also fix the problem of manual intervention returning a blank page in some cases.