### PR TITLE
FIX:(#471) Fix for annuals not being post-processed

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -730,7 +730,7 @@ class PostProcessor(object):
                                     continue
 
                             for isc in issuechk:
-                                if any([temploc is not None, temploc != 999999999999999]) and helpers.issuedigits(temploc) != helpers.issuedigits(isc['Issue_Number']):
+                                if any([temploc is not None, temploc != 999999999999999]) and all([annchk =='no', helpers.issuedigits(temploc) != helpers.issuedigits(isc['Issue_Number'])]) or all([annchk == 'yes', helpers.issuedigits(re.sub('annual', '', temploc.lower()).strip()) != helpers.issuedigits(isc['Issue_Number'])]):
                                     logger.fdebug('issues dont match. Skipping')
                                     continue
 

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5929,6 +5929,8 @@ class WebInterface(object):
         elif all([seriestitle is None, meta_data is None]): # and 'series' not in meta_data:
             myDB = db.DBConnection()
             meta_data = myDB.selectone('SELECT * FROM issues where IssueID=?', [issueid]).fetchone()
+            if meta_data is None:
+                meta_data = myDB.selectone('SELECT * FROM annuals where IssueID=?', [issueid]).fetchone()
             seriestitle = meta_data['ComicName']
             issuenumber = meta_data['Issue_Number']
             try:
@@ -5946,6 +5948,8 @@ class WebInterface(object):
         else:
             myDB = db.DBConnection()
             metadata_db = myDB.selectone('SELECT * FROM issues where IssueID=?', [issueid]).fetchone()
+            if metadata_db is None:
+                metadata_db = myDB.selectone('SELECT * FROM annuals where IssueID=?', [issueid]).fetchone()
             seriestitle = meta_data['series']
             if any([seriestitle == 'None', seriestitle is None]):
                 seriestitle = metadata_db['ComicName']


### PR DESCRIPTION
Also included : quick fix for viewing downloaded annuals on the series detail page (via the **i** icon) - just added the correct table.