### PR TITLE
Removed unrar-cffi component from ComicTagger and requirements.txt

### DIFF
--- a/lib/comictaggerlib/comicapi/comicarchive.py
+++ b/lib/comictaggerlib/comicapi/comicarchive.py
@@ -30,7 +30,13 @@ try:
 except ImportError:
     nsort = False
 
-from unrar.cffi import rarfile
+try:
+    from unrar.cffi import rarfile
+    unrar_cffi = True
+except ImportError:
+    from lib.rarfile import rarfile
+    unrar_cffi = False
+
 try:
     import Image
     pil_available = True
@@ -246,6 +252,8 @@ class RarArchiver:
     def __init__(self, path, rar_exe_path):
         self.path = path
         self.rar_exe_path = rar_exe_path
+        if unrar_cffi is False:
+            rarfile.UNRAR_TOOL = rar_exe_path
 
         if RarArchiver.devnull is None:
             RarArchiver.devnull = open(os.devnull, "w")
@@ -600,7 +608,15 @@ class ComicArchive:
         return zipfile.is_zipfile(self.path)
 
     def rarTest(self):
-        return rarfile.is_rarfile(self.path)        
+        if unrar_cffi is True:
+            return rarfile.is_rarfile(self.path)
+        else:
+            try:
+                rarc = rarfile.RarFile(self.path)
+            except:
+                return False
+            else:
+                return True
 
     def isZip(self):
         return self.archive_type == self.ArchiveType.Zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,5 @@ requests>=2.22.0
 simplejson>=3.17.0
 six>=1.13.0
 tzlocal>=2.0.0
-unrar>=0.3
-unrar-cffi==0.1.0a5
 urllib3>=1.25.7
 


### PR DESCRIPTION
unrar-cffi is now an optional component. Will work with either unrar-cffi if installed, or default back to included rarfile if it's not installed.

If it's already installed, Mylar3 will use it when unraring from within ComicTagger. Otherwise, will default back to the included rarfile module.

If using the rarfile module, either the unrar binary HAS to be in your environment PATH, or you need to locate the .ComicTagger directory path (either in the mylar root, or in the Mylar user's home directory). Once located, edit the ```settings``` file and set the ```rar_exe_path``` to the FULL PATH to the unrar binary (ie. /usr/local/bin/unrar).

Note: wiki updated to include the above with additional instructions as required [here](https://github.com/mylar3/mylar3/wiki/unrar-cffi-vs-included-rarfile)
