### PR TITLE
Add a catch around logic to identify the pack range

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -1341,14 +1341,18 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                     #find the pack range.
                     pack_issuelist = None
                     issueid_info = None
-                    if not entry['title'].startswith('0-Day Comics Pack'):
-                        pack_issuelist = entry['issues']
-                        issueid_info = helpers.issue_find_ids(ComicName, ComicID, pack_issuelist, IssueNumber)
-                        if issueid_info['valid'] == True:
-                            logger.info('Issue Number %s exists within pack. Continuing.' % IssueNumber)
-                        else:
-                            logger.fdebug('Issue Number %s does NOT exist within this pack. Skipping' % IssueNumber)
-                            continue
+                    try:
+                        if not entry['title'].startswith('0-Day Comics Pack'):
+                            pack_issuelist = entry['issues']
+                            issueid_info = helpers.issue_find_ids(ComicName, ComicID, pack_issuelist, IssueNumber)
+                            if issueid_info['valid'] == True:
+                                logger.info('Issue Number %s exists within pack. Continuing.' % IssueNumber)
+                            else:
+                                logger.fdebug('Issue Number %s does NOT exist within this pack. Skipping' % IssueNumber)
+                                continue
+                    except:
+                        logger.error('Unable to identify pack range for %s' % entry['title'])
+                        continue
                     #pack support.
                     nowrite = False
                     if all([nzbprov == 'ddl', 'getcomics' in entry['link']]):


### PR DESCRIPTION
Just a catch to allow search to continue if an error is encountered here. Here is the logs that i encountered for this error:

