### PR TITLE
FIX:(#451) Fixes FeedParser 6.0.0 not working, will still work with < 6

### DIFF
--- a/mylar/rsscheck.py
+++ b/mylar/rsscheck.py
@@ -26,6 +26,7 @@ import time
 import random
 from bs4 import BeautifulSoup
 from io import StringIO
+from pkg_resources import parse_version
 
 import mylar
 from mylar import db, logger, ftpsshup, helpers, auth32p, utorrent, helpers
@@ -49,7 +50,10 @@ def _start_newznab_attr(self, attrsD):
     else:
         context['newznab'][name] = value
 
-feedparser._FeedParserMixin._start_newznab_attr = _start_newznab_attr
+if parse_version(feedparser.__version__) < parse_version('6.0.0'):
+    feedparser._FeedParserMixin._start_newznab_attr = _start_newznab_attr
+else:
+    feedparser.mixin._FeedParserMixin._start_newznab_attr = _start_newznab_attr
 
 def torrents(pickfeed=None, seriesname=None, issue=None, feedinfo=None):
     if pickfeed is None:


### PR DESCRIPTION
Feedparser 6.0.0 breaks backwards compatibility with one of the module calls Mylar uses.

This just checks the version and if it's less than 6 it keeps the current calling method, otherwise it modifies it slightly so that the module can be correctly called using 6.0.0.