### PR TITLE
 FIX: Always replace GB (fixes mylar3#343)

### DIFF
--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -143,7 +143,7 @@ class GC(object):
                         if all([re.sub(':', '', size).strip() != 'Size', len(re.sub('[^0-9]', '', size).strip()) > 0]):
                             if 'MB' in size:
                                 size = re.sub('MB', 'M', size).strip()
-                            elif 'GB' in size:
+                            if 'GB' in size:
                                 size = re.sub('GB', 'G', size).strip()
                             if '//' in size:
                                 nwsize = size.find('//')


### PR DESCRIPTION
If you have a size value which contains mixed values (i.e 1.7GB//512MB) only the MB value was handled correctly.