```
Aug 31, 2020 @ 02:22:45.21131-Aug-2020 02:22:45 - INFO :: mylar.search_results.93 : SEARCH-QUEUE : There are 12 results
31-Aug-2020 02:22:45 - DEBUG :: mylar.search_results.168 : SEARCH-QUEUE : Batman Beyond Vol. 6 - Rebirth #1 + 1 - 30 + TPBs [1.7 G]
31-Aug-2020 02:22:45 - DEBUG :: mylar.search_results.168 : SEARCH-QUEUE : Batman Beyond #30 (2019) [28 M]
31-Aug-2020 02:22:45 - DEBUG :: mylar.search_results.168 : SEARCH-QUEUE : Batman Beyond Vol. 5 - The Final Joke (TPB) (2019) [199 M]
31-Aug-2020 02:22:45 - DEBUG :: mylar.search_results.168 : SEARCH-QUEUE : Batman - Detective Comics Vol. 1 - 9 (TPB) (2017-2019) [1.7 G]
31-Aug-2020 02:22:45 - DEBUG :: mylar.search_results.168 : SEARCH-QUEUE : Batman Beyond Vol. 1 - 3 (TPB) (2016-2017) [506 M]
31-Aug-2020 02:22:45 - DEBUG :: mylar.search_results.168 : SEARCH-QUEUE : Batman Beyond #28 (2019) [34 M]
31-Aug-2020 02:22:45 - DEBUG :: mylar.search_results.168 : SEARCH-QUEUE : Batman Beyond #27 (2019) [40 M]
31-Aug-2020 02:22:45 - DEBUG :: mylar.search_results.168 : SEARCH-QUEUE : Batman Beyond - 10,000 Clowns (TPB) (2013) [212 M]
31-Aug-2020 02:22:45 - DEBUG :: mylar.search_results.168 : SEARCH-QUEUE : Batman Beyond #23 (2018) [30 M]
31-Aug-2020 02:22:45 - DEBUG :: mylar.search_results.168 : SEARCH-QUEUE : Batman Beyond #22 (2018) [30 M]
31-Aug-2020 02:22:45 - DEBUG :: mylar.search_results.168 : SEARCH-QUEUE : Justice League Beyond # [305 M]
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.868 : SEARCH-QUEUE : checking search result: Batman Beyond Vol. 6 - Rebirth #1 + 1 - 30 + TPBs
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.878 : SEARCH-QUEUE : sub: Batman Beyond Vol. 6 - Rebirth #1 + 1 - 30 + TPBs
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.927 : SEARCH-QUEUE : comsize_b: 1825361100
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.964 : SEARCH-QUEUE : size given as: 1.7 GB
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1014 : SEARCH-QUEUE : store date used is : 2019-03-27
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1015 : SEARCH-QUEUE : date used is : 2019-03-27
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1058 : SEARCH-QUEUE : usedate: 2019-03-27
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1104 : SEARCH-QUEUE : [CONV] Thu, 11 Apr 2019 00:00:00 is after store date of 2019-03-27
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1124 : SEARCH-QUEUE : Entry: Batman Beyond Vol. 6 - Rebirth #1 + 1 - 30 + TPBs
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.442 : SEARCH-QUEUE : NEWLY SPLIT REORGD: ['Batman', 'Beyond', 'Vol', '6', '-', 'Rebirth', '#1', 'c11', '1', '-', '30', 'c11', 'TPBs']
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.684 : SEARCH-QUEUE : volume label detected, but vol. number is not adjacent, adjusting scope to include number.
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.656 : SEARCH-QUEUE : volume_found: 2
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.676 : SEARCH-QUEUE : volume label detected as : Volume 6 @ position: 2
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.633 : SEARCH-QUEUE : Issue number found: #1
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.488 : SEARCH-QUEUE : Exception match: c
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.507 : SEARCH-QUEUE : Possible alpha numeric issue (or non-numeric only). Testing my theory.
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.509 : SEARCH-QUEUE : [c] Removing possible alpha issue leaves: 11 (Should be a numeric)
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.488 : SEARCH-QUEUE : Exception match: c
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.808 : SEARCH-QUEUE : datecheck: []
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.859 : SEARCH-QUEUE : No year present within title - ignoring as a variable.
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.862 : SEARCH-QUEUE : highest_series_position: 13
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.882 : SEARCH-QUEUE : possible_issuenumbers: [{'number': '#1', 'position': 6, 'mod_position': 31, 'validcountchk': False}, {'number': 'c11', 'position': 7, 'mod_position': -1, 'validcountchk': False}, {'number': '1', 'position': 8, 'mod_position': -1, 'validcountchk': False}, {'number': '30', 'position': 10, 'mod_position': -1, 'validcountchk': False}]
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.888 : SEARCH-QUEUE : hyphen located at position: 21
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.931 : SEARCH-QUEUE : issue number :30
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.960 : SEARCH-QUEUE : issue_position: 10
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.988 : SEARCH-QUEUE : issue verified as : 30
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.993 : SEARCH-QUEUE : Extra item(s) are present between the volume label and the issue number. Checking..
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.995 : SEARCH-QUEUE : new split: ['Batman', 'Beyond', '', '-', 'Rebirth', '#1', 'c11', '1', '-', '30', 'Vol6', 'c11', 'TPBs']
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.1006 : SEARCH-QUEUE : Volume detected as : v6
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.1108 : SEARCH-QUEUE : ALT-SERIES NAME [ISSUE TITLE]: Batman Beyond  [None]
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.1123 : SEARCH-QUEUE : sf_highest_series_pos: ['Batman', 'Beyond', '', '-', 'Rebirth', '#1', 'c11', '1']
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.1175 : SEARCH-QUEUE : series title possibly: Batman Beyond  - Rebirth #1 + 1
31-Aug-2020 02:22:45 - DEBUG :: mylar.parseit.1188 : SEARCH-QUEUE : Alternate series / issue title: Batman Beyond  [None]
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1141 : SEARCH-QUEUE : parsed_info: {'parse_status': 'success', 'sub': None, 'comicfilename': 'Batman Beyond Vol. 6 - Rebirth #1 + 1 - 30 + TPBs', 'comiclocation': None, 'series_name': 'Batman Beyond  - Rebirth #1 + 1', 'series_name_decoded': 'Batman Beyond  - Rebirth #1 + 1', 'issueid': None, 'dynamic_name': 'BatmanBeyond|Rebirth11', 'series_volume': 'v6', 'alt_series': 'Batman Beyond ', 'alt_issue': None, 'issue_year': None, 'issue_number': '30', 'scangroup': None, 'reading_order': None, 'booktype': 'issue'}
31-Aug-2020 02:22:45 - INFO :: mylar.NZB_SEARCH.1142 : SEARCH-QUEUE : booktype: Print / parsed_booktype: issue [ignore_booktype: False]
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1151 : SEARCH-QUEUE : match_check: {'process_status': 'match', 'sub': None, 'volume': 'v6', 'match_type': None, 'comicfilename': 'Batman Beyond Vol. 6 - Rebirth #1 + 1 - 30 + TPBs', 'comiclocation': None, 'series_name': 'Batman Beyond  - Rebirth #1 + 1', 'series_volume': 'v6', 'alt_series': 'Batman Beyond ', 'alt_issue': None, 'issue_year': None, 'issueid': None, 'justthedigits': '30', 'annual_comicid': None, 'scangroup': None, 'booktype': 'issue'}
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1187 : SEARCH-QUEUE : [Vx] Version detected as v6
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1210 : SEARCH-QUEUE : Series Year not provided but Series Volume detected of v6. Bypassing Year Match.
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1264 : SEARCH-QUEUE : volume detection commencing - adjusting length.
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1265 : SEARCH-QUEUE : watch comicversion is v6
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1266 : SEARCH-QUEUE : version found: v6
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1267 : SEARCH-QUEUE : vers4year: no
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1268 : SEARCH-QUEUE : vers4vol: v6
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1297 : SEARCH-QUEUE : FCVersion: 6
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1298 : SEARCH-QUEUE : DCVersion: 6
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1299 : SEARCH-QUEUE : SCVersion: 2016
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1306 : SEARCH-QUEUE : We matched on versions...v6
31-Aug-2020 02:22:45 - DEBUG :: mylar.NZB_SEARCH.1340 : SEARCH-QUEUE : [PACK-QUEUE] DDL Pack detected for Batman Beyond Vol. 6 - Rebirth #1 + 1 - 30 + TPBs (2016-2019).
31-Aug-2020 02:22:45 - ERROR :: mylar.excepthook.315 : SEARCH-QUEUE : Uncaught exception: Traceback (most recent call last):
  File "/app/mylar/mylar/logger.py", line 337, in new_run
    old_run(*args, **kwargs)
  File "/usr/local/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/app/mylar/mylar/helpers.py", line 3145, in search_queue
    ss_queue = mylar.search.searchforissue(item['issueid'])
ValueError: invalid literal for int() with base 10: '1 + 1 '
Traceback (most recent call last):
```