### PR TITLE
FIX: fix for unrar not being properly detected on new installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The Mylar Forums are also online @ https://forum.mylarcomics.com
 ## Requirements
 - At least Python version 3.7.2 - most heavily tested with 3.8.1 (2.x is not supported)
 - Python version 3.8+ of Mylar will not work on Windows due to some dependency issues
+- Unrar is required to be on the system for ComicTagger integration to work (or RaR will work as well on Windows systems). If Unrar/RaR is not in the system path, the full path to the binary must be specified in the rar_exe_path field in .ComicTagger/settings located in either the root of Mylar or the user's home directory.
 - ComicVine API key (found [here](https://comicvine.gamespot.com/api/) - program will have limited to no functionality without it
 
 ## Installation

--- a/lib/comictaggerlib/settings.py
+++ b/lib/comictaggerlib/settings.py
@@ -162,11 +162,14 @@ class ComicTaggerSettings:
                 # see if it's in the path of unix user
                 if utils.which("rar") is not None:
                     self.rar_exe_path = utils.which("rar")
+                #unrar is used by Mylar for unraring. We don't rar anything up, so this should cover the bases.
+                elif utils.which("unrar") is not None:
+                    self.rar_exe_path = utils.which("unrar")
             if self.rar_exe_path != "":
                 self.save()
         if self.rar_exe_path != "":
-             # make sure rar program is now in the path for the rar class    
-            utils.addtopath(os.path.dirname(self.rar_exe_path))          
+             # make sure rar program is now in the path for the rar class
+            utils.addtopath(os.path.dirname(self.rar_exe_path))
 
     def reset(self):
         os.unlink(self.settings_file)


### PR DESCRIPTION
- fix for unrar binary not being detected on new installations due to checking for the wrong binary (rar != unrar). If the unrar (or RaR can also be used on Windows systems) is not in the system path, then the ```rar_exe_path``` field must be set in the .ComicTagger/Settings file to the full path to the given binary.
- updated README to include unrar requirement for CT (as per above re: rar_exe_path)