### PR TITLE
FIX:(#449) hyphens in filenames during refresh/rescan causing error

### DIFF
--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -151,7 +151,7 @@ class FileChecker(object):
                         if runresults['process_status']:
                             run_status = runresults['process_status']
 
-                    if any([run_status == 'success', run_status == 'match']):
+                    if any([run_status == 'success', run_status == 'match', run_status == 'alt_match']):
                         if self.justparse:
                             comiclist.append({
                                     'sub':                 runresults['sub'],


### PR DESCRIPTION
If the filename would contain a hyphen during a filecheck/rescan - it would get flagged as a possible ```alt_match``` due to how there are lots of various naming schemes.  This fixes the error so that things can keep on trucking.

The ```alt_match``` was implemented in a previous PR in order accommodate search results/post-processing returning values that might possibly be a long-shot of a match, but was mistakingly being taken as the priority match. 