### PR TITLE
fixes #413 also check if "/" is in size instead of only checking "//"

### DIFF
--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -148,6 +148,9 @@ class GC(object):
                             if '//' in size:
                                 nwsize = size.find('//')
                                 size = re.sub('\[', '', size[:nwsize]).strip()
+                            elif '/' in size:
+                                nwsize = size.find('/')
+                                size = re.sub('\[', '', size[:nwsize]).strip()
                         else:
                             size = '0M'
                     i+=1


### PR DESCRIPTION
As descibed here the search aborts if only "/" is used to split sizes on getcomics:
#413

Please let me know if this fix works for you.

@evilhero:
As described in this PR (https://github.com/mylar3/mylar3/pull/414) I cleaned up the commits.

Best regards
miracle152005