### PR TITLE
(#432) Fixes search & post-processing related issues between similar named series on the watchlist

### DIFF
--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -1276,6 +1276,7 @@ class FileChecker(object):
         return self.matchIT(series_info)
 
     def matchIT(self, series_info):
+        qmatch_chk = None
         series_name = series_info['series_name']
         alt_series = series_info['alt_series']
         filename = series_info['comicfilename']
@@ -1339,7 +1340,12 @@ class FileChecker(object):
         if nspace_altseriesname is not None:
             if re.sub('\|','', nspace_altseriesname.lower()).strip() == re.sub('\|', '', nspace_watchcomic.lower()).strip():
                 seriesalt = True
+                qmatch_chk = 'alt_match'
+
         if any([seriesalt is True, re.sub('\|','', nspace_seriesname.lower()).strip() == re.sub('\|', '', nspace_watchcomic.lower()).strip(), re.sub('\|','', nspace_seriesname_decoded.lower()).strip() == re.sub('\|', '', nspace_watchname_decoded.lower()).strip()]) or any(re.sub('[\|\s]','', x.lower()).strip() == re.sub('[\|\s]','', nspace_seriesname.lower()).strip() for x in self.AS_Alt):
+            if qmatch_chk is None:
+                qmatch_chk = 'match'
+        if qmatch_chk is not None:
             #logger.fdebug('[MATCH: ' + series_info['series_name'] + '] ' + filename)
             enable_annual = False
             annual_comicid = None
@@ -1416,7 +1422,7 @@ class FileChecker(object):
                    elif 'special' in nspace_watchcomic.lower():
                        justthedigits = 'Special %s' % justthedigits
 
-            return {'process_status': 'match',
+            return {'process_status':  qmatch_chk,
                     'sub':             series_info['sub'],
                     'volume':          series_info['series_volume'],
                     'match_type':      None,  #match_type - will eventually pass if it wasa folder vs. filename match,

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -573,6 +573,7 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
     foundc['status'] = False
     done = False
     seperatealpha = "no"
+    hold_the_matches = []
     #---issue problem
     # if issue is '011' instead of '11' in nzb search results, will not have same
     # results. '011' will return different than '11', as will '009' and '09'.
@@ -838,6 +839,7 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
         pack_warning = False
         if not bb == "no results":
             for entry in bb['entries']:
+                alt_match = False
                 #logger.fdebug('entry: %s' % entry)  #<--- uncomment this to see what the search result(s) are
                 #brief match here against 32p since it returns the direct issue number
                 if nzbprov == '32P' and entry['title'][:17] == '0-Day Comics Pack':
@@ -1151,6 +1153,12 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                         if filecomic['process_status'] == 'fail':
                             logger.fdebug('%s was not a match to %s (%s)' % (cleantitle, ComicName, SeriesYear))
                             continue
+                        elif filecomic['process_status'] == 'alt_match':
+                            #if it's an alternate series match, we'll retain each value until the search has compeletely run, compiling matches.
+                            #if at any point it's a standard match (ie. non-alternate series) that will be accepted as the one match and ignore the alts
+                            #once all search options have been exhausted and no matches aside from alternate series then we go get the best result from that list
+                            logger.fdebug('%s was a match due to alternate matching.  Continuing to search, but retaining this result just in case.' % ComicTitle)
+                            alt_match = True
                 elif booktype != parsed_comic['booktype'] and ignore_booktype is False:
                     logger.fdebug('Booktypes do not match. Looking for %s, this is a %s. Ignoring this result.' % (booktype, parsed_comic['booktype']))
                     continue
@@ -1359,7 +1367,7 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                         nzbid = entry['id']
                     else:
                         nzbid = generate_id(nzbprov, entry['link'])
-                    if manual is not True:
+                    if all([manual is not True, alt_match is False]):
                         downloadit = True
                     else:
                         for x in mylar.COMICINFO:
@@ -1378,7 +1386,8 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                             kind = 'torrent'
                             if torznab_host is not None:
                                 tprov = torznab_host[0]
-                        mylar.COMICINFO.append({"ComicName":       ComicName,
+
+                        search_values = {"ComicName":       ComicName,
                                           "ComicID":         ComicID,
                                           "IssueID":         IssueID,
                                           "ComicVolume":     ComicVersion,
@@ -1401,8 +1410,11 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                                           "SARC":            SARC,
                                           "IssueArcID":      IssueArcID,
                                           "newznab":         newznab_host,
-                                          "torznab":         torznab_host})
+                                          "torznab":         torznab_host}
 
+                        mylar.COMICINFO.append(search_values)
+
+                        hold_the_matches.append(search_values)
 
                 else:
                     if filecomic['process_status'] == 'match':
@@ -1442,7 +1454,7 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                                 entry['title'] = entry['filename']
                             else:
                                 nzbid = generate_id(nzbprov, entry['link'])
-                            if manual is not True:
+                            if all([manual is not True, alt_match is False]):
                                 downloadit = True
                             else:
                                 for x in mylar.COMICINFO:
@@ -1475,7 +1487,7 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                                     if torznab_host is not None:
                                         tprov = torznab_host[0]
 
-                                mylar.COMICINFO.append({"ComicName":      ComicName,
+                                search_values = {"ComicName":      ComicName,
                                                   "ComicID":        ComicID,
                                                   "IssueID":        IssueID,
                                                   "ComicVolume":    ComicVersion,
@@ -1498,7 +1510,11 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                                                   "SARC":           SARC,
                                                   "IssueArcID":     IssueArcID,
                                                   "newznab":        newznab_host,
-                                                  "torznab":        torznab_host})
+                                                  "torznab":        torznab_host}
+
+                                mylar.COMICINFO.append(search_values)
+
+                                hold_the_matches.append(search_values)
                         else:
                             log2file = log2file + "issues don't match.." + "\n"
                             downloadit = False


### PR DESCRIPTION
When searching for series that would match as an alternate naming possibility - would incorrectly take the alternate naming match instead of ensuring no other matches exist with the correct series titles (ie. Empyre would match to Empyre - Avengers, etc)

When trying to post-process issues similar as above - if no watchlisted series were present, but the series existed on the arc watchlist, would incorrectly take the wrong series as the matching title.

This PR should resolve all the matching problems as indicated above - however, in doing so, any any alternate series titles that are discovered when file parsing (not the ```Alternate Search Name``` field), are discarded atm in order to try and minimize incorrect matches going forward. 