### PR TITLE
python3-dev merge

### DIFF
--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -151,7 +151,7 @@ class FileChecker(object):
                         if runresults['process_status']:
                             run_status = runresults['process_status']
 
-                    if any([run_status == 'success', run_status == 'match']):
+                    if any([run_status == 'success', run_status == 'match', run_status == 'alt_match']):
                         if self.justparse:
                             comiclist.append({
                                     'sub':                 runresults['sub'],

--- a/mylar/rsscheck.py
+++ b/mylar/rsscheck.py
@@ -26,6 +26,7 @@ import time
 import random
 from bs4 import BeautifulSoup
 from io import StringIO
+from pkg_resources import parse_version
 
 import mylar
 from mylar import db, logger, ftpsshup, helpers, auth32p, utorrent, helpers
@@ -49,7 +50,10 @@ def _start_newznab_attr(self, attrsD):
     else:
         context['newznab'][name] = value
 
-feedparser._FeedParserMixin._start_newznab_attr = _start_newznab_attr
+if parse_version(feedparser.__version__) < parse_version('6.0.0'):
+    feedparser._FeedParserMixin._start_newznab_attr = _start_newznab_attr
+else:
+    feedparser.mixin._FeedParserMixin._start_newznab_attr = _start_newznab_attr
 
 def torrents(pickfeed=None, seriesname=None, issue=None, feedinfo=None):
     if pickfeed is None:


### PR DESCRIPTION
- FIX:(#449) hyphens in filenames during refresh/rescan causing traceback error

- FIX:(#451) Fixes FeedParser 6.0.0 not working, will still work with < 6