### PR TITLE
IMP: Traceback/exception handling added to better handle crashes during search

### DIFF
--- a/data/interfaces/carbon/css/style.css
+++ b/data/interfaces/carbon/css/style.css
@@ -1783,6 +1783,23 @@ div#artistheader h2 a {
   min-width: 160px;
   text-align: center;
 }
+
+#exceptions_table th#date { text-align: center; max-width: 20px; }
+#exceptions_table th#line_num { text-align: center; width: 5px; }
+#exceptions_table th#func_name { text-align: center; width: 15px; }
+#exceptions_table th#filename { text-align: center; max-width: 15px; }
+#exceptions_table th#error { text-align: center; max-width: 40px; }
+#exceptions_table th#error_text { text-align: center; max-width: 50px; }
+#exceptions_table th#options { text-align: center; max-width: 15px; }
+
+#exceptions_table td#date { vertical-align: middle; text-align: left; max-width: 20px; }
+#exceptions_table td#line_num { vertical-align: middle; text-align: left; width: 5px; }
+#exceptions_table td#func_name { vertical-align: middle; text-align: left; width: 15px; }
+#exceptions_table td#filename { vertical-align: middle; text-align: center; max-width: 15px; }
+#exceptions_table td#error { vertical-align: middle; text-align: left; max-width:40px; }
+#exceptions_table td#error_text { vertical-align: middle; text-align: left; max-width: 50px; }
+#exceptions_table td#options { vertical-align: middle; text-align: center; max-width: 15px; }
+
 DIV.progress-container
 {
 	position: relative;

--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -829,7 +829,6 @@ div#searchbar .mini-icon {
 .comictable td {
   padding-right: 15px;
 }
-
 .configtable legend {
   font-size: 16px;
   font-weight: bold;
@@ -1766,6 +1765,23 @@ div#artistheader h2 a {
   min-width: 160px;
   text-align: center;
 }
+
+#exceptions_table th#date { text-align: center; max-width: 20px; }
+#exceptions_table th#line_num { text-align: center; width: 5px; }
+#exceptions_table th#func_name { text-align: center; width: 15px; }
+#exceptions_table th#filename { text-align: center; max-width: 15px; }
+#exceptions_table th#error { text-align: center; max-width: 40px; }
+#exceptions_table th#error_text { text-align: center; max-width: 50px; }
+#exceptions_table th#options { text-align: center; max-width: 15px; }
+
+#exceptions_table td#date { vertical-align: middle; text-align: left; max-width: 20px; }
+#exceptions_table td#line_num { vertical-align: middle; text-align: left; width: 5px; }
+#exceptions_table td#func_name { vertical-align: middle; text-align: left; width: 15px; }
+#exceptions_table td#filename { vertical-align: middle; text-align: center; max-width: 15px; }
+#exceptions_table td#error { vertical-align: middle; text-align: left; max-width:40px; }
+#exceptions_table td#error_text { vertical-align: middle; text-align: left; max-width: 50px; }
+#exceptions_table td#options { vertical-align: middle; text-align: center; max-width: 15px; }
+
 DIV.progress-container
 {
 	position: relative;

--- a/data/interfaces/default/logs.html
+++ b/data/interfaces/default/logs.html
@@ -15,6 +15,25 @@
               OFF
             %endif
             </a>
+                        <a id="menu_link_edit" title="Manage Exceptions" href="javascript:void(0)" onclick="manageTheExceptions()">Exceptions / Tracebacks</a>
+                        <div id="manage_exceptions_dialog" title="View currently logged tracebacks / exceptions" style="display:none">
+                            <table name="exceptions_table" id="exceptions_table" width="100%" border="1px;" style="border-collapse: separate; border-spacing:5px;">
+                                <thead>
+                                <tr>
+                                    <th id="date">Date</th>
+                                    <th id="line_num">Line #</th>
+                                    <th id="func_name">Function</th>
+                                    <th id="filename">Filename</th>
+                                    <th id="error">Error</th>
+                                    <th id="error_text">Error Text</th>
+                                    <th id="options">Options</th>
+                                </tr>
+                                </thead>
+                                <tbody id="exception_table_body" value="There is nothing logged to the excptions db currently">
+                                </tbody>
+                            </table>
+                        </div>
+
         </div>
     </div>
 </%def>
@@ -56,6 +75,92 @@
 <%def name="javascriptIncludes()">
 	<script src="js/libs/jquery.dataTables.min.js"></script>
         <script>
+        function manageTheExceptions() {
+                $.getJSON("manageExceptions", function(data) {
+                        if (data.error != undefined) {
+                                $('#exception_table_body').text("No data available...");
+                        }
+                        if (data.length != 0) {
+                                document.getElementById("exception_table_body").innerHTML = '';
+                                for( var i = 0, len = data.length; i < len; i++ ) {
+                                        $('#exception_table_body').append('<tr><td id="date">'+data[i].date+'</a></td><td id="line_num">'+data[i].line_num+'</td><td id="func_name">'+data[i].func_name+'</td><td id="filename">'+data[i].filename+'</td><td id="error">'+data[i].error+'</td><td id="error_text">'+data[i].error_text+'</td><td id="options"><a id="delete" onclick="delete_log(' + data[i].id + ')" name="delete" href="#"><img style="padding:10px;" src="images/delete.png" height="20" width="20" title="delete entry" class="highqual" /></a> <a id="view" onclick="view_log(' + data[i].id + ')" name="view" class="view" href="#"><img style="padding:10px;" src="images/list-view.png" height="20" title="view log snippet" width="20" class="highqual" /></a></td></tr>');
+                                };
+                                $('#exceptions_table').dataTable({
+                                        "aoColumns": [
+                                                null,
+                                                null,
+                                                null,
+                                                null,
+                                                null,
+                                                null,
+                                                null
+                                        ],
+                                        "aaSorting": [[ 1, 'desc']],
+                                        "bFilter": false,
+                                        "bInfo": false,
+                                        "bPaginate": false,
+                                        "bDestroy": true
+                                });
+                        } else {
+                                document.getElementById("exception_table_body").innerHTML = '</br><td colspan="3"><center>There are no errors/tracebacks logged thus far...</center></td>';
+                        }
+                $("#manage_exceptions_dialog").dialog({
+                        modal: true,
+                        width: "75%",
+                        maxHeight: 500
+                });
+                return false;
+                });
+        }
+        </script>
+        <script>
+        function delete_log(log_id) {
+            $.get("deleteSpecificLog",
+                { log_id: log_id },
+                function(data){
+                   if (data.error != undefined) {
+                       $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Unable to delete specific log file</div>");
+                       $('#ajaxMsg').addClass('failure').fadeIn().delay(3000).fadeOut();
+                   }
+                   if ( data.indexOf("success") > -1){
+                       $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Successfully deleted log file</div>");
+                       $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                       $('#exception_table_body').empty(); //dialog('destroy');
+                       manageTheExceptions();
+                   } else {
+                       $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Unable to delete specific log file</div>");
+                       $('#ajaxMsg').addClass('failure').fadeIn().delay(3000).fadeOut();
+                   }
+
+            return false;
+            });
+        }
+
+        function view_log(log_id) {
+            $.get("viewSpecificLog",
+                { log_id: log_id },
+                function(data){
+                   if (data.error != undefined) {
+                       $('#specific_log_body').text("No data available...");
+                   }
+                   if (data.length != 0) {
+                       $('<div id="specific_log_dialog" title="View specific log snippet">'+data+'</div>').appendTo('body');
+                   } else {
+                       document.getElementById("specific_log_body").innerHTML = 'There is nothing to see here atm at least.';
+                   }
+
+            $("#specific_log_dialog").dialog({
+                    modal: true,
+                    width: "50%",
+                    maxHeight: 500,
+                    close: function(event, ui){
+                        $("#specific_log_dialog").remove();
+                    }
+            });
+            return false;
+            });
+        }
+
         $(document).ready(function() {
             initActions();
             $('#log_table').dataTable( {

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -700,6 +700,7 @@ def dbcheck():
     c.execute('CREATE TABLE IF NOT EXISTS manualresults (provider TEXT, id TEXT, kind TEXT, comicname TEXT, volume TEXT, oneoff TEXT, fullprov TEXT, issuenumber TEXT, modcomicname TEXT, name TEXT, link TEXT, size TEXT, pack_numbers TEXT, pack_issuelist TEXT, comicyear TEXT, issuedate TEXT, tmpprov TEXT, pack TEXT, issueid TEXT, comicid TEXT, sarc TEXT, issuearcid TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS storyarcs(StoryArcID TEXT, ComicName TEXT, IssueNumber TEXT, SeriesYear TEXT, IssueYEAR TEXT, StoryArc TEXT, TotalIssues TEXT, Status TEXT, inCacheDir TEXT, Location TEXT, IssueArcID TEXT, ReadingOrder INT, IssueID TEXT, ComicID TEXT, ReleaseDate TEXT, IssueDate TEXT, Publisher TEXT, IssuePublisher TEXT, IssueName TEXT, CV_ArcID TEXT, Int_IssueNumber INT, DynamicComicName TEXT, Volume TEXT, Manual TEXT, DateAdded TEXT, DigitalDate TEXT, Type TEXT, Aliases TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS ddl_info (ID TEXT UNIQUE, series TEXT, year TEXT, filename TEXT, size TEXT, issueid TEXT, comicid TEXT, link TEXT, status TEXT, remote_filesize TEXT, updated_date TEXT, mainlink TEXT, issues TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS exceptions(date TEXT UNIQUE, comicname TEXT, issuenumber TEXT, seriesyear TEXT, issueid TEXT, comicid TEXT, booktype TEXT, searchmode TEXT, error TEXT, error_text TEXT, filename TEXT, line_num TEXT, func_name TEXT, traceback TEXT)')
     conn.commit
     c.close
 

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -14,46 +14,86 @@
 #  along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
 
 
-
 import mylar
-from mylar import logger, db, updater, helpers, parseit, findcomicfeed, notifiers, rsscheck, Failed, filechecker, auth32p, sabnzbd, nzbget, wwt, getcomics
+from mylar import (
+    logger,
+    db,
+    updater,
+    helpers,
+    findcomicfeed,
+    notifiers,
+    rsscheck,
+    Failed,
+    filechecker,
+    auth32p,
+    sabnzbd,
+    nzbget,
+    wwt,
+    getcomics,
+)
 
 import feedparser
 import requests
-import urllib.request, urllib.parse, urllib.error
-import os, errno
-import string
+import os
+import errno
 import sys
-import getopt
 import re
 import time
+import urllib.request
+import urllib.error
 import urllib.parse
 from urllib.parse import urljoin
-from xml.dom.minidom import parseString
-import urllib.request, urllib.error, urllib.parse
 import email.utils
 import datetime
 import shutil
-from base64 import b16encode, b32decode
 from operator import itemgetter
 from wsgiref.handlers import format_date_time
+import traceback
 
-def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, IssueID, AlternateSearch=None, UseFuzzy=None, ComicVersion=None, SARC=None, IssueArcID=None, mode=None, rsscheck=None, ComicID=None, manualsearch=None, filesafe=None, allow_packs=None, oneoff=False, manual=False, torrentid_32p=None, digitaldate=None, booktype=None, ignore_booktype=False):
+
+def search_init(
+    ComicName,
+    IssueNumber,
+    ComicYear,
+    SeriesYear,
+    Publisher,
+    IssueDate,
+    StoreDate,
+    IssueID,
+    AlternateSearch=None,
+    UseFuzzy=None,
+    ComicVersion=None,
+    SARC=None,
+    IssueArcID=None,
+    mode=None,
+    rsscheck=None,
+    ComicID=None,
+    manualsearch=None,
+    filesafe=None,
+    allow_packs=None,
+    oneoff=False,
+    manual=False,
+    torrentid_32p=None,
+    digitaldate=None,
+    booktype=None,
+    ignore_booktype=False,
+):
 
     mylar.COMICINFO = []
     unaltered_ComicName = None
     if filesafe:
         if filesafe != ComicName and mode != 'want_ann':
-            logger.info('[SEARCH] Special Characters exist within Series Title. Enabling search-safe Name : %s' % filesafe)
+            logger.info(
+                '[SEARCH] Special Characters exist within Series Title. Enabling'
+                ' search-safe Name : %s' % filesafe
+            )
             if AlternateSearch is None or AlternateSearch == 'None':
                 AlternateSearch = filesafe
             else:
                 AlternateSearch += '##' + filesafe
             unaltered_ComicName = ComicName
-            #ComicName = filesafe
-            #logger.info('AlternateSearch is : ' + AlternateSearch)
 
-    if ComicYear == None:
+    if ComicYear is None:
         ComicYear = str(datetime.datetime.now().year)
     else:
         ComicYear = str(ComicYear)[:4]
@@ -73,16 +113,22 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
         logger.fdebug('Issue Title not found. Setting to None.')
 
     if mode == 'want_ann':
-        logger.info("Annual/Special issue search detected. Appending to issue #")
-        #anything for mode other than None indicates an annual.
+        logger.info('Annual/Special issue search detected. Appending to issue #')
+        # anything for mode other than None indicates an annual.
         if all(['annual' not in ComicName.lower(), 'special' not in ComicName.lower()]):
             ComicName = '%s Annual' % ComicName
 
-        if all([AlternateSearch is not None, AlternateSearch != "None", 'special' not in ComicName.lower()]):
+        if all(
+            [
+                AlternateSearch is not None,
+                AlternateSearch != "None",
+                'special' not in ComicName.lower(),
+            ]
+        ):
             AlternateSearch = '%s Annual' % AlternateSearch
 
     if mode == 'pullwant' or IssueID is None:
-        #one-off the download.
+        # one-off the download.
         logger.fdebug('One-Off Search parameters:')
         logger.fdebug('ComicName: %s' % ComicName)
         logger.fdebug('Issue: %s' % IssueNumber)
@@ -100,36 +146,41 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
     torznab_hosts = []
 
     logger.fdebug("Checking for torrent enabled.")
-    if mylar.CONFIG.ENABLE_TORRENT_SEARCH: #and mylar.CONFIG.ENABLE_TORRENTS:
+    if mylar.CONFIG.ENABLE_TORRENT_SEARCH:
         if mylar.CONFIG.ENABLE_32P and not helpers.block_provider_check('32P'):
             torprovider.append('32p')
-            torp+=1
-        if mylar.CONFIG.ENABLE_PUBLIC and not helpers.block_provider_check('public torrents'):
+            torp += 1
+        if mylar.CONFIG.ENABLE_PUBLIC and not helpers.block_provider_check(
+            'public torrents'
+        ):
             torprovider.append('public torrents')
-            torp+=1
+            torp += 1
         if mylar.CONFIG.ENABLE_TORZNAB is True:
             for torznab_host in mylar.CONFIG.EXTRA_TORZNABS:
-                if any([torznab_host[5] == '1', torznab_host[5] == 1]) and not helpers.block_provider_check(torznab_host[0]):
-                    torznab_hosts.append(torznab_host)
-                    torprovider.append('torznab: %s' % torznab_host[0])
-                    torznabs+=1
+                if any([torznab_host[5] == '1', torznab_host[5] == 1]):
+                    if not helpers.block_provider_check(torznab_host[0]):
+                        torznab_hosts.append(torznab_host)
+                        torprovider.append('torznab: %s' % torznab_host[0])
+                        torznabs += 1
 
-    ##nzb provider selection##
-    ##'dognzb' or 'nzb.su' or 'experimental'
+    # nzb provider selection##
+    # 'dognzb' or 'nzb.su' or 'experimental'
     nzbprovider = []
     nzbp = 0
-    if mylar.CONFIG.NZBSU == True and not helpers.block_provider_check('nzb.su'):
+    if mylar.CONFIG.NZBSU is True and not helpers.block_provider_check('nzb.su'):
         nzbprovider.append('nzb.su')
-        nzbp+=1
-    if mylar.CONFIG.DOGNZB == True and not helpers.block_provider_check('dognzb'):
+        nzbp += 1
+    if mylar.CONFIG.DOGNZB is True and not helpers.block_provider_check('dognzb'):
         nzbprovider.append('dognzb')
-        nzbp+=1
+        nzbp += 1
 
     # --------
     #  Xperimental
-    if mylar.CONFIG.EXPERIMENTAL == True and not helpers.block_provider_check('experimental'):
+    if mylar.CONFIG.EXPERIMENTAL is True and not helpers.block_provider_check(
+        'experimental'
+    ):
         nzbprovider.append('experimental')
-        nzbp+=1
+        nzbp += 1
 
     newznabs = 0
 
@@ -137,17 +188,18 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
 
     if mylar.CONFIG.NEWZNAB is True:
         for newznab_host in mylar.CONFIG.EXTRA_NEWZNABS:
-            if any([newznab_host[5] == '1', newznab_host[5] == 1]) and not helpers.block_provider_check(newznab_host[0]):
-                newznab_hosts.append(newznab_host)
-                nzbprovider.append('newznab: %s' % newznab_host[0])
-                newznabs+=1
+            if any([newznab_host[5] == '1', newznab_host[5] == 1]):
+                if not helpers.block_provider_check(newznab_host[0]):
+                    newznab_hosts.append(newznab_host)
+                    nzbprovider.append('newznab: %s' % newznab_host[0])
+                    newznabs += 1
 
     ddls = 0
     ddlprovider = []
 
     if mylar.CONFIG.ENABLE_DDL is True and not helpers.block_provider_check('DDL'):
         ddlprovider.append('DDL')
-        ddls+=1
+        ddls += 1
 
     logger.fdebug('nzbprovider(s): %s' % nzbprovider)
     # --------
@@ -162,32 +214,49 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
         logger.fdebug('Usenet Retention : %s days' % mylar.CONFIG.USENET_RETENTION)
 
     if ddls > 0:
-        logger.fdebug('there are %s Direct Download providers that are currently enabled.' % ddls)
+        logger.fdebug(
+            'there are %s Direct Download providers that are currently enabled.' % ddls
+        )
     findit = {}
     findit['status'] = False
 
     totalproviders = providercount + torproviders + ddls
 
     if totalproviders == 0:
-        logger.error('[WARNING] You have %s search providers enabled. I need at least ONE provider to work. Aborting search.' % totalproviders)
+        logger.error(
+            '[WARNING] You have %s search providers enabled. I need at least ONE'
+            ' provider to work. Aborting search.'
+            % totalproviders
+        )
         findit['status'] = False
         nzbprov = None
         return findit, nzbprov
 
-    prov_order, torznab_info, newznab_info = provider_sequence(nzbprovider, torprovider, newznab_hosts, torznab_hosts, ddlprovider)
+    prov_order, torznab_info, newznab_info = provider_sequence(
+        nzbprovider, torprovider, newznab_hosts, torznab_hosts, ddlprovider
+    )
     # end provider order sequencing
     logger.fdebug('search provider order is %s' % prov_order)
 
-    #fix for issue dates between Nov-Dec/(Jan-Feb-Mar)
+    # fix for issue dates between Nov-Dec/(Jan-Feb-Mar)
     IssDt = str(IssueDate)[5:7]
     if any([IssDt == "12", IssDt == "11", IssDt == "01", IssDt == "02", IssDt == "03"]):
-         IssDateFix = IssDt
+        IssDateFix = IssDt
     else:
-         IssDateFix = "no"
-         if StoreDate is not None:
-             StDt = str(StoreDate)[5:7]
-             if any([StDt == "10", StDt == "12", StDt == "11", StDt == "01", StDt == "02", StDt == "03"]):
-                 IssDateFix = StDt
+        IssDateFix = "no"
+        if StoreDate is not None:
+            StDt = str(StoreDate)[5:7]
+            if any(
+                [
+                    StDt == "10",
+                    StDt == "12",
+                    StDt == "11",
+                    StDt == "01",
+                    StDt == "02",
+                    StDt == "03",
+                ]
+            ):
+                IssDateFix = StDt
 
     searchcnt = 0
     srchloop = 1
@@ -199,14 +268,13 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
             searchcnt = 0  # if it's not enabled, don't even bother.
     else:
         if mylar.CONFIG.ENABLE_RSS:
-            searchcnt = 2 # rss first, then api on non-matches
+            searchcnt = 2  # rss first, then api on non-matches
         else:
-            searchcnt = 2  #set the searchcnt to 2 (api)
-            srchloop = 2   #start the counter at api, so it will exit without running RSS
+            searchcnt = 2  # set the searchcnt to 2 (api)
+            srchloop = 2  # start the counter at API, so itll exit without running RSS
 
     if IssueNumber is not None:
-        intIss = helpers.issuedigits(IssueNumber)
-        iss = IssueNumber
+        findcomiciss = IssueNumber
         if '\xbd' in IssueNumber:
             findcomiciss = '0.5'
         elif '\xbc' in IssueNumber:
@@ -214,53 +282,55 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
         elif '\xbe' in IssueNumber:
             findcomiciss = '0.75'
         elif '\u221e' in IssueNumber:
-            #issnum = utf-8 will encode the infinity symbol without any help
+            # issnum = utf-8 will encode the infinity symbol without any help
             findcomiciss = 'infinity'  # set 9999999999 for integer value of issue
-        else:
-            findcomiciss = iss
 
-        #determine the amount of loops here
+        # determine the amount of loops here
         fcs = 0
         c_alpha = None
-        dsp_c_alpha = None
         c_number = None
+        dsp_c_alpha = None
         c_num_a4 = None
         while fcs < len(findcomiciss):
-            #take first occurance of alpha in string and carry it through
+            # take first occurance of alpha in string and carry it through
             if findcomiciss[fcs].isalpha():
                 c_alpha = findcomiciss[fcs:].rstrip()
                 c_number = findcomiciss[:fcs].rstrip()
                 break
             elif '.' in findcomiciss[fcs]:
                 c_number = findcomiciss[:fcs].rstrip()
-                c_num_a4 = findcomiciss[fcs+1:].rstrip()
-                #if decimal seperates numeric from alpha (ie - 7.INH)
-                #don't give calpha a value or else will seperate with a space further down
-                #assign it to dsp_c_alpha so that it can be displayed for debugging.
+                c_num_a4 = findcomiciss[fcs + 1 :].rstrip()
+                # if decimal seperates numeric from alpha (ie - 7.INH), don't give
+                # calpha a value or else will seperate with a space further down.
+                # Assign it to dsp_c_alpha so that it can be displayed for debugging.
                 if not c_num_a4.isdigit():
                     dsp_c_alpha = c_num_a4
                 else:
                     c_number = str(c_number) + '.' + str(c_num_a4)
                 break
-            fcs+=1
+            fcs += 1
         logger.fdebug('calpha/cnumber: %s / %s' % (dsp_c_alpha, c_number))
 
         if c_number is None:
-            c_number = findcomiciss # if it's None, means no special alphas or decimals
+            c_number = findcomiciss  # if it's None = no special alphas or decimals
 
         if '.' in c_number:
             decst = c_number.find('.')
             c_number = c_number[:decst].rstrip()
 
-    while (srchloop <= searchcnt):
-        #searchmodes:
-        # rss - will run through the built-cached db of entries
-        # api - will run through the providers via api (or non-api in the case of Experimental)
-        # the trick is if the search is done during an rss compare, it needs to exit when done.
-        # otherwise, the order of operations is rss feed check first, followed by api on non-results.
+    while srchloop <= searchcnt:
+        """searchmodes:
+        rss - will run through the built-cached db of entries
+        api - will run through the providers via api (or non-api in the case of
+              Experimental) the trick is if the search is done during an rss compare,
+              it needs to exit when done. Ootherwise, the order of operations is rss
+              feed check first, followed by api on non-results.
+        """
 
-        if srchloop == 1: searchmode = 'rss'  #order of ops - this will be used first.
-        elif srchloop == 2: searchmode = 'api'
+        if srchloop == 1:
+            searchmode = 'rss'  # order of ops - this will be used first.
+        elif srchloop == 2:
+            searchmode = 'api'
 
         if '0-Day' in ComicName:
             cmloopit = 1
@@ -284,7 +354,7 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
 
         logger.fdebug('Initiating Search via : %s' % searchmode)
 
-        while (cmloopit >= 1):
+        while cmloopit >= 1:
             prov_count = 0
             if len(prov_order) == 1:
                 tmp_prov_count = 1
@@ -296,7 +366,7 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
 
             searchprov = None
 
-            while (tmp_prov_count > prov_count):
+            while tmp_prov_count > prov_count:
                 checked_once = False
                 provider_blocked = helpers.block_provider_check(prov_order[prov_count])
                 send_prov_count = tmp_prov_count - prov_count
@@ -304,53 +374,135 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
                 torznab_host = None
                 if prov_order[prov_count] == 'DDL' and not provider_blocked:
                     searchprov = 'DDL'
-                if prov_order[prov_count] == '32p' and not provider_blocked:
+                elif prov_order[prov_count] == '32p' and not provider_blocked:
                     searchprov = '32P'
-                elif prov_order[prov_count] == 'public torrents' and not provider_blocked:
+                elif (
+                    prov_order[prov_count] == 'public torrents' and not provider_blocked
+                ):
                     searchprov = 'Public Torrents'
                 elif 'torznab' in prov_order[prov_count]:
                     searchprov = 'torznab'
                     for nninfo in torznab_info:
-                        if nninfo['provider'] == prov_order[prov_count] and not provider_blocked:
+                        if (
+                            nninfo['provider'] == prov_order[prov_count]
+                            and not provider_blocked
+                        ):
                             torznab_host = nninfo['info']
                     if torznab_host is None:
-                        logger.fdebug('there was an error - torznab information was blank and it should not be.')
+                        logger.fdebug(
+                            'there was an error - torznab information was blank and'
+                            ' it should not be.'
+                        )
                 elif 'newznab' in prov_order[prov_count]:
-                #this is for newznab
                     searchprov = 'newznab'
                     for nninfo in newznab_info:
-                        if nninfo['provider'] == prov_order[prov_count] and not provider_blocked:
+                        if (
+                            nninfo['provider'] == prov_order[prov_count]
+                            and not provider_blocked
+                        ):
                             newznab_host = nninfo['info']
                     if newznab_host is None:
-                        logger.fdebug('there was an error - newznab information was blank and it should not be.')
+                        logger.fdebug(
+                            'there was an error - newznab information was blank and it'
+                            ' should not be.'
+                        )
                 else:
                     newznab_host = None
                     torznab_host = None
                     searchprov = prov_order[prov_count].lower()
 
-                if all([searchprov == 'dognzb', mylar.CONFIG.DOGNZB == 0]) or all([searchprov == 'dognzb', provider_blocked]):
-                    #since dognzb could hit the 100 daily api limit during the middle of a search run, check here on each pass to make
-                    #sure it's not disabled (it gets auto-disabled on maxing out the API hits)
-                    prov_count+=1
+                if searchprov == 'dognzb' and any(
+                    [mylar.CONFIG.DOGNZB == 0, provider_blocked]
+                ):
+                    # since dognzb could hit the 100 daily api limit during the middle
+                    # of a search run, check here on each pass to make sure it's not
+                    # disabled (it gets auto-disabled on maxing out the API hits)
+                    prov_count += 1
                     continue
-                elif all([searchprov == '32P', checked_once is True, not provider_blocked]) or all([searchprov == 'DDL', checked_once is True, not provider_blocked]) or all ([searchprov == 'Public Torrents', checked_once is True, not provider_blocked]) or all([searchprov == 'experimental', checked_once is True, not provider_blocked]) or all([searchprov == 'DDL', checked_once is True, not provider_blocked]):
-                    prov_count+=1
+                elif all(
+                    [checked_once is True, not provider_blocked]
+                ) and searchprov not in (
+                    '32P',
+                    'DDL',
+                    'Public Torrents',
+                    'experimental',
+                    'DDL',
+                ):
+                    prov_count += 1
                     continue
                 if searchmode == 'rss':
-                    #if searchprov.lower() == 'ddl':
-                    #    prov_count+=1
-                    #    continue
-                    findit = NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="yes", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=unaltered_ComicName, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, digitaldate=digitaldate, booktype=booktype, chktpb=chktpb, ignore_booktype=ignore_booktype)
+                    findit = NZB_SEARCH(
+                        ComicName,
+                        IssueNumber,
+                        ComicYear,
+                        SeriesYear,
+                        Publisher,
+                        IssueDate,
+                        StoreDate,
+                        searchprov,
+                        send_prov_count,
+                        IssDateFix,
+                        IssueID,
+                        UseFuzzy,
+                        newznab_host,
+                        ComicVersion=ComicVersion,
+                        SARC=SARC,
+                        IssueArcID=IssueArcID,
+                        RSS="yes",
+                        ComicID=ComicID,
+                        issuetitle=issuetitle,
+                        unaltered_ComicName=unaltered_ComicName,
+                        oneoff=oneoff,
+                        cmloopit=cmloopit,
+                        manual=manual,
+                        torznab_host=torznab_host,
+                        digitaldate=digitaldate,
+                        booktype=booktype,
+                        chktpb=chktpb,
+                        ignore_booktype=ignore_booktype,
+                    )
                     if findit['status'] is False:
                         if AlternateSearch is not None and AlternateSearch != "None":
                             chkthealt = AlternateSearch.split('##')
                             if chkthealt == 0:
                                 AS_Alternate = AlternateSearch
-                            loopit = len(chkthealt)
                             for calt in chkthealt:
                                 AS_Alternate = re.sub('##', '', calt)
-                                logger.info('Alternate Search pattern detected...re-adjusting to : %s' % AS_Alternate)
-                                findit = NZB_SEARCH(AS_Alternate, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="yes", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=AS_Alternate, allow_packs=allow_packs, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, digitaldate=digitaldate, booktype=booktype, chktpb=chktpb, ignore_booktype=ignore_booktype)
+                                logger.info(
+                                    'Alternate Search pattern detected...re-adjusting'
+                                    ' to : %s' % AS_Alternate
+                                )
+                                findit = NZB_SEARCH(
+                                    AS_Alternate,
+                                    IssueNumber,
+                                    ComicYear,
+                                    SeriesYear,
+                                    Publisher,
+                                    IssueDate,
+                                    StoreDate,
+                                    searchprov,
+                                    send_prov_count,
+                                    IssDateFix,
+                                    IssueID,
+                                    UseFuzzy,
+                                    newznab_host,
+                                    ComicVersion=ComicVersion,
+                                    SARC=SARC,
+                                    IssueArcID=IssueArcID,
+                                    RSS="yes",
+                                    ComicID=ComicID,
+                                    issuetitle=issuetitle,
+                                    unaltered_ComicName=AS_Alternate,
+                                    allow_packs=allow_packs,
+                                    oneoff=oneoff,
+                                    cmloopit=cmloopit,
+                                    manual=manual,
+                                    torznab_host=torznab_host,
+                                    digitaldate=digitaldate,
+                                    booktype=booktype,
+                                    chktpb=chktpb,
+                                    ignore_booktype=ignore_booktype,
+                                )
                                 if findit['status'] is True:
                                     break
                             if findit['status'] is True:
@@ -360,19 +512,91 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
                         break
 
                 else:
-                    findit = NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="no", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=unaltered_ComicName, allow_packs=allow_packs, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, torrentid_32p=torrentid_32p, digitaldate=digitaldate, booktype=booktype, chktpb=chktpb, ignore_booktype=ignore_booktype)
-                    if all([searchprov == '32P', checked_once is False]) or all([searchprov.lower() == 'ddl', checked_once is False]) or all([searchprov == 'Public Torrents', checked_once is False]) or all([searchprov == 'experimental', checked_once is False]):
+                    findit = NZB_SEARCH(
+                        ComicName,
+                        IssueNumber,
+                        ComicYear,
+                        SeriesYear,
+                        Publisher,
+                        IssueDate,
+                        StoreDate,
+                        searchprov,
+                        send_prov_count,
+                        IssDateFix,
+                        IssueID,
+                        UseFuzzy,
+                        newznab_host,
+                        ComicVersion=ComicVersion,
+                        SARC=SARC,
+                        IssueArcID=IssueArcID,
+                        RSS="no",
+                        ComicID=ComicID,
+                        issuetitle=issuetitle,
+                        unaltered_ComicName=unaltered_ComicName,
+                        allow_packs=allow_packs,
+                        oneoff=oneoff,
+                        cmloopit=cmloopit,
+                        manual=manual,
+                        torznab_host=torznab_host,
+                        torrentid_32p=torrentid_32p,
+                        digitaldate=digitaldate,
+                        booktype=booktype,
+                        chktpb=chktpb,
+                        ignore_booktype=ignore_booktype,
+                    )
+                    if all(
+                        [checked_once is False, not provider_blocked]
+                    ) and searchprov in (
+                        '32P',
+                        'DDL',
+                        'Public Torrents',
+                        'experimental',
+                        'DDL',
+                    ):
                         checked_once = True
                     if findit['status'] is False:
                         if AlternateSearch is not None and AlternateSearch != "None":
                             chkthealt = AlternateSearch.split('##')
                             if chkthealt == 0:
                                 AS_Alternate = AlternateSearch
-                            loopit = len(chkthealt)
                             for calt in chkthealt:
                                 AS_Alternate = re.sub('##', '', calt)
-                                logger.info('Alternate Search pattern detected...re-adjusting to : %s' % AS_Alternate)
-                                findit = NZB_SEARCH(AS_Alternate, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, searchprov, send_prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host, ComicVersion=ComicVersion, SARC=SARC, IssueArcID=IssueArcID, RSS="no", ComicID=ComicID, issuetitle=issuetitle, unaltered_ComicName=unaltered_ComicName, allow_packs=allow_packs, oneoff=oneoff, cmloopit=cmloopit, manual=manual, torznab_host=torznab_host, torrentid_32p=torrentid_32p, digitaldate=digitaldate, booktype=booktype, chktpb=chktpb, ignore_booktype=ignore_booktype)
+                                logger.info(
+                                    'Alternate Search pattern detected...re-adjusting'
+                                    'to : %s' % AS_Alternate
+                                )
+                                findit = NZB_SEARCH(
+                                    AS_Alternate,
+                                    IssueNumber,
+                                    ComicYear,
+                                    SeriesYear,
+                                    Publisher,
+                                    IssueDate,
+                                    StoreDate,
+                                    searchprov,
+                                    send_prov_count,
+                                    IssDateFix,
+                                    IssueID,
+                                    UseFuzzy,
+                                    newznab_host,
+                                    ComicVersion=ComicVersion,
+                                    SARC=SARC,
+                                    IssueArcID=IssueArcID,
+                                    RSS="no",
+                                    ComicID=ComicID,
+                                    issuetitle=issuetitle,
+                                    unaltered_ComicName=unaltered_ComicName,
+                                    allow_packs=allow_packs,
+                                    oneoff=oneoff,
+                                    cmloopit=cmloopit,
+                                    manual=manual,
+                                    torznab_host=torznab_host,
+                                    torrentid_32p=torrentid_32p,
+                                    digitaldate=digitaldate,
+                                    booktype=booktype,
+                                    chktpb=chktpb,
+                                    ignore_booktype=ignore_booktype,
+                                )
                                 if findit['status'] is True:
                                     break
                             if findit['status'] is True:
@@ -394,10 +618,22 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
                         else:
                             issuedisplay = StoreDate[5:]
                     if issuedisplay is None:
-                        logger.info('Could not find %s (%s) using %s [%s]' % (ComicName, SeriesYear, searchprov, searchmode))
+                        logger.info(
+                            'Could not find %s (%s) using %s [%s]'
+                            % (ComicName, SeriesYear, searchprov, searchmode)
+                        )
                     else:
-                        logger.info('Could not find Issue %s of %s (%s) using %s [%s]' % (issuedisplay, ComicName, SeriesYear, searchprov, searchmode))
-                prov_count+=1
+                        logger.info(
+                            'Could not find Issue %s of %s (%s) using %s [%s]'
+                            % (
+                                issuedisplay,
+                                ComicName,
+                                SeriesYear,
+                                searchprov,
+                                searchmode,
+                            )
+                        )
+                prov_count += 1
 
             if findit['status'] is True:
                 if searchprov == 'newznab':
@@ -406,21 +642,26 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
                     searchprov = torznab_host[0].rstrip() + ' (torznab)'
                 srchloop = 4
                 break
-            elif srchloop == 2 and (cmloopit -1 >= 1):
-                time.sleep(30)  #pause for 30s to not hammmer api's
+            elif srchloop == 2 and (cmloopit - 1 >= 1):
+                time.sleep(30)  # pause for 30s to not hammmer api's
 
-            cmloopit-=1
+            cmloopit -= 1
 
-        srchloop+=1
+        srchloop += 1
 
     if manual is True:
-        logger.info('I have matched %s files: %s' % (len(mylar.COMICINFO), mylar.COMICINFO))
+        logger.info(
+            'I have matched %s files: %s' % (len(mylar.COMICINFO), mylar.COMICINFO)
+        )
         return mylar.COMICINFO, 'None'
 
     if findit['status'] is True:
-        #check for snatched_havetotal being enabled here and adjust counts now.
-        #IssueID being the catch/check for one-offs as they won't exist on the watchlist and error out otherwise.
-        if mylar.CONFIG.SNATCHED_HAVETOTAL and any([oneoff is False, IssueID is not None]):
+        # check for snatched_havetotal being enabled here and adjust counts now.
+        # IssueID being the catch/check for one-offs as they won't exist on the
+        # watchlist and error out otherwise.
+        if mylar.CONFIG.SNATCHED_HAVETOTAL and any(
+            [oneoff is False, IssueID is not None]
+        ):
             logger.fdebug('Adding this to the HAVE total for the series.')
             helpers.incr_snatched(ComicID)
         if searchprov == 'Public Torrents' and mylar.TMP_PROV != searchprov:
@@ -428,12 +669,15 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
         return findit, searchprov
     else:
         logger.fdebug('findit: %s' % findit)
-        #if searchprov == '32P':
-        #    pass
         if manualsearch is None:
-            logger.info('Finished searching via : %s. Issue not found - status kept as Wanted.' % searchmode)
+            logger.info(
+                'Finished searching via : %s. Issue not found - status kept as Wanted.'
+                % searchmode
+            )
         else:
-            logger.fdebug('Could not find issue doing a manual search via : %s' % searchmode)
+            logger.fdebug(
+                'Could not find issue doing a manual search via : %s' % searchmode
+            )
         if searchprov == '32P':
             if mylar.CONFIG.MODE_32P == 0:
                 return findit, 'None'
@@ -442,13 +686,46 @@ def search_init(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueD
 
     return findit, 'None'
 
-def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, nzbprov, prov_count, IssDateFix, IssueID, UseFuzzy, newznab_host=None, ComicVersion=None, SARC=None, IssueArcID=None, RSS=None, ComicID=None, issuetitle=None, unaltered_ComicName=None, allow_packs=None, oneoff=False, cmloopit=None, manual=False, torznab_host=None, torrentid_32p=None, digitaldate=None, booktype=None, chktpb=0, ignore_booktype=False):
 
-    if any([allow_packs is None, allow_packs == 'None', allow_packs == 0, allow_packs == '0']) and all([mylar.CONFIG.ENABLE_TORRENT_SEARCH, mylar.CONFIG.ENABLE_32P]):
-        allow_packs = False
-    elif any([allow_packs == 1, allow_packs == '1']) and all([mylar.CONFIG.ENABLE_TORRENT_SEARCH, mylar.CONFIG.ENABLE_32P]):
+def NZB_SEARCH(
+    ComicName,
+    IssueNumber,
+    ComicYear,
+    SeriesYear,
+    Publisher,
+    IssueDate,
+    StoreDate,
+    nzbprov,
+    prov_count,
+    IssDateFix,
+    IssueID,
+    UseFuzzy,
+    newznab_host=None,
+    ComicVersion=None,
+    SARC=None,
+    IssueArcID=None,
+    RSS=None,
+    ComicID=None,
+    issuetitle=None,
+    unaltered_ComicName=None,
+    allow_packs=None,
+    oneoff=False,
+    cmloopit=None,
+    manual=False,
+    torznab_host=None,
+    torrentid_32p=None,
+    digitaldate=None,
+    booktype=None,
+    chktpb=0,
+    ignore_booktype=False,
+):
+
+    if any([allow_packs == 1, allow_packs == '1']) and all(
+        [mylar.CONFIG.ENABLE_TORRENT_SEARCH, mylar.CONFIG.ENABLE_32P]
+    ):
         allow_packs = True
-
+    else:
+        allow_packs = False
     newznab_local = False
 
     if nzbprov == 'nzb.su':
@@ -470,7 +747,7 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
             category_torznab = '8020'
         logger.fdebug('Using Torznab host of : %s' % name_torznab)
     elif nzbprov == 'newznab':
-        #updated to include Newznab Name now
+        # updated to include Newznab Name now
         name_newznab = newznab_host[0].rstrip()
         host_newznab = newznab_host[1].rstrip()
         if name_newznab[-7:] == '[local]':
@@ -483,7 +760,7 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
         verify = bool(newznab_host[2])
         if '#' in newznab_host[4].rstrip():
             catstart = newznab_host[4].find('#')
-            category_newznab = newznab_host[4][catstart +1:]
+            category_newznab = newznab_host[4][catstart + 1 :]
             logger.fdebug('Non-default Newznab category set to : %s' % category_newznab)
         else:
             category_newznab = '7030'
@@ -505,40 +782,41 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
             tmpprov = nzbprov
     if cmloopit == 4:
         issuedisplay = None
-        logger.info('Shhh be very quiet...I\'m looking for %s (%s) using %s.' % (ComicName, ComicYear, tmpprov))
+        logger.info(
+            'Shhh be very quiet...I\'m looking for %s (%s) using %s.'
+            % (ComicName, ComicYear, tmpprov)
+        )
     elif IssueNumber is not None:
         issuedisplay = IssueNumber
     else:
         issuedisplay = StoreDate[5:]
 
     if '0-Day Comics Pack' in ComicName:
-        logger.info('Shhh be very quiet...I\'m looking for %s using %s.' % (ComicName, tmpprov))
+        logger.info(
+            'Shhh be very quiet...I\'m looking for %s using %s.' % (ComicName, tmpprov)
+        )
     elif cmloopit != 4:
-        logger.info('Shhh be very quiet...I\'m looking for %s issue: %s (%s) using %s.' % (ComicName, issuedisplay, ComicYear, tmpprov))
+        logger.info(
+            'Shhh be very quiet...I\'m looking for %s issue: %s (%s) using %s.'
+            % (ComicName, issuedisplay, ComicYear, tmpprov)
+        )
 
-
-    #this will completely render the api search results empty. Needs to get fixed.
-    if mylar.CONFIG.PREFERRED_QUALITY == 0: filetype = ""
-    elif mylar.CONFIG.PREFERRED_QUALITY == 1: filetype = ".cbr"
-    elif mylar.CONFIG.PREFERRED_QUALITY == 2: filetype = ".cbz"
-
-    ci = ""
     comsearch = []
     isssearch = []
     comyear = str(ComicYear)
+    findcomic = ComicName
 
-    #print ("-------SEARCH FOR MISSING------------------")
-    #ComicName is unicode - let's unicode and ascii it cause we'll be comparing filenames against it.
-    u_ComicName = ComicName #.encode('ascii', 'replace').strip()
-    findcomic = u_ComicName
+    cm1 = re.sub(r'[\/\-]', ' ', findcomic)
+    # remove 'and' & '&' from the search pattern entirely
+    # (broader results, will filter out later)
+    cm = re.sub("\\band\\b", "", cm1.lower())
 
-    cm1 = re.sub("[\/\-]", " ", findcomic)
+    # remove 'the' from the search pattern to accomodate naming differences
+    cm = re.sub("\\bthe\\b", "", cm.lower())
+
+    cm = re.sub(r'[\&\:\?\,]', '', str(cm))
+    cm = re.sub(r'\s+', ' ', cm)
     # replace whitespace in comic name with %20 for api search
-    #cm = re.sub("\&", "%26", str(cm1))
-    cm = re.sub("\\band\\b", "", cm1.lower()) # remove 'and' & '&' from the search pattern entirely (broader results, will filter out later)
-    cm = re.sub("\\bthe\\b", "", cm.lower()) # remove 'the' from the search pattern to accomodate naming differences
-    cm = re.sub("[\&\:\?\,]", "", str(cm))
-    cm = re.sub('\s+', ' ', cm)
     cm = re.sub(" ", "%20", str(cm))
     cm = re.sub("'", "%27", str(cm))
 
@@ -552,7 +830,7 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
         elif '\xbe' in IssueNumber:
             findcomiciss = '0.75'
         elif '\u221e' in IssueNumber:
-            #issnum = utf-8 will encode the infinity symbol without any help
+            # issnum = utf-8 will encode the infinity symbol without any help
             findcomiciss = 'infinity'  # set 9999999999 for integer value of issue
         else:
             findcomiciss = iss
@@ -564,7 +842,6 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
         findcomiciss = None
 
     comsearch = cm
-    #origcmloopit = cmloopit
     findcount = 1  # this could be a loop in the future possibly
 
     findloop = 0
@@ -572,45 +849,48 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
     foundc = {}
     foundc['status'] = False
     done = False
-    seperatealpha = "no"
+    # origcmloopit = cmloopit
+    # seperatealpha = "no"
     hold_the_matches = []
-    #---issue problem
+    # ---issue problem
     # if issue is '011' instead of '11' in nzb search results, will not have same
     # results. '011' will return different than '11', as will '009' and '09'.
-    while (findloop < findcount):
+    while findloop < findcount:
         logger.fdebug('findloop: %s / findcount: %s' % (findloop, findcount))
         comsrc = comsearch
         if nzbprov == 'dognzb' and not mylar.CONFIG.DOGNZB:
             foundc['status'] = False
             done = True
             break
-        if any([nzbprov == '32P', nzbprov == 'Public Torrents', nzbprov == 'ddl']):
-            #because 32p directly stores the exact issue, no need to worry about iterating over variations of the issue number.
+        if any([nzbprov == '32P', nzbprov == 'Public Torrents', nzbprov == 'DDL']):
+            # 32p directly stores the exact issue, no need to iterate over variations
+            # of the issue number. DDL iteration is handled in it's own module.
             findloop == 99
 
-        if done is True and seperatealpha == "no":
+        if done is True:  # and seperatealpha == "no":
             logger.fdebug("we should break out now - sucessful search previous")
             findloop == 99
             break
 
-                # here we account for issue pattern variations
+            # here we account for issue pattern variations
         if IssueNumber is not None:
-            if seperatealpha == "yes":
-                isssearch = str(c_number) + "%20" + str(c_alpha)
+            # if seperatealpha == "yes":
+            #     isssearch = str(c_number) + "%20" + str(c_alpha)
             if cmloopit == 3:
-                comsearch = comsrc + "%2000" + str(isssearch) #+ "%20" + str(filetype)
+                comsearch = comsrc + "%2000" + str(isssearch)
                 issdig = '00'
             elif cmloopit == 2:
-                comsearch = comsrc + "%200" + str(isssearch) #+ "%20" + str(filetype)
+                comsearch = comsrc + "%200" + str(isssearch)
                 issdig = '0'
             elif cmloopit == 1:
-                comsearch = comsrc + "%20" + str(isssearch) #+ "%20" + str(filetype)
+                comsearch = comsrc + "%20" + str(isssearch)
                 issdig = ''
                 if chktpb == 1:
-                    #this will open end the search based on just the series title, no issue number, no volume.
-                    #putting it at the last search option and ONLY for tpb items hopefully will help it not retrieve thousands.
+                    # this will open end the search based on just the series title,
+                    # no issue number, & no volume. Putting it at the last search option
+                    # and ONLY for tpb items hopefully will help it not retrieve 1000's.
                     comsearch = comsrc
-                    chktpb+=1
+                    chktpb += 1
             else:
                 foundc['status'] = False
                 done = True
@@ -625,52 +905,85 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                 comsearch = StoreDate
                 mod_isssearch = StoreDate
 
-        #--- this is basically for RSS Feeds ---
-        #logger.fdebug('RSS Check: %s' % RSS)
-        #logger.fdebug('nzbprov: %s' % nzbprov)
-        #logger.fdebug('comicid: %s' % ComicID)
-        if nzbprov == 'ddl' and RSS == "no":
+        if nzbprov == 'DDL' and RSS == "no":
             cmname = re.sub("%20", " ", str(comsrc))
-            logger.fdebug('Sending request to DDL site for : %s %s' % (findcomic, isssearch))
+            logger.fdebug(
+                'Sending request to DDL site for : %s %s' % (findcomic, isssearch)
+            )
             if any([isssearch == 'None', isssearch is None]):
                 lineq = findcomic
             else:
                 lineq = '%s %s' % (findcomic, isssearch)
             b = getcomics.GC(query=lineq)
             bb = b.search()
-            #logger.info('bb returned from DDL: %s' % bb)
         elif RSS == "yes":
-            if nzbprov == 'ddl':
-                logger.fdebug('Sending request to [%s] RSS for %s : %s' % (nzbprov, ComicName, mod_isssearch))
-                bb = rsscheck.ddl_dbsearch(ComicName, mod_isssearch, ComicID, nzbprov, oneoff)
+            if nzbprov == 'DDL':
+                logger.fdebug(
+                    'Sending request to [%s] RSS for %s : %s'
+                    % (nzbprov, ComicName, mod_isssearch)
+                )
+                bb = rsscheck.ddl_dbsearch(
+                    ComicName, mod_isssearch, ComicID, nzbprov, oneoff
+                )
             elif nzbprov == '32P' or nzbprov == 'Public Torrents':
                 cmname = re.sub("%20", " ", str(comsrc))
-                logger.fdebug('Sending request to [%s] RSS for %s : %s' % (nzbprov, ComicName, mod_isssearch))
-                bb = rsscheck.torrentdbsearch(ComicName, mod_isssearch, ComicID, nzbprov, oneoff)
+                logger.fdebug(
+                    'Sending request to [%s] RSS for %s : %s'
+                    % (nzbprov, ComicName, mod_isssearch)
+                )
+                bb = rsscheck.torrentdbsearch(
+                    ComicName, mod_isssearch, ComicID, nzbprov, oneoff
+                )
             else:
-                logger.fdebug('Sending request to RSS for %s : %s (%s)' % (findcomic, mod_isssearch, ComicYear))
+                logger.fdebug(
+                    'Sending request to RSS for %s : %s (%s)'
+                    % (findcomic, mod_isssearch, ComicYear)
+                )
                 if nzbprov == 'newznab':
                     nzbprov_fix = name_newznab
                 elif nzbprov == 'torznab':
                     nzbprov_fix = name_torznab
-                else: nzbprov_fix = nzbprov
-                bb = rsscheck.nzbdbsearch(findcomic, mod_isssearch, ComicID, nzbprov_fix, ComicYear, ComicVersion, oneoff)
+                else:
+                    nzbprov_fix = nzbprov
+                bb = rsscheck.nzbdbsearch(
+                    findcomic,
+                    mod_isssearch,
+                    ComicID,
+                    nzbprov_fix,
+                    ComicYear,
+                    ComicVersion,
+                    oneoff,
+                )
             if bb is None:
                 bb = 'no results'
-        #this is the API calls
+        # this is the API calls
         else:
-            #32P is redudant now since only RSS works
+            # 32P is redudant now since only RSS works
             # - just getting it ready for when it's not redudant :)
             if nzbprov == '':
                 bb = "no results"
             if nzbprov == '32P':
                 if all([mylar.CONFIG.MODE_32P == 1, mylar.CONFIG.ENABLE_32P is True]):
                     if ComicName[:17] == '0-Day Comics Pack':
-                        searchterm = {'series': ComicName, 'issue': StoreDate[8:10], 'volume': StoreDate[5:7], 'torrentid_32p': None}
+                        searchterm = {
+                            'series': ComicName,
+                            'issue': StoreDate[8:10],
+                            'volume': StoreDate[5:7],
+                            'torrentid_32p': None,
+                        }
                     else:
-                        searchterm = {'series': ComicName, 'id': ComicID, 'issue': findcomiciss, 'volume': ComicVersion, 'publisher': Publisher, 'torrentid_32p': torrentid_32p, 'booktype': booktype}
-                    #first we find the id on the serieslist of 32P
-                    #then we call the ajax against the id and issue# and volume (if exists)
+                        searchterm = {
+                            'series': ComicName,
+                            'id': ComicID,
+                            'issue': findcomiciss,
+                            'volume': ComicVersion,
+                            'publisher': Publisher,
+                            'torrentid_32p': torrentid_32p,
+                            'booktype': booktype,
+                        }
+
+                    # first we find the id on the serieslist of 32P
+                    # then call the ajax against the id & issue# and volume (if exists)
                     a = auth32p.info32p(searchterm=searchterm)
                     bb = a.searchit()
                     try:
@@ -680,30 +993,46 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                         if any([bb is None, bb == 'no results']):
                             bb = 'no results'
                     except Exception as e:
+                        logger.fdebug('No applicable results returned: %s' % e)
                         bb = 'no results'
                 else:
                     bb = "no results"
             elif nzbprov == 'Public Torrents':
                 cmname = re.sub("%20", " ", str(comsrc))
-                logger.fdebug('Sending request to [WWT-SEARCH] for %s : %s' % (cmname, mod_isssearch))
+                logger.fdebug(
+                    'Sending request to [WWT-SEARCH] for %s : %s'
+                    % (cmname, mod_isssearch)
+                )
                 ww = wwt.wwt(cmname, mod_isssearch)
                 bb = ww.wwt_connect()
-                #bb = rsscheck.torrents(pickfeed='TPSE-SEARCH', seriesname=cmname, issue=mod_isssearch)#cmname,issue=mod_isssearch)
                 if bb is None:
                     bb = 'no results'
             elif nzbprov != 'experimental':
                 if nzbprov == 'dognzb':
-                    findurl = "https://api.dognzb.cr/api?t=search&q=" + str(comsearch) + "&o=xml&cat=7030"
+                    findurl = (
+                        "https://api.dognzb.cr/api?t=search&q="
+                        + str(comsearch)
+                        + "&o=xml&cat=7030"
+                    )
                 elif nzbprov == 'nzb.su':
-                    findurl = "https://api.nzb.su/api?t=search&q=" + str(comsearch) + "&o=xml&cat=7030"
+                    findurl = (
+                        "https://api.nzb.su/api?t=search&q="
+                        + str(comsearch)
+                        + "&o=xml&cat=7030"
+                    )
                 elif nzbprov == 'newznab':
-                    #let's make sure the host has a '/' at the end, if not add it.
-                    if host_newznab[len(host_newznab) -1:len(host_newznab)] != '/':
+                    # let's make sure the host has a '/' at the end, if not add it.
+                    if host_newznab[len(host_newznab) - 1 : len(host_newznab)] != '/':
                         host_newznab_fix = str(host_newznab) + "/"
-                    else: host_newznab_fix = host_newznab
-                    findurl = str(host_newznab_fix) + "api?t=search&q=" + str(comsearch) + "&o=xml&cat=" + str(category_newznab)
+                    else:
+                        host_newznab_fix = host_newznab
+                    findurl = '%sapi?t=search&q=%s&o=xml&cat=%s' % (
+                        host_newznab_fix,
+                        comsearch,
+                        category_newznab,
+                    )
                 elif nzbprov == 'torznab':
-                    if host_torznab[len(host_torznab)-1:len(host_torznab)] == '/':
+                    if host_torznab[len(host_torznab) - 1 : len(host_torznab)] == '/':
                         torznab_fix = host_torznab[:-1]
                     else:
                         torznab_fix = host_torznab
@@ -711,7 +1040,11 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                     if category_torznab is not None:
                         findurl += "&cat=" + str(category_torznab)
                 else:
-                    logger.warn('You have a blank newznab entry within your configuration. Remove it, save the config and restart mylar to fix things. Skipping this blank provider until fixed.')
+                    logger.warn(
+                        'You have a blank newznab entry within your configuration.'
+                        'Remove it, save the config and restart mylar to fix things.'
+                        'Skipping this blank provider until fixed.'
+                    )
                     findurl = None
                     bb = "noresults"
 
@@ -720,23 +1053,36 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                     findurl = findurl + "&apikey=" + str(apikey)
                     logsearch = helpers.apiremove(str(findurl), 'nzb')
 
-                    ### IF USENET_RETENTION is set, honour it
-                    ### For newznab sites, that means appending "&maxage=<whatever>" on the URL
-                    if mylar.CONFIG.USENET_RETENTION != None and nzbprov != 'torznab':
-                        findurl = findurl + "&maxage=" + str(mylar.CONFIG.USENET_RETENTION)
+                    # IF USENET_RETENTION is set, honour it
+                    # For newznab sites, that means appending "&maxage=<whatever>"
+                    # on the URL
+                    if (
+                        mylar.CONFIG.USENET_RETENTION is not None
+                        and nzbprov != 'torznab'
+                    ):
+                        findurl = (
+                            findurl + "&maxage=" + str(mylar.CONFIG.USENET_RETENTION)
+                        )
 
-                    #set a delay between searches here. Default is for 30 seconds...
-                    #changing this to lower could result in a ban from your nzb source due to hammering.
-                    if mylar.CONFIG.SEARCH_DELAY == 'None' or mylar.CONFIG.SEARCH_DELAY is None:
-                        pause_the_search = 30   # (it's in seconds)
+                    # set a delay between searches here. Default is for 30 seconds...
+                    # changing this to lower could result in a ban from your nzb source
+                    # due to hammering.
+                    if (
+                        mylar.CONFIG.SEARCH_DELAY == 'None'
+                        or mylar.CONFIG.SEARCH_DELAY is None
+                    ):
+                        pause_the_search = 30  # in seconds
                     elif str(mylar.CONFIG.SEARCH_DELAY).isdigit() and manual is False:
                         pause_the_search = int(mylar.CONFIG.SEARCH_DELAY) * 60
                     else:
-                        logger.info("Check Search Delay - invalid numerical given. Force-setting to 30 seconds.")
+                        logger.info(
+                            'Check Search Delay - invalid numerical given.'
+                            ' Force-setting to 30 seconds.'
+                        )
                         pause_the_search = 30
 
-                    #bypass for local newznabs
-                    #remove the protocol string (http/https)
+                    # bypass for local newznabs
+                    # remove the protocol string (http/https)
                     localbypass = False
                     if nzbprov == 'newznab':
                         if host_newznab_fix.startswith('http'):
@@ -746,58 +1092,118 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                         else:
                             hnc = host_newznab_fix
 
-                        if any([hnc[:3] == '10.', hnc[:4] == '172.', hnc[:4] == '192.', hnc.startswith('localhost'), newznab_local is True]) and newznab_local != False:
-                            logger.info('local domain bypass for %s is active.' % name_newznab)
+                        if (
+                            any(
+                                [
+                                    hnc[:3] == '10.',
+                                    hnc[:4] == '172.',
+                                    hnc[:4] == '192.',
+                                    hnc.startswith('localhost'),
+                                    newznab_local is True,
+                                ]
+                            )
+                            and newznab_local is not False
+                        ):
+                            logger.info(
+                                'local domain bypass for %s is active.' % name_newznab
+                            )
                             localbypass = True
 
-                    if localbypass == False:
-                        logger.info('Pausing for %s seconds before continuing to avoid hammering' % pause_the_search)
-                        #time.sleep(pause_the_search)
+                    if localbypass is False:
+                        logger.info(
+                            'Pausing for %s seconds before continuing to'
+                            ' avoid hammering.' % pause_the_search
+                        )
+                        # time.sleep(pause_the_search)
 
                     # Add a user-agent
-                    headers = {'User-Agent':   str(mylar.USER_AGENT)}
+                    headers = {'User-Agent': str(mylar.USER_AGENT)}
                     payload = None
 
-                    if findurl.startswith('https:') and verify == False:
+                    if findurl.startswith('https:') and verify is False:
                         try:
                             from requests.packages.urllib3 import disable_warnings
-                            disable_warnings()
-                        except:
-                            logger.warn('Unable to disable https warnings. Expect some spam if using https nzb providers.')
 
-                    elif findurl.startswith('http:') and verify == True:
+                            disable_warnings()
+                        except Exception as e:
+                            logger.warn(
+                                'Unable to disable https warnings. Expect some spam if'
+                                'using https nzb providers.' % e
+                            )
+
+                    elif findurl.startswith('http:') and verify is True:
                         verify = False
 
-                    #logger.fdebug('[SSL: ' + str(verify) + '] Search URL: ' + findurl)
+                    # logger.fdebug('[SSL: ' + str(verify) + '] Search URL: ' + findurl)
                     logger.fdebug('[SSL: %s] Search URL: %s' % (verify, logsearch))
 
                     try:
-                        r = requests.get(findurl, params=payload, verify=verify, headers=headers)
+                        r = requests.get(
+                            findurl, params=payload, verify=verify, headers=headers
+                        )
                         r.raise_for_status()
                     except requests.exceptions.Timeout as e:
-                        logger.warn('Timeout occured fetching data from %s: %s' % (nzbprov, e))
+                        logger.warn(
+                            'Timeout occured fetching data from %s: %s' % (nzbprov, e)
+                        )
                         foundc['status'] = False
                         break
                     except requests.exceptions.ConnectionError as e:
-                        logger.warn('Connection error trying to retrieve data from %s: %s' % (nzbprov, e))
-                        logger.warn('[%s]Connection error trying to retrieve data from %s: %s' % (errno,nzbprov,e))
-                        if any([errno.ETIMEDOUT, errno.ECONNREFUSED, errno.EHOSTDOWN, errno.EHOSTUNREACH]):
+                        logger.warn(
+                            'Connection error trying to retrieve data from %s: %s'
+                            % (nzbprov, e)
+                        )
+                        logger.warn(
+                            '[%s]Connection error trying to retrieve data from %s: %s'
+                            % (errno, nzbprov, e)
+                        )
+                        if any(
+                            [
+                                errno.ETIMEDOUT,
+                                errno.ECONNREFUSED,
+                                errno.EHOSTDOWN,
+                                errno.EHOSTUNREACH,
+                            ]
+                        ):
                             helpers.disable_provider(tmpprov, 'Connection Refused.')
                         foundc['status'] = False
                         break
                     except requests.exceptions.RequestException as e:
-                        logger.warn('[%s]General Error fetching data from %s: %s' % (errno.errorcode, nzbprov, e))
-                        if any([errno.ETIMEDOUT, errno.ECONNREFUSED, errno.EHOSTDOWN, errno.EHOSTUNREACH]):
+                        logger.warn(
+                            '[%s]General Error fetching data from %s: %s'
+                            % (errno.errorcode, nzbprov, e)
+                        )
+                        if any(
+                            [
+                                errno.ETIMEDOUT,
+                                errno.ECONNREFUSED,
+                                errno.EHOSTDOWN,
+                                errno.EHOSTUNREACH,
+                            ]
+                        ):
                             helpers.disable_provider(tmpprov, 'Connection Refused.')
-                            logger.warn('Aborting search due to Provider unavailability')
+                            logger.warn(
+                                'Aborting search due to Provider unavailability'
+                            )
                             foundc['status'] = False
                         break
 
                     try:
                         if str(r.status_code) != '200':
-                            logger.warn('Unable to retrieve search results from %s [Status Code returned: %s]' % (tmpprov, r.status_code))
-                            if any([str(r.status_code) == '503', str(r.status_code) == '404']):
-                                logger.warn('Unavailable indexer detected. Disabling for a short duration and will try again.')
+                            logger.warn(
+                                'Unable to retrieve search results from %s'
+                                '[Status Code returned: %s]' % (tmpprov, r.status_code)
+                            )
+                            if any(
+                                [
+                                    str(r.status_code) == '503',
+                                    str(r.status_code) == '404',
+                                ]
+                            ):
+                                logger.warn(
+                                    'Unavailable indexer detected. Disabling for a'
+                                    ' short duration and will try again.'
+                                )
                                 helpers.disable_provider(tmpprov, 'Unavailable Indexer')
                             data = False
                         else:
@@ -813,28 +1219,43 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
 
                     try:
                         if bb == 'no results':
-                            logger.fdebug('No results for search query from %s' % tmpprov)
+                            logger.fdebug(
+                                'No results for search query from %s' % tmpprov
+                            )
                             break
                         elif bb['feed']['error']:
-                            logger.error('[ERROR CODE: %s] %s' % (bb['feed']['error']['code'], bb['feed']['error']['description']))
+                            logger.error(
+                                '[ERROR CODE: %s] %s'
+                                % (
+                                    bb['feed']['error']['code'],
+                                    bb['feed']['error']['description'],
+                                )
+                            )
                             if bb['feed']['error']['code'] == '910':
-                                logger.warn('DAILY API limit reached. Disabling %s' % tmpprov)
+                                logger.warn(
+                                    'DAILY API limit reached. Disabling %s' % tmpprov
+                                )
                                 helpers.disable_provider(tmpprov, 'API Limit reached')
                                 foundc['status'] = False
                                 done = True
                             else:
-                                logger.warn('API Error. Check the error message and take action if required.')
+                                logger.warn(
+                                    'API Error. Check the error message and take action'
+                                    ' if required.'
+                                )
                                 foundc['status'] = False
                                 done = True
                             break
-                    except:
+                    except Exception:
                         logger.info('no errors on data retrieval...proceeding')
                         pass
             elif nzbprov == 'experimental':
-                #bb = parseit.MysterBinScrape(comsearch[findloop], comyear)
                 logger.info('sending %s to experimental search' % findcomic)
-                bb = findcomicfeed.Startit(findcomic, isssearch, comyear, ComicVersion, IssDateFix, booktype)
-                # since the regexs in findcomicfeed do the 3 loops, lets force the exit after
+                bb = findcomicfeed.Startit(
+                    findcomic, isssearch, comyear, ComicVersion, IssDateFix, booktype
+                )
+                # since the regexs in findcomicfeed do the 3 loops,
+                # lets force the exit after
                 cmloopit == 1
 
         done = False
@@ -844,95 +1265,143 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
         if not bb == "no results":
             for entry in bb['entries']:
                 alt_match = False
-                #logger.fdebug('entry: %s' % entry)  #<--- uncomment this to see what the search result(s) are
-                #brief match here against 32p since it returns the direct issue number
+                # logger.fdebug('entry: %s' % entry)
+                # ^^^ uncomment the above line to see what the search result(s) are
+                # brief match here against 32p since it returns the direct issue number
                 if nzbprov == '32P' and entry['title'][:17] == '0-Day Comics Pack':
-                    logger.info('[32P-0DAY] 0-Day Comics Pack Discovered. Analyzing the pack info...')
+                    logger.info(
+                        '[32P-0DAY] 0-Day Comics Pack Discovered. Analyzing the'
+                        ' pack info...'
+                    )
                     if len(bb['entries']) == 1 or pack0day is True:
-                        logger.info('[32P-0DAY] Only one pack for the week available. Selecting this by default.')
+                        logger.info(
+                            '[32P-0DAY] Only one pack for the week available. Selecting'
+                            ' this by default.'
+                        )
                     else:
-                        logger.info('[32P-0DAY] More than one pack for the week is available...')
+                        logger.info(
+                            '[32P-0DAY] More than one pack for the week is available...'
+                        )
                         logger.info('bb-entries: %s' % bb['entries'])
                         if bb['entries'][1]['int_pubdate'] >= bb['int_pubdate']:
-                            logger.info('[32P-0DAY] 2nd Pack is newest. Snatching that...')
+                            logger.info(
+                                '[32P-0DAY] 2nd Pack is newest. Snatching that...'
+                            )
                             pack0day = True
                             continue
                 elif nzbprov == '32P' and RSS == 'no':
                     if entry['pack'] == '0':
                         if helpers.issuedigits(entry['issues']) == intIss:
-                            logger.fdebug('32P direct match to issue # : %s' % entry['issues'])
+                            logger.fdebug(
+                                '32P direct match to issue # : %s' % entry['issues']
+                            )
                         else:
-                            logger.fdebug('The search result issue [%s] does not match up for some reason to our search result [%s]' % (entry['issues'], findcomiciss))
+                            logger.fdebug(
+                                'The search result issue [%s] does not match up for'
+                                ' some reason to our search result [%s]'
+                                % (entry['issues'], findcomiciss)
+                            )
                             continue
-                    elif any([entry['pack'] == '1', entry['pack'] == '2']) and allow_packs is False:
+                    elif (
+                        any([entry['pack'] == '1', entry['pack'] == '2'])
+                        and allow_packs is False
+                    ):
                         if pack_warning is False:
-                            logger.fdebug('(possibly more than one) Pack detected, but option not enabled for this series. Ignoring subsequent pack results (to enable: on the series details page -> Edit Settings -> Enable Pack Downloads)')
+                            logger.fdebug(
+                                '(possibly more than one) Pack detected, but option not'
+                                ' enabled for this series. Ignoring subsequent pack'
+                                ' results (to enable: on the series details page ->'
+                                ' Edit Settings -> Enable Pack Downloads)'
+                            )
                             pack_warning = True
                         continue
 
                 logger.fdebug("checking search result: %s" % entry['title'])
-                #some nzbsites feel that comics don't deserve a nice regex to strip the crap from the header, the end result is that we're
-                #dealing with the actual raw header which causes incorrect matches below.
-                #this is a temporary cut from the experimental search option (findcomicfeed) as it does this part well usually.
-                except_list=['releases', 'gold line', 'distribution', '0-day', '0 day']
+                # some nzbsites feel that comics don't deserve a nice regex to strip
+                # the crap from the header, the end result is that we're dealing with
+                # the actual raw header which causes incorrect matches below. This is a
+                # temporary cut from the experimental search option (findcomicfeed) as
+                # it does this part well usually.
+                except_list = [
+                    'releases',
+                    'gold line',
+                    'distribution',
+                    '0-day',
+                    '0 day',
+                ]
                 splitTitle = entry['title'].split("\"")
-                _digits = re.compile('\d')
+                _digits = re.compile(r'\d')
 
                 ComicTitle = entry['title']
                 for subs in splitTitle:
                     logger.fdebug('sub: %s' % subs)
-                    regExCount = 0
                     try:
-                        if len(subs) >= len(ComicName.split()) and not any(d in subs.lower() for d in except_list) and bool(_digits.search(subs)) is True:
+                        if (
+                            len(subs) >= len(ComicName.split())
+                            and not any(d in subs.lower() for d in except_list)
+                            and bool(_digits.search(subs)) is True
+                        ):
                             if subs.lower().startswith('for'):
                                 if ComicName.lower().startswith('for'):
                                     pass
                                 else:
-                                    #this is the crap we ignore. Continue (commented else, as it spams the logs)
-                                    #logger.fdebug('this starts with FOR : ' + str(subs) + '. This is not present in the series - ignoring.')
+                                    # this is the crap we ignore. Continue
                                     continue
-                                logger.fdebug('Detected crap within header. Ignoring this portion of the result in order to see if it\'s a valid match.')
+                                logger.fdebug(
+                                    'Detected crap within header. Ignoring this portion'
+                                    ' of the result in order to see if it\'s a valid'
+                                    ' match.'
+                                )
                             ComicTitle = subs
                             break
-                    except:
+                    except Exception:
                         break
 
                 comsize_m = 0
                 if nzbprov != "dognzb":
-                    #rss for experimental doesn't have the size constraints embedded. So we do it here.
+                    # rss for experimental doesn't have the size constraints embedded.
+                    # So we do it here.
                     if RSS == "yes":
                         if nzbprov == '32P':
                             try:
-                                #newer rss feeds will now return filesize from 32p. Safe-guard it incase it's an older result
+                                # newer rss feeds will now return filesize from 32p.
+                                # Safe-guard it incase it's an older result
                                 comsize_b = entry['length']
-                            except:
-                                comsize_b = None 
+                            except Exception:
+                                comsize_b = None
                         elif nzbprov == 'Public Torrents':
                             comsize_b = entry['length']
                         else:
                             comsize_b = entry['length']
                     else:
-                        #Experimental already has size constraints done.
+                        # Experimental already has size constraints done.
                         if nzbprov == '32P':
-                            comsize_b = entry['filesize'] #None
+                            comsize_b = entry['filesize']
                         elif nzbprov == 'Public Torrents':
                             comsize_b = entry['size']
                         elif nzbprov == 'experimental':
-                            comsize_b = entry['length']  # we only want the size from the rss - the search/api has it already.
+                            # we only want the size from the rss as
+                            # the search/api has it already.
+                            comsize_b = entry['length']
                         else:
                             try:
                                 if entry['site'] == 'WWT':
                                     comsize_b = entry['size']
                                 elif entry['site'] == 'DDL':
                                     comsize_b = helpers.human2bytes(entry['size'])
-                            except Exception as e:
+                            except Exception:
                                 tmpsz = entry.enclosures[0]
                                 comsize_b = tmpsz['length']
 
                     logger.fdebug('comsize_b: %s' % comsize_b)
-                    #file restriction limitation here
-                    #only works with TPSE (done here) & 32P (done in rsscheck) & Experimental (has it embeded in search and rss checks)
-                    if nzbprov == 'Public Torrents' or (nzbprov == '32P' and RSS == 'no' and entry['title'][:17] != '0-Day Comics Pack'):
+                    # file restriction limitation here
+                    # only works with TPSE (done here) & 32P (done in rsscheck) &
+                    # Experimental (has it embeded in search and rss checks)
+                    if nzbprov == 'Public Torrents' or (
+                        nzbprov == '32P'
+                        and RSS == 'no'
+                        and entry['title'][:17] != '0-Day Comics Pack'
+                    ):
                         if nzbprov == 'Public Torrents':
                             if 'cbr' in entry['title'].lower():
                                 format_type = 'cbr'
@@ -949,67 +1418,112 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                                 format_type = 'unknown'
                         if mylar.CONFIG.PREFERRED_QUALITY == 1:
                             if format_type == 'cbr':
-                                logger.fdebug('Quality restriction enforced [ .cbr only ]. Accepting result.')
+                                logger.fdebug(
+                                    'Quality restriction enforced [ .cbr only ].'
+                                    ' Accepting result.'
+                                )
                             else:
-                                logger.fdebug('Quality restriction enforced [ .cbr only ]. Rejecting this result.')
+                                logger.fdebug(
+                                    'Quality restriction enforced [ .cbr only ].'
+                                    ' Rejecting this result.'
+                                )
                                 continue
                         elif mylar.CONFIG.PREFERRED_QUALITY == 2:
                             if format_type == 'cbz':
-                                logger.fdebug('Quality restriction enforced [ .cbz only ]. Accepting result.')
+                                logger.fdebug(
+                                    'Quality restriction enforced [ .cbz only ].'
+                                    ' Accepting result.'
+                                )
                             else:
-                                logger.fdebug('Quality restriction enforced [ .cbz only ]. Rejecting this result.')
+                                logger.fdebug(
+                                    'Quality restriction enforced [ .cbz only ].'
+                                    ' Rejecting this result.'
+                                )
                                 continue
 
                     if comsize_b is None or comsize_b == '0':
-                        logger.fdebug('Size of file cannot be retrieved. Ignoring size-comparison and continuing.')
-                        #comsize_b = 0
+                        logger.fdebug(
+                            'Size of file cannot be retrieved.'
+                            ' Ignoring size-comparison and continuing.'
+                        )
+                        # comsize_b = 0
                     else:
                         if entry['title'][:17] != '0-Day Comics Pack':
                             comsize_m = helpers.human_size(comsize_b)
                             logger.fdebug('size given as: %s' % comsize_m)
-                            #----size constraints.
-                            #if it's not within size constaints - dump it now and save some time.
+                            # ----size constraints.
+                            # if it's not within size constaints - dump it now.
                             if mylar.CONFIG.USE_MINSIZE:
-                                conv_minsize = helpers.human2bytes(mylar.CONFIG.MINSIZE + "M")
-                                logger.fdebug('comparing Min threshold %s .. to .. nzb %s' % (conv_minsize, comsize_b))
+                                conv_minsize = helpers.human2bytes(
+                                    mylar.CONFIG.MINSIZE + "M"
+                                )
+                                logger.fdebug(
+                                    'comparing Min threshold %s .. to .. nzb %s'
+                                    % (conv_minsize, comsize_b)
+                                )
                                 if int(conv_minsize) > int(comsize_b):
-                                    logger.fdebug('Failure to meet the Minimum size threshold - skipping')
+                                    logger.fdebug(
+                                        'Failure to meet the Minimum size threshold'
+                                        ' - skipping'
+                                    )
                                     continue
                             if mylar.CONFIG.USE_MAXSIZE:
-                                conv_maxsize = helpers.human2bytes(mylar.CONFIG.MAXSIZE + "M")
-                                logger.fdebug('comparing Max threshold %s .. to .. nzb %s' % (conv_maxsize, comsize_b))
+                                conv_maxsize = helpers.human2bytes(
+                                    mylar.CONFIG.MAXSIZE + "M"
+                                )
+                                logger.fdebug(
+                                    'comparing Max threshold %s .. to .. nzb %s'
+                                    % (conv_maxsize, comsize_b)
+                                )
                                 if int(comsize_b) > int(conv_maxsize):
-                                    logger.fdebug('Failure to meet the Maximium size threshold - skipping')
+                                    logger.fdebug(
+                                        'Failure to meet the Maximium size threshold'
+                                        ' - skipping'
+                                    )
                                     continue
 
-                if mylar.CONFIG.IGNORE_COVERS is True and 'coveronly' in re.sub('[\s\s+\_\.]', '', entry['title'].lower(), re.UNICODE):
+                if mylar.CONFIG.IGNORE_COVERS is True and 'coveronly' in re.sub(
+                    r'[\s\s+\_\.]', '', entry['title'].lower(), re.UNICODE
+                ):
                     logger.fdebug('Cover only detected. Ignoring result.')
                     continue
 
-#---- date constaints.
-                # if the posting date is prior to the publication date, dump it and save the time.
-                #logger.fdebug('entry: %s' % entry)
-                if nzbprov == 'experimental' or nzbprov =='32P':
+                # ---- date constaints.
+                # if the posting date is prior to the publication date,
+                # dump it and save the time.
+                # logger.fdebug('entry: %s' % entry)
+                if nzbprov == 'experimental' or nzbprov == '32P':
                     pubdate = entry['pubdate']
                 else:
                     try:
                         pubdate = entry['updated']
-                    except:
+                    except Exception:
                         try:
                             pubdate = entry['pubdate']
-                        except:
-                            logger.fdebug('invalid date found. Unable to continue - skipping result.')
+                        except Exception as e:
+                            logger.fdebug(
+                                'Invalid date found. Unable to continue'
+                                ' - skipping result. Error returned: %s' % e
+                            )
                             continue
 
                 if UseFuzzy == "1":
-                    logger.fdebug('Year has been fuzzied for this series, ignoring store date comparison entirely.')
+                    logger.fdebug(
+                        'Year has been fuzzied for this series,'
+                        ' ignoring store date comparison entirely.'
+                    )
                     postdate_int = None
                     issuedate_int = None
                 else:
-                    #use store date instead of publication date for comparisons since publication date is usually +2 months
+                    # use store date instead of publication date for comparisons since
+                    # publication date is usually +2 months
                     if StoreDate is None or StoreDate == '0000-00-00':
                         if IssueDate is None or IssueDate == '0000-00-00':
-                            logger.fdebug('Invalid store date & issue date detected - you probably should refresh the series or wait for CV to correct the data')
+                            logger.fdebug(
+                                'Invalid store date & issue date detected - you'
+                                ' probably should refresh the series or wait for CV'
+                                ' to correct the data'
+                            )
                             continue
                         else:
                             stdate = IssueDate
@@ -1020,33 +1534,59 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                     logger.fdebug('date used is : %s' % stdate)
 
                     postdate_int = None
-                    if all([nzbprov == '32P', RSS == 'no']) or all([nzbprov == 'ddl', len(pubdate) == 10]):
+                    if all([nzbprov == '32P', RSS == 'no']) or all(
+                        [nzbprov == 'DDL', len(pubdate) == 10]
+                    ):
                         postdate_int = pubdate
-                        logger.fdebug('[%s] postdate_int (%s): %s' % (nzbprov, type(postdate_int), postdate_int))
-                    if any([postdate_int is None, type(postdate_int) != int]) or not all([nzbprov == '32P', RSS == 'no']):
+                        logger.fdebug(
+                            '[%s] postdate_int (%s): %s'
+                            % (nzbprov, type(postdate_int), postdate_int)
+                        )
+                    if any(
+                        [postdate_int is None, type(postdate_int) != int]
+                    ) or not all([nzbprov == '32P', RSS == 'no']):
                         # convert it to a tuple
                         dateconv = email.utils.parsedate_tz(pubdate)
                         if all([nzbprov == '32P', dateconv is None, RSS == 'no']):
                             try:
-                                pubdate = email.utils.formatdate(entry['int_pubdate'], localtime=True, usegmt=False)
-                            except:
-                                logger.warn('Unable to parsedate to a long-date that I can undestand : %s' % entry['int_pubdate'])
+                                pubdate = email.utils.formatdate(
+                                    entry['int_pubdate'], localtime=True, usegmt=False
+                                )
+                            except Exception as e:
+                                logger.warn(
+                                    '[%s] Unable to parse the date [%s] to a long-date'
+                                    % (e, entry['int_pubdate'])
+                                )
                             else:
-                                logger.fdebug('Successfully converted to : %s' % pubdate)
+                                logger.fdebug(
+                                    'Successfully converted to : %s' % pubdate
+                                )
                                 dateconv = email.utils.parsedate_tz(pubdate)
 
                         try:
                             dateconv2 = datetime.datetime(*dateconv[:6])
                         except TypeError as e:
-                            logger.warn('Unable to convert timestamp from : %s [%s]' % ((dateconv,), e))
+                            logger.warn(
+                                'Unable to convert timestamp from : %s [%s]'
+                                % ((dateconv,), e)
+                            )
                         try:
-                            # convert it to a numeric time, then subtract the timezone difference (+/- GMT)
+                            # convert it to a numeric time, then subtract the
+                            # timezone difference (+/- GMT)
                             if dateconv[-1] is not None:
-                                postdate_int = time.mktime(dateconv[:len(dateconv) -1]) - dateconv[-1]
+                                postdate_int = (
+                                    time.mktime(dateconv[: len(dateconv) - 1])
+                                    - dateconv[-1]
+                                )
                             else:
-                                postdate_int = time.mktime(dateconv[:len(dateconv) -1])
-                        except:
-                            logger.warn('Unable to parse posting date from provider result set for : %s' % entry['title'])
+                                postdate_int = time.mktime(
+                                    dateconv[: len(dateconv) - 1]
+                                )
+                        except Exception as e:
+                            logger.warn(
+                                'Unable to parse posting date from provider result set'
+                                ' for : %s. Error returned: %s' % (entry['title'], e)
+                            )
                             continue
 
                     if all([digitaldate != '0000-00-00', digitaldate is not None]):
@@ -1061,91 +1601,151 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                         else:
                             usedate = stdate
                         logger.fdebug('usedate: %s' % usedate)
-                        #convert it to a Thu, 06 Feb 2014 00:00:00 format
-                        issue_converted = datetime.datetime.strptime(usedate.rstrip(), '%Y-%m-%d')
+                        # convert it to a Thu, 06 Feb 2014 00:00:00 format
+                        issue_converted = datetime.datetime.strptime(
+                            usedate.rstrip(), '%Y-%m-%d'
+                        )
                         issue_convert = issue_converted + datetime.timedelta(days=-1)
-                        # to get past different locale's os-dependent dates, let's convert it to a generic datetime format
+                        # to get past different locale's os-dependent dates, let's
+                        # convert it to a generic datetime format
                         try:
                             stamp = time.mktime(issue_convert.timetuple())
                             issconv = format_date_time(stamp)
-                        except OverflowError:
-                            logger.fdebug('Error attempting to convert the timestamp into a generic format. Probably due to the epoch limiation.')
+                        except OverflowError as e:
+                            logger.fdebug(
+                                'Error converting the timestamp into a generic format:'
+                                ' %s' % e
+                            )
                             issconv = issue_convert.strftime('%a, %d %b %Y %H:%M:%S')
-                        #convert it to a tuple
+                        # convert it to a tuple
                         econv = email.utils.parsedate_tz(issconv)
                         econv2 = datetime.datetime(*econv[:6])
-                        #convert it to a numeric and drop the GMT/Timezone
+                        # convert it to a numeric and drop the GMT/Timezone
                         try:
-                            usedate_int = time.mktime(econv[:len(econv) -1])
+                            usedate_int = time.mktime(econv[: len(econv) - 1])
                         except OverflowError:
-                            logger.fdebug('Unable to convert timestamp to integer format. Forcing things through.')
+                            logger.fdebug(
+                                'Unable to convert timestamp to integer format.'
+                                ' Forcing things through.'
+                            )
                             isyear = econv[1]
                             epochyr = '1970'
                             if int(isyear) <= int(epochyr):
                                 tm = datetime.datetime(1970, 1, 1)
                                 usedate_int = int(time.mktime(tm.timetuple()))
                             else:
-                               continue
+                                continue
                         if i == 0:
                             digitaldate_int = usedate_int
                             digconv2 = econv2
                         else:
                             issuedate_int = usedate_int
                             issconv2 = econv2
-                        i+=1
+                        i += 1
 
                     try:
-                        #try new method to get around issues populating in a diff timezone thereby putting them in a different day.
-                        #logger.info('digitaldate: %s' % digitaldate)
-                        #logger.info('dateconv2: %s' % dateconv2.date())
-                        #logger.info('digconv2: %s' % digconv2.date())
-                        if digitaldate != '0000-00-00' and dateconv2.date() >= digconv2.date():
-                            logger.fdebug('%s is after DIGITAL store date of %s' % (pubdate, digitaldate))
+                        # try new method to get around issues populating in a diff
+                        # timezone thereby putting them in a different day.
+                        # logger.info('digitaldate: %s' % digitaldate)
+                        # logger.info('dateconv2: %s' % dateconv2.date())
+                        # logger.info('digconv2: %s' % digconv2.date())
+                        if (
+                            digitaldate != '0000-00-00'
+                            and dateconv2.date() >= digconv2.date()
+                        ):
+                            logger.fdebug(
+                                '%s is after DIGITAL store date of %s'
+                                % (pubdate, digitaldate)
+                            )
                         elif dateconv2.date() < issconv2.date():
-                            logger.fdebug('[CONV] pubdate: %s  < storedate: %s' % (dateconv2.date(), issconv2.date()))
-                            logger.fdebug('%s is before store date of %s. Ignoring search result as this is not the right issue.' % (pubdate, stdate))
+                            logger.fdebug(
+                                '[CONV] pubdate: %s  < storedate: %s'
+                                % (dateconv2.date(), issconv2.date())
+                            )
+                            logger.fdebug(
+                                '%s is before store date of %s. Ignoring search result'
+                                ' as this is not the right issue.'
+                                % (pubdate, stdate)
+                            )
                             continue
                         else:
-                            logger.fdebug('[CONV] %s is after store date of %s' % (pubdate, stdate))
-                    except:
-                        #if the above fails, drop down to the integer compare method as a failsafe.
-                        if digitaldate != '0000-00-00' and postdate_int >= digitaldate_int:
-                            logger.fdebug('%s is after DIGITAL store date of %s' % (pubdate, digitaldate))
+                            logger.fdebug(
+                                '[CONV] %s is after store date of %s'
+                                % (pubdate, stdate)
+                            )
+                    except Exception:
+                        # if the above fails, drop down to the integer compare method
+                        # as a failsafe.
+                        if (
+                            digitaldate != '0000-00-00'
+                            and postdate_int >= digitaldate_int
+                        ):
+                            logger.fdebug(
+                                '%s is after DIGITAL store date of %s'
+                                % (pubdate, digitaldate)
+                            )
                         elif postdate_int < issuedate_int:
-                            logger.fdebug('[INT]pubdate: %s  < storedate: %s' % (postdate_int, issuedate_int))
-                            logger.fdebug('%s is before store date of %s. Ignoring search result as this is not the right issue.' % (pubdate, stdate))
+                            logger.fdebug(
+                                '[INT]pubdate: %s  < storedate: %s'
+                                % (postdate_int, issuedate_int)
+                            )
+                            logger.fdebug(
+                                '%s is before store date of %s. Ignoring search result'
+                                ' as this is not the right issue.'
+                                % (pubdate, stdate)
+                            )
                             continue
                         else:
-                            logger.fdebug('[INT] %s is after store date of %s' % (pubdate, stdate))
-# -- end size constaints.
-                if '(digital first)' in ComicTitle.lower(): #entry['title'].lower():
-                    dig_moving = re.sub('\(digital first\)', '', ComicTitle.lower()).strip() #entry['title'].lower()).strip()
-                    dig_moving = re.sub('[\s+]', ' ', dig_moving)
+                            logger.fdebug(
+                                '[INT] %s is after store date of %s' % (pubdate, stdate)
+                            )
+                # -- end size constaints.
+                if '(digital first)' in ComicTitle.lower():
+                    dig_moving = re.sub(
+                        r'\(digital first\)', '', ComicTitle.lower()
+                    ).strip()
+                    dig_moving = re.sub(r'[\s+]', ' ', dig_moving)
                     dig_mov_end = '%s (Digital First)' % dig_moving
                     thisentry = dig_mov_end
                 else:
-                    thisentry = ComicTitle #entry['title']
+                    thisentry = ComicTitle
 
                 logger.fdebug('Entry: %s' % thisentry)
                 cleantitle = thisentry
 
                 if 'mixed format' in cleantitle.lower():
                     cleantitle = re.sub('mixed format', '', cleantitle).strip()
-                    logger.fdebug('removed extra information after issue # that is not necessary: %s' % cleantitle)
+                    logger.fdebug(
+                        'removed extra information after issue # that'
+                        ' is not necessary: %s' % cleantitle
+                    )
 
-                # if it's coming from 32P, remove the ' -' at the end as it screws it up.
+                # if it's coming from 32P, remove the ' -' at the end as it screws it up
                 if nzbprov == '32P':
                     if cleantitle.endswith(' - '):
                         cleantitle = cleantitle[:-3]
                         logger.fdebug('Cleaned up title to : %s' % cleantitle)
 
-                #send it to the parser here.
+                # send it to the parser here.
                 p_comic = filechecker.FileChecker(file=ComicTitle, watchcomic=ComicName)
                 parsed_comic = p_comic.listFiles()
 
                 logger.fdebug('parsed_info: %s' % parsed_comic)
-                logger.info('booktype: %s / parsed_booktype: %s [ignore_booktype: %s]' % (booktype, parsed_comic['booktype'], ignore_booktype))
-                if parsed_comic['parse_status'] == 'success' and (all([booktype is None, parsed_comic['booktype'] == 'issue']) or all([booktype == 'Print', parsed_comic['booktype'] == 'issue']) or all([booktype == 'One-Shot', parsed_comic['booktype'] == 'issue']) or all([booktype != parsed_comic['booktype'], ignore_booktype is True]) or booktype == parsed_comic['booktype']):
+                logger.info(
+                    'booktype: %s / parsed_booktype: %s [ignore_booktype: %s]'
+                    % (booktype, parsed_comic['booktype'], ignore_booktype)
+                )
+                if parsed_comic['parse_status'] == 'success' and (
+                    all([booktype is None, parsed_comic['booktype'] == 'issue'])
+                    or all([booktype == 'Print', parsed_comic['booktype'] == 'issue'])
+                    or all(
+                        [booktype == 'One-Shot', parsed_comic['booktype'] == 'issue']
+                    )
+                    or all(
+                        [booktype != parsed_comic['booktype'], ignore_booktype is True]
+                    )
+                    or booktype == parsed_comic['booktype']
+                ):
                     try:
                         fcomic = filechecker.FileChecker(watchcomic=ComicName)
                         filecomic = fcomic.matchIT(parsed_comic)
@@ -1155,54 +1755,86 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                     else:
                         logger.fdebug('match_check: %s' % filecomic)
                         if filecomic['process_status'] == 'fail':
-                            logger.fdebug('%s was not a match to %s (%s)' % (cleantitle, ComicName, SeriesYear))
+                            logger.fdebug(
+                                '%s was not a match to %s (%s)'
+                                % (cleantitle, ComicName, SeriesYear)
+                            )
                             continue
                         elif filecomic['process_status'] == 'alt_match':
-                            #if it's an alternate series match, we'll retain each value until the search has compeletely run, compiling matches.
-                            #if at any point it's a standard match (ie. non-alternate series) that will be accepted as the one match and ignore the alts
-                            #once all search options have been exhausted and no matches aside from alternate series then we go get the best result from that list
-                            logger.fdebug('%s was a match due to alternate matching.  Continuing to search, but retaining this result just in case.' % ComicTitle)
+                            # if it's an alternate series match, we'll retain each value
+                            # until the search has compeletely run, compiling matches.
+                            # If at any point it's a standard match (ie. non-alternate
+                            # series) that will be accepted as the one match and
+                            # ignore the alts. Once all the search options have been
+                            # exhausted and no matches aside from alternate series then
+                            # we go get the best result from that list
+                            logger.fdebug(
+                                '%s was a match due to alternate matching.  Continuing'
+                                ' to search, but retaining this result just in case.'
+                                % ComicTitle
+                            )
                             alt_match = True
                 elif booktype != parsed_comic['booktype'] and ignore_booktype is False:
-                    logger.fdebug('Booktypes do not match. Looking for %s, this is a %s. Ignoring this result.' % (booktype, parsed_comic['booktype']))
+                    logger.fdebug(
+                        'Booktypes do not match. Looking for %s, this is a %s.'
+                        ' Ignoring this result.' % (booktype, parsed_comic['booktype'])
+                    )
                     continue
                 else:
-                    logger.fdebug('Unable to parse name properly: %s. Ignoring this result' % parsed_comic)
+                    logger.fdebug(
+                        'Unable to parse name properly: %s. Ignoring this result'
+                        % parsed_comic
+                    )
                     continue
 
-                #adjust for covers only by removing them entirely...
+                # adjust for covers only by removing them entirely...
                 vers4year = "no"
                 vers4vol = "no"
                 versionfound = "no"
 
                 if ComicVersion:
-                   ComVersChk = re.sub("[^0-9]", "", ComicVersion)
-                   if ComVersChk == '' or ComVersChk == '1':
+                    ComVersChk = re.sub("[^0-9]", "", ComicVersion)
+                    if ComVersChk == '' or ComVersChk == '1':
                         ComVersChk = 0
                 else:
-                   ComVersChk = 0
-
-                origvol = None
-                volfound = False
-                vol_nono = []
+                    ComVersChk = 0
 
                 fndcomicversion = None
 
                 if parsed_comic['series_volume'] is not None:
                     versionfound = "yes"
-                    if len(parsed_comic['series_volume'][1:]) == 4 and parsed_comic['series_volume'][1:].isdigit():  #v2013
-                        logger.fdebug("[Vxxxx] Version detected as %s" % (parsed_comic['series_volume']))
-                        vers4year = "yes" #re.sub("[^0-9]", " ", str(ct)) #remove the v
+                    if len(parsed_comic['series_volume'][1:]) == 4 and (
+                        parsed_comic['series_volume'][1:].isdigit()
+                    ):  # v2013
+                        logger.fdebug(
+                            "[Vxxxx] Version detected as %s"
+                            % (parsed_comic['series_volume'])
+                        )
+                        vers4year = "yes"
                         fndcomicversion = parsed_comic['series_volume']
-                    elif len(parsed_comic['series_volume'][1:]) == 1 and parsed_comic['series_volume'][1:].isdigit():  #v2
-                        logger.fdebug("[Vx] Version detected as %s" % parsed_comic['series_volume'])
+                    elif len(parsed_comic['series_volume'][1:]) == 1 and (
+                        parsed_comic['series_volume'][1:].isdigit()
+                    ):  # v2
+                        logger.fdebug(
+                            "[Vx] Version detected as %s"
+                            % parsed_comic['series_volume']
+                        )
                         vers4vol = parsed_comic['series_volume']
                         fndcomicversion = parsed_comic['series_volume']
-                    elif parsed_comic['series_volume'][1:].isdigit() and len(parsed_comic['series_volume']) < 4:
-                        logger.fdebug('[Vxxx] Version detected as %s' % parsed_comic['series_volume'])
+                    elif (
+                        parsed_comic['series_volume'][1:].isdigit()
+                        and len(parsed_comic['series_volume']) < 4
+                    ):
+                        logger.fdebug(
+                            '[Vxxx] Version detected as %s'
+                            % parsed_comic['series_volume']
+                        )
                         vers4vol = parsed_comic['series_volume']
                         fndcomicversion = parsed_comic['series_volume']
-                    elif parsed_comic['series_volume'].isdigit() and len(parsed_comic['series_volume']) <=4:
+                    elif (
+                        parsed_comic['series_volume'].isdigit()
+                        and len(parsed_comic['series_volume']) <= 4
+                    ):
                         # this stuff is necessary for 32P volume manipulation
                         if len(parsed_comic['series_volume']) == 4:
                             vers4year = "yes"
@@ -1214,59 +1846,114 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                             vers4vol = parsed_comic['series_volume']
                             fndcomicversion = parsed_comic['series_volume']
                         else:
-                            logger.fdebug("error - unknown length for : %s" % parsed_comic['series_volume'])
+                            logger.fdebug(
+                                "error - unknown length for : %s"
+                                % parsed_comic['series_volume']
+                            )
 
                 yearmatch = "false"
                 if vers4vol != "no" or vers4year != "no":
-                    logger.fdebug("Series Year not provided but Series Volume detected of %s. Bypassing Year Match." % fndcomicversion)
+                    logger.fdebug(
+                        'Series Year not provided but Series Volume detected of %s.'
+                        ' Bypassing Year Match.'
+                        % fndcomicversion
+                    )
                     yearmatch = "true"
                 elif ComVersChk == 0 and parsed_comic['issue_year'] is None:
-                    logger.fdebug("Series version detected as V1 (only series in existance with that title). Bypassing Year/Volume check")
+                    logger.fdebug(
+                        'Series version detected as V1 (only series in existance with'
+                        ' that title). Bypassing Year/Volume check'
+                    )
                     yearmatch = "true"
-                elif any([UseFuzzy == "0", UseFuzzy == "2", UseFuzzy is None, IssDateFix != "no"]) and parsed_comic['issue_year'] is not None:
-                    if parsed_comic['issue_year'][:-2] == '19' or parsed_comic['issue_year'][:-2] == '20':
-                        logger.fdebug('year detected: %s' % parsed_comic['issue_year'])
-                        result_comyear = parsed_comic['issue_year']
-                        logger.fdebug('year looking for: %s' % comyear)
-                        if str(comyear) in result_comyear:
+                elif (
+                    any(
+                        [
+                            UseFuzzy == "0",
+                            UseFuzzy == "2",
+                            UseFuzzy is None,
+                            IssDateFix != "no",
+                        ]
+                    )
+                    and parsed_comic['issue_year'] is not None
+                ):
+                    if any(
+                        [
+                            parsed_comic['issue_year'][:-2] == '19',
+                            parsed_comic['issue_year'][:-2] == '20',
+                        ]
+                    ):
+                        if str(comyear) == parsed_comic['issue_year']:
                             logger.fdebug('%s - right years match baby!' % comyear)
                             yearmatch = "true"
                         else:
-                            logger.fdebug('%s - not right - years do not match' % comyear)
+                            logger.fdebug(
+                                '%s - not right - years do not match' % comyear
+                            )
                             yearmatch = "false"
                             if UseFuzzy == "2":
-                                #Fuzzy the year +1 and -1
+                                # Fuzzy the year +1 and -1
                                 ComUp = int(ComicYear) + 1
                                 ComDwn = int(ComicYear) - 1
-                                if str(ComUp) in result_comyear or str(ComDwn) in result_comyear:
-                                    logger.fdebug('Fuzzy Logic\'d the Year and got a match with a year of %s' % result_comyear)
+                                if (
+                                    str(ComUp) in parsed_comic['issue_year']
+                                    or str(ComDwn) in parsed_comic['issue_year']
+                                ):
+                                    logger.fdebug(
+                                        'Fuzzy Logicd the Year and matched to a year'
+                                        ' of %s' % parsed_comic['issue_year']
+                                    )
                                     yearmatch = "true"
                                 else:
-                                    logger.fdebug('%s Fuzzy logic\'d the Year and year still did not match.' % comyear)
-                        #let's do this here and save a few extra loops ;)
-                        #fix for issue dates between Nov-Dec/Jan
+                                    logger.fdebug(
+                                        '%s Fuzzy logicd the Year and year still did'
+                                        ' not match.' % comyear
+                                    )
+                            # let's do this here and save a few extra loops ;)
+                            # fix for issue dates between Nov-Dec/Jan
                             if IssDateFix != "no" and UseFuzzy != "2":
-                                if IssDateFix == "01" or IssDateFix == "02" or IssDateFix == "03":
+                                if (
+                                    IssDateFix == "01"
+                                    or IssDateFix == "02"
+                                    or IssDateFix == "03"
+                                ):
                                     ComicYearFix = int(ComicYear) - 1
-                                    if str(ComicYearFix) in result_comyear:
-                                        logger.fdebug('Further analysis reveals this was published inbetween Nov-Jan, decreasing year to %s has resulted in a match!' % ComicYearFix)
+                                    if str(ComicYearFix) in parsed_comic['issue_year']:
+                                        logger.fdebug(
+                                            'Further analysis reveals this was'
+                                            ' published inbetween Nov-Jan, decreasing'
+                                            ' year to %s has resulted in a match!'
+                                            % ComicYearFix
+                                        )
                                         yearmatch = "true"
                                     else:
-                                        logger.fdebug('%s- not the right year.' % comyear)
+                                        logger.fdebug(
+                                            '%s- not the right year.' % comyear
+                                        )
                                 else:
                                     ComicYearFix = int(ComicYear) + 1
-                                    if str(ComicYearFix) in result_comyear:
-                                        logger.fdebug('Further analysis reveals this was published inbetween Nov-Jan, incrementing year to %s has resulted in a match!' % ComicYearFix)
+                                    if str(ComicYearFix) in parsed_comic['issue_year']:
+                                        logger.fdebug(
+                                            'Further analysis reveals this was'
+                                            ' published inbetween Nov-Jan, incrementing'
+                                            ' year to %s has resulted in a match!'
+                                            % ComicYearFix
+                                        )
                                         yearmatch = "true"
                                     else:
-                                        logger.fdebug('%s - not the right year.' % comyear)
-                elif UseFuzzy == "1": yearmatch = "true"
+                                        logger.fdebug(
+                                            '%s - not the right year.' % comyear
+                                        )
+                elif UseFuzzy == "1":
+                    yearmatch = "true"
 
-                if yearmatch == "false": continue
+                if yearmatch == "false":
+                    continue
 
                 annualize = "false"
                 if 'annual' in ComicName.lower():
-                    logger.fdebug("IssueID of : %s This is an annual...let's adjust." % IssueID)
+                    logger.fdebug(
+                        "IssueID of : %s This is an annual...let's adjust." % IssueID
+                    )
                     annualize = "true"
 
                 F_ComicVersion = None
@@ -1279,95 +1966,161 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                     logger.fdebug("vers4vol: %s" % vers4vol)
 
                     if vers4year != "no" or vers4vol != "no":
-                        #if the volume is None, assume it's a V1 to increase % hits
+                        # if the volume is None, assume it's a V1 to increase % hits
                         if ComVersChk == 0:
                             D_ComicVersion = 1
                         else:
                             D_ComicVersion = ComVersChk
 
-                    #if this is a one-off, SeriesYear will be None and cause errors.
+                    # if this is a one-off, SeriesYear will be None and cause errors.
                     if SeriesYear is None:
                         S_ComicVersion = 0
                     else:
                         S_ComicVersion = str(SeriesYear)
 
                     F_ComicVersion = re.sub("[^0-9]", "", fndcomicversion)
-                    #if the found volume is a vol.0, up it to vol.1 (since there is no V0)
+                    # if found volume is a vol.0, up it to vol.1 (since there is no V0)
                     if F_ComicVersion == '0':
-                       #need to convert dates to just be yyyy-mm-dd and do comparison, time operator in the below calc as well which probably throws off$
+                        # need to convert dates to just be yyyy-mm-dd and do comparison,
+                        # time operator in the below calc
                         F_ComicVersion = '1'
                         if postdate_int is not None:
-                            if digitaldate != '0000-00-00' and all([postdate_int >= digitaldate_int, nzbprov == '32P']):
-                                logger.fdebug('32P torrent discovery. Posting date (%s) is after DIGITAL store date (%s), forcing volume label to be the same as series label (0-Day Enforcement): v%s --> v%s' % (pubdate, digitaldate, F_ComicVersion, S_ComicVersion))
+                            if digitaldate != '0000-00-00' and all(
+                                [postdate_int >= digitaldate_int, nzbprov == '32P']
+                            ):
+                                logger.fdebug(
+                                    '32P torrent discovery. Posting date (%s) is after'
+                                    ' DIGITAL store date (%s), forcing volume label to'
+                                    ' be the same as series label (0-Day Enforcement):'
+                                    ' v%s --> v%s'
+                                    % (
+                                        pubdate,
+                                        digitaldate,
+                                        F_ComicVersion,
+                                        S_ComicVersion,
+                                    )
+                                )
                                 F_ComicVersion = D_ComicVersion
                             elif all([postdate_int >= issuedate_int, nzbprov == '32P']):
-                                logger.fdebug('32P torrent discovery. Posting date (%s) is after store date (%s), forcing volume label to be the same as series label (0-Day Enforcement): v%s --> v%s' % (pubdate, stdate, F_ComicVersion, S_ComicVersion))
+                                logger.fdebug(
+                                    '32P torrent discovery. Posting date (%s) is after'
+                                    ' store date (%s), forcing volume label to be the'
+                                    ' same as series label (0-Day Enforcement): v%s'
+                                    ' --> v%s'
+                                    % (pubdate, stdate, F_ComicVersion, S_ComicVersion)
+                                )
                                 F_ComicVersion = D_ComicVersion
                             else:
                                 pass
-                    logger.fdebug("FCVersion: %s" % F_ComicVersion)
-                    logger.fdebug("DCVersion: %s" % D_ComicVersion)
-                    logger.fdebug("SCVersion: %s" % S_ComicVersion)
+                    logger.fdebug('FCVersion: %s' % F_ComicVersion)
+                    logger.fdebug('DCVersion: %s' % D_ComicVersion)
+                    logger.fdebug('SCVersion: %s' % S_ComicVersion)
 
-                    #here's the catch, sometimes annuals get posted as the Pub Year
+                    # here's the catch, sometimes annuals get posted as the Pub Year
                     # instead of the Series they belong to (V2012 vs V2013)
                     if annualize == "true" and int(ComicYear) == int(F_ComicVersion):
-                        logger.fdebug("We matched on versions for annuals %s" % fndcomicversion)
-                    elif booktype != 'TPB' and (int(F_ComicVersion) == int(D_ComicVersion) or int(F_ComicVersion) == int(S_ComicVersion)):
-                        logger.fdebug("We matched on versions...%s" %fndcomicversion)
+                        logger.fdebug(
+                            "We matched on versions for annuals %s" % fndcomicversion
+                        )
+                    elif booktype != 'TPB' and (
+                        int(F_ComicVersion) == int(D_ComicVersion)
+                        or int(F_ComicVersion) == int(S_ComicVersion)
+                    ):
+                        logger.fdebug("We matched on versions...%s" % fndcomicversion)
                     else:
-                        if booktype == 'TPB' and int(F_ComicVersion) == int(findcomiciss) and filecomic['justthedigits'] is None:
-                            logger.fdebug('TPB detected - reassigning volume %s to match as the issue number based on Volume' % fndcomicversion)
-                        elif all([int(F_ComicVersion) == int(findcomiciss), fndcomicversion is not None, booktype == 'TPB', filecomic['booktype'] == 'TPB', filecomic['justthedigits'] is None]):
-                            logger.fdebug('TPB detected - reassigning volume %s to match as the issue number' % fndcomicversion)
+                        if booktype == 'TPB' and (
+                            int(F_ComicVersion) == int(findcomiciss)
+                            and filecomic['justthedigits'] is None
+                        ):
+                            logger.fdebug(
+                                'TPB detected - reassigning volume %s to match as the'
+                                ' issue number based on Volume'
+                                % fndcomicversion
+                            )
+                        elif all(
+                            [
+                                int(F_ComicVersion) == int(findcomiciss),
+                                fndcomicversion is not None,
+                                booktype == 'TPB',
+                                filecomic['booktype'] == 'TPB',
+                                filecomic['justthedigits'] is None,
+                            ]
+                        ):
+                            logger.fdebug(
+                                'TPB detected - reassigning volume %s to match as the issue number'
+                                % fndcomicversion
+                            )
                         else:
                             logger.fdebug("Versions wrong. Ignoring possible match.")
                             continue
 
                 downloadit = False
-#-------------------------------------fix this!
+
                 try:
                     pack_test = entry['pack']
-                except Exception as e:
+                except Exception:
                     pack_test = False
 
-                if nzbprov == 'Public Torrents' and any([entry['site'] == 'WWT', entry['site'] == 'DEM']):
+                if nzbprov == 'Public Torrents' and any(
+                    [entry['site'] == 'WWT', entry['site'] == 'DEM']
+                ):
                     if entry['site'] == 'WWT':
                         nzbprov = 'WWT'
                     else:
                         nzbprov = 'DEM'
 
-                if all([nzbprov == '32P', allow_packs == True, RSS == 'no']):
+                if all([nzbprov == '32P', allow_packs is True, RSS == 'no']):
                     logger.fdebug('pack: %s' % entry['pack'])
-                if (all([nzbprov == '32P', RSS == 'no', allow_packs == True]) and any([entry['pack'] == '1', entry['pack'] == '2'])) or (all([nzbprov == 'ddl', pack_test is True])):  #allow_packs is True 
+                if (
+                    all([nzbprov == '32P', RSS == 'no', allow_packs is True])
+                    and any([entry['pack'] == '1', entry['pack'] == '2'])
+                ) or (all([nzbprov == 'DDL', pack_test is True])):
                     if nzbprov == '32P':
                         if entry['pack'] == '2':
-                            logger.fdebug('[PACK-QUEUE] Diamond FreeLeech Pack detected.')
+                            logger.fdebug(
+                                '[PACK-QUEUE] Diamond FreeLeech Pack detected.'
+                            )
                         elif entry['pack'] == '1':
-                            logger.fdebug('[PACK-QUEUE] Normal Pack detected. Checking available inkdrops prior to downloading.')
+                            logger.fdebug(
+                                '[PACK-QUEUE] Normal Pack detected. Checking available'
+                                ' inkdrops prior to downloading.'
+                            )
                         else:
                             logger.fdebug('[PACK-QUEUE] Invalid Pack.')
                     else:
-                        logger.fdebug('[PACK-QUEUE] DDL Pack detected for %s.' % entry['filename'])
+                        logger.fdebug(
+                            '[PACK-QUEUE] DDL Pack detected for %s.' % entry['filename']
+                        )
 
-                    #find the pack range.
+                    # find the pack range.
                     pack_issuelist = None
                     issueid_info = None
                     try:
                         if not entry['title'].startswith('0-Day Comics Pack'):
                             pack_issuelist = entry['issues']
-                            issueid_info = helpers.issue_find_ids(ComicName, ComicID, pack_issuelist, IssueNumber)
-                            if issueid_info['valid'] == True:
-                                logger.info('Issue Number %s exists within pack. Continuing.' % IssueNumber)
+                            issueid_info = helpers.issue_find_ids(
+                                ComicName, ComicID, pack_issuelist, IssueNumber
+                            )
+                            if issueid_info['valid'] is True:
+                                logger.info(
+                                    'Issue Number %s exists within pack. Continuing.'
+                                    % IssueNumber
+                                )
                             else:
-                                logger.fdebug('Issue Number %s does NOT exist within this pack. Skipping' % IssueNumber)
+                                logger.fdebug(
+                                    'Issue Number %s does NOT exist within this pack.'
+                                    ' Skipping' % IssueNumber
+                                )
                                 continue
-                    except:
-                        logger.error('Unable to identify pack range for %s' % entry['title'])
+                    except Exception as e:
+                        logger.error(
+                            'Unable to identify pack range for %s. Error returned: %s'
+                            % (entry['title'], e)
+                        )
                         continue
-                    #pack support.
+                    # pack support.
                     nowrite = False
-                    if all([nzbprov == 'ddl', 'getcomics' in entry['link']]):
+                    if all([nzbprov == 'DDL', 'getcomics' in entry['link']]):
                         nzbid = entry['id']
                     else:
                         nzbid = generate_id(nzbprov, entry['link'])
@@ -1375,12 +2128,32 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                         downloadit = True
                     else:
                         for x in mylar.COMICINFO:
-                            if all([x['link'] == entry['link'], x['tmpprov'] == tmpprov]) or all([x['nzbid'] == nzbid, x['newznab'] == newznab_host]) or all([x['nzbid'] == nzbid, x['torznab'] == torznab_host]):
+                            if (
+                                all(
+                                    [
+                                        x['link'] == entry['link'],
+                                        x['tmpprov'] == tmpprov,
+                                    ]
+                                )
+                                or all(
+                                    [x['nzbid'] == nzbid, x['newznab'] == newznab_host]
+                                )
+                                or all(
+                                    [x['nzbid'] == nzbid, x['torznab'] == torznab_host]
+                                )
+                            ):
                                 nowrite = True
                                 break
 
                     if nowrite is False:
-                        if any([nzbprov == 'dognzb', nzbprov == 'nzb.su', nzbprov == 'experimental', 'newznab' in nzbprov]):
+                        if any(
+                            [
+                                nzbprov == 'dognzb',
+                                nzbprov == 'nzb.su',
+                                nzbprov == 'experimental',
+                                'newznab' in nzbprov,
+                            ]
+                        ):
                             tprov = nzbprov
                             kind = 'usenet'
                             if newznab_host is not None:
@@ -1391,30 +2164,32 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                             if torznab_host is not None:
                                 tprov = torznab_host[0]
 
-                        search_values = {"ComicName":       ComicName,
-                                          "ComicID":         ComicID,
-                                          "IssueID":         IssueID,
-                                          "ComicVolume":     ComicVersion,
-                                          "IssueNumber":     IssueNumber,
-                                          "IssueDate":       IssueDate,
-                                          "comyear":         comyear,
-                                          "pack":            True,
-                                          "pack_numbers":    pack_issuelist,
-                                          "pack_issuelist":  issueid_info,
-                                          "modcomicname":    entry['title'],
-                                          "oneoff":          oneoff,
-                                          "nzbprov":         nzbprov,
-                                          "nzbtitle":        entry['title'],
-                                          "nzbid":           nzbid,
-                                          "provider":        tprov,
-                                          "link":            entry['link'],
-                                          "size":            comsize_m,
-                                          "tmpprov":         tmpprov,
-                                          "kind":            kind,
-                                          "SARC":            SARC,
-                                          "IssueArcID":      IssueArcID,
-                                          "newznab":         newznab_host,
-                                          "torznab":         torznab_host}
+                        search_values = {
+                            "ComicName": ComicName,
+                            "ComicID": ComicID,
+                            "IssueID": IssueID,
+                            "ComicVolume": ComicVersion,
+                            "IssueNumber": IssueNumber,
+                            "IssueDate": IssueDate,
+                            "comyear": comyear,
+                            "pack": True,
+                            "pack_numbers": pack_issuelist,
+                            "pack_issuelist": issueid_info,
+                            "modcomicname": entry['title'],
+                            "oneoff": oneoff,
+                            "nzbprov": nzbprov,
+                            "nzbtitle": entry['title'],
+                            "nzbid": nzbid,
+                            "provider": tprov,
+                            "link": entry['link'],
+                            "size": comsize_m,
+                            "tmpprov": tmpprov,
+                            "kind": kind,
+                            "SARC": SARC,
+                            "IssueArcID": IssueArcID,
+                            "newznab": newznab_host,
+                            "torznab": torznab_host,
+                        }
 
                         mylar.COMICINFO.append(search_values)
 
@@ -1423,37 +2198,86 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                 else:
                     if filecomic['process_status'] == 'match':
                         if cmloopit != 4:
-                            logger.fdebug("issue we are looking for is : %s" % findcomiciss)
-                            logger.fdebug("integer value of issue we are looking for : %s" % intIss)
+                            logger.fdebug(
+                                "issue we are looking for is : %s" % findcomiciss
+                            )
+                            logger.fdebug(
+                                "integer value of issue we are looking for : %s"
+                                % intIss
+                            )
                         else:
-                            if intIss is None and all([booktype == 'One-Shot', helpers.issuedigits(parsed_comic['issue_number']) == 1000]):
+                            if intIss is None and all(
+                                [
+                                    booktype == 'One-Shot',
+                                    helpers.issuedigits(parsed_comic['issue_number'])
+                                    == 1000,
+                                ]
+                            ):
                                 intIss = 1000
                             else:
                                 intIss = 9999999999
                         if filecomic['justthedigits'] is not None:
-                            logger.fdebug("issue we found for is : %s" % filecomic['justthedigits'])
+                            logger.fdebug(
+                                "issue we found for is : %s"
+                                % filecomic['justthedigits']
+                            )
                             comintIss = helpers.issuedigits(filecomic['justthedigits'])
-                            logger.fdebug("integer value of issue we have found : %s" % comintIss)
+                            logger.fdebug(
+                                "integer value of issue we have found : %s" % comintIss
+                            )
                         else:
                             comintIss = 11111111111
 
-                        #do this so that we don't touch the actual value but just use it for comparisons
+                        # do this so that we don't touch the actual value but just
+                        # use it for comparisons
                         if filecomic['justthedigits'] is None:
                             pc_in = None
                         else:
                             pc_in = helpers.issuedigits(filecomic['justthedigits'])
-                        #issue comparison now as well
-                        if all([intIss is not None, comintIss is not None]) and int(intIss) == int(comintIss) or all([chktpb !=0, filecomic['booktype'] == 'TPB', pc_in is None, helpers.issuedigits(F_ComicVersion) == intIss]) or all([chktpb == 2, filecomic['booktype'] == 'TPB', pc_in is None, cmloopit == 1]) or all([cmloopit == 4, findcomiciss is None, pc_in is None]) or all([cmloopit == 4, findcomiciss is None, pc_in == 1]):
+                        # issue comparison now as well
+                        if (
+                            all([intIss is not None, comintIss is not None])
+                            and int(intIss) == int(comintIss)
+                            or all(
+                                [
+                                    chktpb != 0,
+                                    filecomic['booktype'] == 'TPB',
+                                    pc_in is None,
+                                    helpers.issuedigits(F_ComicVersion) == intIss,
+                                ]
+                            )
+                            or all(
+                                [
+                                    chktpb == 2,
+                                    filecomic['booktype'] == 'TPB',
+                                    pc_in is None,
+                                    cmloopit == 1,
+                                ]
+                            )
+                            or all([cmloopit == 4, findcomiciss is None, pc_in is None])
+                            or all([cmloopit == 4, findcomiciss is None, pc_in == 1])
+                        ):
                             nowrite = False
-                            if all([nzbprov == 'torznab', 'worldwidetorrents' in entry['link']]):
+                            if all(
+                                [
+                                    nzbprov == 'torznab',
+                                    'worldwidetorrents' in entry['link'],
+                                ]
+                            ):
                                 nzbid = generate_id(nzbprov, entry['id'])
-                            elif all([nzbprov == 'ddl', 'getcomics' in entry['link']]) or all([nzbprov == 'ddl', RSS == 'yes']):
+                            elif all(
+                                [nzbprov == 'DDL', 'getcomics' in entry['link']]
+                            ) or all([nzbprov == 'DDL', RSS == 'yes']):
                                 if RSS == "yes":
                                     entry['id'] = entry['link']
-                                    entry['link'] = 'https://getcomics.info/?p='+str(entry['id'])
+                                    entry['link'] = 'https://getcomics.info/?p=' + str(
+                                        entry['id']
+                                    )
                                     entry['filename'] = entry['title']
                                 if '/cat/' in entry['link']:
-                                    entry['link'] = 'https://getcomics.info/?p='+str(entry['id'])
+                                    entry['link'] = 'https://getcomics.info/?p=' + str(
+                                        entry['id']
+                                    )
                                 nzbid = entry['id']
                                 entry['title'] = entry['filename']
                             else:
@@ -1462,25 +2286,49 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                                 downloadit = True
                             else:
                                 for x in mylar.COMICINFO:
-                                    if all([x['link'] == entry['link'], x['tmpprov'] == tmpprov]) or all([x['nzbid'] == nzbid, x['newznab'] == newznab_host]) or all([x['nzbid'] == nzbid, x['torznab'] == torznab_host]):
+                                    if (
+                                        all(
+                                            [
+                                                x['link'] == entry['link'],
+                                                x['tmpprov'] == tmpprov,
+                                            ]
+                                        )
+                                        or all(
+                                            [
+                                                x['nzbid'] == nzbid,
+                                                x['newznab'] == newznab_host,
+                                            ]
+                                        )
+                                        or all(
+                                            [
+                                                x['nzbid'] == nzbid,
+                                                x['torznab'] == torznab_host,
+                                            ]
+                                        )
+                                    ):
                                         nowrite = True
                                         break
 
-                            #modify the name for annualization to be displayed properly
-                            if annualize == True:
+                            # modify the name for annualization to be displayed properly
+                            if annualize is True:
                                 modcomicname = '%s Annual' % ComicName
                             else:
                                 modcomicname = ComicName
 
-
-                            #comicinfo = []
                             if IssueID is None:
                                 cyear = ComicYear
                             else:
                                 cyear = comyear
 
                             if nowrite is False:
-                                if any([nzbprov == 'dognzb', nzbprov == 'nzb.su', nzbprov == 'experimental', 'newznab' in nzbprov]):
+                                if any(
+                                    [
+                                        nzbprov == 'dognzb',
+                                        nzbprov == 'nzb.su',
+                                        nzbprov == 'experimental',
+                                        'newznab' in nzbprov,
+                                    ]
+                                ):
                                     tprov = nzbprov
                                     kind = 'usenet'
                                     if newznab_host is not None:
@@ -1491,74 +2339,106 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                                     if torznab_host is not None:
                                         tprov = torznab_host[0]
 
-                                search_values = {"ComicName":      ComicName,
-                                                  "ComicID":        ComicID,
-                                                  "IssueID":        IssueID,
-                                                  "ComicVolume":    ComicVersion,
-                                                  "IssueNumber":    IssueNumber,
-                                                  "IssueDate":      IssueDate,
-                                                  "comyear":        cyear,
-                                                  "pack":           False,
-                                                  "pack_numbers":   None,
-                                                  "pack_issuelist": None,
-                                                  "modcomicname":   modcomicname,
-                                                  "oneoff":         oneoff,
-                                                  "nzbprov":        nzbprov,
-                                                  "provider":       tprov,
-                                                  "nzbtitle":       entry['title'],
-                                                  "nzbid":          nzbid,
-                                                  "link":           entry['link'],
-                                                  "size":           comsize_m,
-                                                  "tmpprov":        tmpprov,
-                                                  "kind":           kind,
-                                                  "SARC":           SARC,
-                                                  "IssueArcID":     IssueArcID,
-                                                  "newznab":        newznab_host,
-                                                  "torznab":        torznab_host}
+                                search_values = {
+                                    "ComicName": ComicName,
+                                    "ComicID": ComicID,
+                                    "IssueID": IssueID,
+                                    "ComicVolume": ComicVersion,
+                                    "IssueNumber": IssueNumber,
+                                    "IssueDate": IssueDate,
+                                    "comyear": cyear,
+                                    "pack": False,
+                                    "pack_numbers": None,
+                                    "pack_issuelist": None,
+                                    "modcomicname": modcomicname,
+                                    "oneoff": oneoff,
+                                    "nzbprov": nzbprov,
+                                    "provider": tprov,
+                                    "nzbtitle": entry['title'],
+                                    "nzbid": nzbid,
+                                    "link": entry['link'],
+                                    "size": comsize_m,
+                                    "tmpprov": tmpprov,
+                                    "kind": kind,
+                                    "SARC": SARC,
+                                    "IssueArcID": IssueArcID,
+                                    "newznab": newznab_host,
+                                    "torznab": torznab_host,
+                                }
 
                                 mylar.COMICINFO.append(search_values)
 
                                 hold_the_matches.append(search_values)
+
                         else:
                             log2file = log2file + "issues don't match.." + "\n"
                             downloadit = False
                             foundc['status'] = False
 
-                #logger.fdebug('mylar.COMICINFO: %s' % mylar.COMICINFO)
+                # logger.fdebug('mylar.COMICINFO: %s' % mylar.COMICINFO)
                 if downloadit:
                     try:
                         if entry['chkit']:
                             helpers.checkthe_id(ComicID, entry['chkit'])
-                    except:
+                    except Exception:
                         pass
 
-                    #generate nzbname
-                    nzbname = nzbname_create(nzbprov, info=mylar.COMICINFO, title=ComicTitle) #entry['title'])
+                    # generate nzbname
+                    nzbname = nzbname_create(
+                        nzbprov, info=mylar.COMICINFO, title=ComicTitle
+                    )
                     if nzbname is None:
-                        logger.error('[NZBPROVIDER = NONE] Encountered an error using given provider with requested information: %s. You have a blank entry most likely in your newznabs, fix it & restart Mylar' % mylar.COMICINFO)
+                        logger.error(
+                            '[NZBPROVIDER = NONE] Encountered an error using given '
+                            'provider with requested information: %s. You have a blank '
+                            'entry most likely in your newznabs, fix it & restart Mylar'
+                            % mylar.COMICINFO
+                        )
                         continue
-                    #generate the send-to and actually send the nzb / torrent.
-                    #logger.info('entry: %s' % entry)
+                    # generate the send-to and actually send the nzb / torrent.
+                    # logger.info('entry: %s' % entry)
                     try:
-                        links = {'id': entry['id'],
-                                 'link': entry['link']}
-                    except:
+                        links = {'id': entry['id'], 'link': entry['link']}
+                    except Exception:
                         links = entry['link']
-                    searchresult = searcher(nzbprov, nzbname, mylar.COMICINFO, links, IssueID, ComicID, tmpprov, newznab=newznab_host, torznab=torznab_host, rss=RSS)
+                    searchresult = searcher(
+                        nzbprov,
+                        nzbname,
+                        mylar.COMICINFO,
+                        links,
+                        IssueID,
+                        ComicID,
+                        tmpprov,
+                        newznab=newznab_host,
+                        torznab=torznab_host,
+                        rss=RSS,
+                    )
 
-                    if any([searchresult == 'downloadchk-fail', searchresult == 'double-pp']):
+                    if any(
+                        [
+                            searchresult == 'downloadchk-fail',
+                            searchresult == 'double-pp',
+                        ]
+                    ):
                         foundc['status'] = False
                         continue
-                    elif any([searchresult == 'torrent-fail', searchresult == 'nzbget-fail', searchresult == 'sab-fail', searchresult == 'blackhole-fail', searchresult == 'ddl-fail']):
+                    elif any(
+                        [
+                            searchresult == 'torrent-fail',
+                            searchresult == 'nzbget-fail',
+                            searchresult == 'sab-fail',
+                            searchresult == 'blackhole-fail',
+                            searchresult == 'ddl-fail',
+                        ]
+                    ):
                         foundc['status'] = False
                         return foundc
 
-                    #nzbid, nzbname, sent_to
+                    # nzbid, nzbname, sent_to
                     nzbid = searchresult['nzbid']
                     nzbname = searchresult['nzbname']
                     sent_to = searchresult['sent_to']
                     alt_nzbname = searchresult['alt_nzbname']
-                    t_hash = searchresult['t_hash']
                     if searchresult['SARC'] is not None:
                         SARC = searchresult['SARC']
                     foundc['info'] = searchresult
@@ -1566,19 +2446,26 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
                     done = True
                     break
 
-                if done == True:
-                    #cmloopit == 1 #let's make sure it STOPS searching after a sucessful match.
+                if done is True:
+                    # cmloopit == 1 #let's make sure it STOPS searching after a
+                    # sucessful match.
                     break
-        #cmloopit-=1
-        #if cmloopit < 1 and c_alpha is not None and seperatealpha == "no" and foundc['status'] is False:
-        #    logger.info("Alphanumerics detected within IssueNumber. Seperating from Issue # and re-trying.")
-        #    cmloopit = origcmloopit
-        #    seperatealpha = "yes"
-        logger.info('booktype:%s / chktpb: %s / findloop: %s' % (booktype, chktpb, findloop))
-        if booktype == 'TPB' and chktpb == 1 and findloop+1 > findcount:
-            pass #findloop=-1
+        # cmloopit-=1
+        # if (
+        #     cmloopit < 1 and c_alpha is not None and seperatealpha == "no" and
+        #     foundc['status'] is False
+        #     ):
+        #     logger.info("Alphanumerics detected within IssueNumber. Seperating
+        #                 " from Issue # and re-trying.")
+        #     cmloopit = origcmloopit
+        #     seperatealpha = "yes"
+        logger.info(
+            'booktype:%s / chktpb: %s / findloop: %s' % (booktype, chktpb, findloop)
+        )
+        if booktype == 'TPB' and chktpb == 1 and findloop + 1 > findcount:
+            pass  # findloop=-1
         else:
-            findloop+=1
+            findloop += 1
 
     if foundc['status'] is True:
         if 'Public Torrents' in tmpprov and any([nzbprov == 'WWT', nzbprov == 'DEM']):
@@ -1588,34 +2475,92 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
         if mylar.COMICINFO[0]['pack'] is True:
             try:
                 issinfo = mylar.COMICINFO[0]['pack_issuelist']
-            except:
+            except Exception:
                 issinfo = mylar.COMICINFO['pack_issuelist']
             if issinfo is not None:
-                #we need to get EVERY issue ID within the pack and update the log to reflect that they're being downloaded via a pack.
-                
+                # we need to get EVERY issue ID within the pack and update the log to
+                # reflect that they're being downloaded via a pack.
                 try:
-                    logger.fdebug('Found matching comic within pack...preparing to send to Updater with IssueIDs: %s and nzbname of %s' % (issueid_info, nzbname))
+                    logger.fdebug(
+                        'Found matching comic within pack...preparing to send to'
+                        ' Updater with IssueIDs: %s and nzbname of %s'
+                        % (issueid_info, nzbname)
+                    )
                 except NameError:
                     logger.fdebug('Did not find issueid_info')
-                    
-                #because packs need to have every issue that's not already Downloaded in a Snatched status, throw it to the updater here as well.
+
+                # because packs need to have every issue that's not already Downloaded
+                # in a Snatched status, throw it to
+                # the updater here as well.
                 for isid in issinfo['issues']:
-                    updater.nzblog(isid['issueid'], nzbname, ComicName, SARC=SARC, IssueArcID=IssueArcID, id=nzbid, prov=tmpprov, oneoff=oneoff)
-                    updater.foundsearch(ComicID, isid['issueid'], mode='series', provider=tmpprov)
-                notify_snatch(sent_to, mylar.COMICINFO[0]['ComicName'], mylar.COMICINFO[0]['comyear'], mylar.COMICINFO[0]['pack_numbers'], nzbprov, True)
+                    updater.nzblog(
+                        isid['issueid'],
+                        nzbname,
+                        ComicName,
+                        SARC=SARC,
+                        IssueArcID=IssueArcID,
+                        id=nzbid,
+                        prov=tmpprov,
+                        oneoff=oneoff,
+                    )
+                    updater.foundsearch(
+                        ComicID, isid['issueid'], mode='series', provider=tmpprov
+                    )
+                notify_snatch(
+                    sent_to,
+                    mylar.COMICINFO[0]['ComicName'],
+                    mylar.COMICINFO[0]['comyear'],
+                    mylar.COMICINFO[0]['pack_numbers'],
+                    nzbprov,
+                    True,
+                )
             else:
-                notify_snatch(sent_to, mylar.COMICINFO[0]['ComicName'], mylar.COMICINFO[0]['comyear'], None, nzbprov, True)
+                notify_snatch(
+                    sent_to,
+                    mylar.COMICINFO[0]['ComicName'],
+                    mylar.COMICINFO[0]['comyear'],
+                    None,
+                    nzbprov,
+                    True,
+                )
 
         else:
             if alt_nzbname is None or alt_nzbname == '':
-                logger.fdebug('Found matching comic...preparing to send to Updater with IssueID: %s and nzbname: %s' % (IssueID, nzbname))
-                if '[RSS]' in tmpprov: tmpprov = re.sub('\[RSS\]', '', tmpprov).strip()
-                updater.nzblog(IssueID, nzbname, ComicName, SARC=SARC, IssueArcID=IssueArcID, id=nzbid, prov=tmpprov, oneoff=oneoff)
+                logger.fdebug(
+                    'Found matching comic...preparing to send to Updater with IssueID:'
+                    ' %s and nzbname: %s' % (IssueID, nzbname)
+                )
+                if '[RSS]' in tmpprov:
+                    tmpprov = re.sub(r'\[RSS\]', '', tmpprov).strip()
+                updater.nzblog(
+                    IssueID,
+                    nzbname,
+                    ComicName,
+                    SARC=SARC,
+                    IssueArcID=IssueArcID,
+                    id=nzbid,
+                    prov=tmpprov,
+                    oneoff=oneoff,
+                )
             else:
-                logger.fdebug('Found matching comic...preparing to send to Updater with IssueID: %s and nzbname: %s [%s]' % (IssueID, nzbname, alt_nzbname))
-                if '[RSS]' in tmpprov: tmpprov = re.sub('\[RSS\]', '', tmpprov).strip()
-                updater.nzblog(IssueID, nzbname, ComicName, SARC=SARC, IssueArcID=IssueArcID, id=nzbid, prov=tmpprov, alt_nzbname=alt_nzbname, oneoff=oneoff)
-            #send out the notifications for the snatch.
+                logger.fdebug(
+                    'Found matching comic...preparing to send to Updater with IssueID:'
+                    ' %s and nzbname: %s [%s]' % (IssueID, nzbname, alt_nzbname)
+                )
+                if '[RSS]' in tmpprov:
+                    tmpprov = re.sub(r'\[RSS\]', '', tmpprov).strip()
+                updater.nzblog(
+                    IssueID,
+                    nzbname,
+                    ComicName,
+                    SARC=SARC,
+                    IssueArcID=IssueArcID,
+                    id=nzbid,
+                    prov=tmpprov,
+                    alt_nzbname=alt_nzbname,
+                    oneoff=oneoff,
+                )
+            # send out the notifications for the snatch.
             if any([oneoff is True, IssueID is None]):
                 cyear = ComicYear
             else:
@@ -1624,378 +2569,709 @@ def NZB_SEARCH(ComicName, IssueNumber, ComicYear, SeriesYear, Publisher, IssueDa
         prov_count == 0
         mylar.TMP_PROV = nzbprov
 
-        #if mylar.SAB_PARAMS is not None:
-        #    #should be threaded....
-        #    ss = sabnzbd.SABnzbd(mylar.SAB_PARAMS)
-        #    sendtosab = ss.sender()
-        #    if all([sendtosab['status'] is True, mylar.CONFIG.SAB_CLIENT_POST_PROCESSING is True]):
-        #        mylar.NZB_QUEUE.put(sendtosab)
         return foundc
 
     else:
-        #logger.fdebug('prov_count: ' + str(prov_count))
         foundcomic.append("no")
-        #if IssDateFix == "no":
-            #logger.info('Could not find Issue ' + str(IssueNumber) + ' of ' + ComicName + '(' + str(comyear) + ') using ' + str(tmpprov) + '. Status kept as wanted.' )
-            #break
+        # if IssDateFix == "no":
+        #     logger.info('Could not find Issue ' + str(IssueNumber) + ' of '
+        #     + ComicName + '(' + str(comyear) + ') using ' + str(tmpprov) '
+        #     + '. Status kept as wanted.' )
+        #     break
     return foundc
 
-def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
 
+def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
     if rsscheck == 'yes':
         while mylar.SEARCHLOCK is True:
+            logger.info(
+                'A search is currently in progress....queueing this up again to try'
+                ' in a bit.'
+            )
             time.sleep(5)
 
     if mylar.SEARCHLOCK is True:
-        logger.info('A search is currently in progress....queueing this up again to try in a bit.')
+        logger.info(
+            'A search is currently in progress....queueing this up again to try'
+            ' in a bit.'
+        )
         return {'status': 'IN PROGRESS'}
 
     myDB = db.DBConnection()
 
     ens = [x for x in mylar.CONFIG.EXTRA_NEWZNABS if x[5] == '1']
     ets = [x for x in mylar.CONFIG.EXTRA_TORZNABS if x[5] == '1']
-    if (any([mylar.CONFIG.ENABLE_DDL is True, mylar.CONFIG.NZBSU is True, mylar.CONFIG.DOGNZB is True, mylar.CONFIG.EXPERIMENTAL is True]) or all([mylar.CONFIG.NEWZNAB is True, len(ens) > 0]) and any([mylar.USE_SABNZBD is True, mylar.USE_NZBGET is True, mylar.USE_BLACKHOLE is True])) or (all([mylar.CONFIG.ENABLE_TORRENT_SEARCH is True, mylar.CONFIG.ENABLE_TORRENTS is True]) and (any([mylar.CONFIG.ENABLE_PUBLIC is True, mylar.CONFIG.ENABLE_32P is True]) or all([mylar.CONFIG.ENABLE_TORZNAB is True, len(ets) > 0]))):
+    if (
+        any(
+            [
+                mylar.CONFIG.ENABLE_DDL is True,
+                mylar.CONFIG.NZBSU is True,
+                mylar.CONFIG.DOGNZB is True,
+                mylar.CONFIG.EXPERIMENTAL is True,
+            ]
+        )
+        or all([mylar.CONFIG.NEWZNAB is True, len(ens) > 0])
+        and any(
+            [
+                mylar.USE_SABNZBD is True,
+                mylar.USE_NZBGET is True,
+                mylar.USE_BLACKHOLE is True,
+            ]
+        )
+    ) or (
+        all(
+            [
+                mylar.CONFIG.ENABLE_TORRENT_SEARCH is True,
+                mylar.CONFIG.ENABLE_TORRENTS is True,
+            ]
+        )
+        and (
+            any([mylar.CONFIG.ENABLE_PUBLIC is True, mylar.CONFIG.ENABLE_32P is True])
+            or all([mylar.CONFIG.ENABLE_TORZNAB is True, len(ets) > 0])
+        )
+    ):
         if not issueid or rsscheck:
 
             if rsscheck:
-                logger.info('Initiating RSS Search Scan at the scheduled interval of %s minutes' % mylar.CONFIG.RSS_CHECKINTERVAL)
+                logger.info(
+                    'Initiating RSS Search Scan at the scheduled interval of %s minutes'
+                    % mylar.CONFIG.RSS_CHECKINTERVAL
+                )
                 mylar.SEARCHLOCK = True
             else:
                 logger.info('Initiating check to add Wanted items to Search Queue....')
 
             myDB = db.DBConnection()
 
-            stloop = 2   # 2 levels - one for issues, one for storyarcs - additional for annuals below if enabled
+            stloop = 2  # 3 levels - one for issues, one for storyarcs, one  for annuals
             results = []
 
             if mylar.CONFIG.ANNUALS_ON:
-                stloop+=1
-            while (stloop > 0):
+                stloop += 1
+            while stloop > 0:
                 if stloop == 1:
-                    if mylar.CONFIG.FAILED_DOWNLOAD_HANDLING and mylar.CONFIG.FAILED_AUTO:
-                        issues_1 = myDB.select('SELECT * from issues WHERE Status="Wanted" OR Status="Failed"')
+                    if (
+                        mylar.CONFIG.FAILED_DOWNLOAD_HANDLING
+                        and mylar.CONFIG.FAILED_AUTO
+                    ):
+                        issues_1 = myDB.select(
+                            'SELECT * from issues WHERE Status="Wanted" OR'
+                            ' Status="Failed"'
+                        )
                     else:
-                        issues_1 = myDB.select('SELECT * from issues WHERE Status="Wanted"')
+                        issues_1 = myDB.select(
+                            'SELECT * from issues WHERE Status="Wanted"'
+                        )
                     for iss in issues_1:
-                        results.append({'ComicID':       iss['ComicID'],
-                                        'IssueID':       iss['IssueID'],
-                                        'Issue_Number':  iss['Issue_Number'],
-                                        'IssueDate':     iss['IssueDate'],
-                                        'StoreDate':     iss['ReleaseDate'],
-                                        'DigitalDate':   iss['DigitalDate'],
-                                        'SARC':          None,
-                                        'StoryArcID':    None,
-                                        'IssueArcID':    None,
-                                        'mode':          'want',
-                                        'DateAdded':     iss['DateAdded']
-                                       })
+                        results.append(
+                            {
+                                'ComicID': iss['ComicID'],
+                                'IssueID': iss['IssueID'],
+                                'Issue_Number': iss['Issue_Number'],
+                                'IssueDate': iss['IssueDate'],
+                                'StoreDate': iss['ReleaseDate'],
+                                'DigitalDate': iss['DigitalDate'],
+                                'SARC': None,
+                                'StoryArcID': None,
+                                'IssueArcID': None,
+                                'mode': 'want',
+                                'DateAdded': iss['DateAdded'],
+                            }
+                        )
                 elif stloop == 2:
                     if mylar.CONFIG.SEARCH_STORYARCS is True or rsscheck:
-                        if mylar.CONFIG.FAILED_DOWNLOAD_HANDLING and mylar.CONFIG.FAILED_AUTO:
-                           issues_2 = myDB.select('SELECT * from storyarcs WHERE Status="Wanted" OR Status="Failed"')
+                        if (
+                            mylar.CONFIG.FAILED_DOWNLOAD_HANDLING
+                            and mylar.CONFIG.FAILED_AUTO
+                        ):
+                            issues_2 = myDB.select(
+                                'SELECT * from storyarcs WHERE Status="Wanted" OR'
+                                ' Status="Failed"'
+                            )
                         else:
-                           issues_2 = myDB.select('SELECT * from storyarcs WHERE Status="Wanted"')
-                        cnt=0
+                            issues_2 = myDB.select(
+                                'SELECT * from storyarcs WHERE Status="Wanted"'
+                            )
+                        cnt = 0
                         for iss in issues_2:
-                            results.append({'ComicID':       iss['ComicID'],
-                                            'IssueID':       iss['IssueID'],
-                                            'Issue_Number':  iss['IssueNumber'],
-                                            'IssueDate':     iss['IssueDate'],
-                                            'StoreDate':     iss['ReleaseDate'],
-                                            'DigitalDate':   iss['DigitalDate'],
-                                            'SARC':          iss['StoryArc'],
-                                            'StoryArcID':    iss['StoryArcID'],
-                                            'IssueArcID':    iss['IssueArcID'],
-                                            'mode':          'story_arc',
-                                            'DateAdded':     iss['DateAdded']
-                                           })
-                            cnt+=1
+                            results.append(
+                                {
+                                    'ComicID': iss['ComicID'],
+                                    'IssueID': iss['IssueID'],
+                                    'Issue_Number': iss['IssueNumber'],
+                                    'IssueDate': iss['IssueDate'],
+                                    'StoreDate': iss['ReleaseDate'],
+                                    'DigitalDate': iss['DigitalDate'],
+                                    'SARC': iss['StoryArc'],
+                                    'StoryArcID': iss['StoryArcID'],
+                                    'IssueArcID': iss['IssueArcID'],
+                                    'mode': 'story_arc',
+                                    'DateAdded': iss['DateAdded'],
+                                }
+                            )
+                            cnt += 1
                         logger.info('Storyarcs to be searched for : %s' % cnt)
                 elif stloop == 3:
-                    if mylar.CONFIG.FAILED_DOWNLOAD_HANDLING and mylar.CONFIG.FAILED_AUTO:
-                        issues_3 = myDB.select('SELECT * from annuals WHERE Status="Wanted" OR Status="Failed"')
+                    if (
+                        mylar.CONFIG.FAILED_DOWNLOAD_HANDLING
+                        and mylar.CONFIG.FAILED_AUTO
+                    ):
+                        issues_3 = myDB.select(
+                            'SELECT * from annuals WHERE Status="Wanted" OR'
+                            ' Status="Failed"'
+                        )
                     else:
-                        issues_3 = myDB.select('SELECT * from annuals WHERE Status="Wanted"')
+                        issues_3 = myDB.select(
+                            'SELECT * from annuals WHERE Status="Wanted"'
+                        )
                     for iss in issues_3:
-                        results.append({'ComicID':       iss['ComicID'],
-                                        'IssueID':       iss['IssueID'],
-                                        'Issue_Number':  iss['Issue_Number'],
-                                        'IssueDate':     iss['IssueDate'],
-                                        'StoreDate':     iss['ReleaseDate'],   #need to replace with Store date
-                                        'DigitalDate':   iss['DigitalDate'],
-                                        'SARC':          None,
-                                        'StoryArcID':    None,
-                                        'IssueArcID':    None,
-                                        'mode':          'want_ann',
-                                        'DateAdded':     iss['DateAdded']
-                                       })
-                stloop-=1
+                        results.append(
+                            {
+                                'ComicID': iss['ComicID'],
+                                'IssueID': iss['IssueID'],
+                                'Issue_Number': iss['Issue_Number'],
+                                'IssueDate': iss['IssueDate'],
+                                'StoreDate': iss['ReleaseDate'],
+                                'DigitalDate': iss['DigitalDate'],
+                                'SARC': None,
+                                'StoryArcID': None,
+                                'IssueArcID': None,
+                                'mode': 'want_ann',
+                                'DateAdded': iss['DateAdded'],
+                            }
+                        )
+                stloop -= 1
 
-            new = True
-            #to-do: re-order the results list so it's most recent to least recent.
+            # to-do: re-order the results list so it's most recent to least recent.
 
             for result in sorted(results, key=itemgetter('StoreDate'), reverse=True):
-                #status issue check - check status to see if it's Downloaded / Snatched already due to concurrent searches possible.
-                if result['IssueID'] is not None:
-                    if result['mode'] == 'story_arc':
-                        isscheck = helpers.issue_status(result['IssueArcID'])
+
+                try:
+                    # status issue check - check status to see if it's Downloaded /
+                    # Snatched already due to concurrent searches possible.
+                    if result['IssueID'] is not None:
+                        if result['mode'] == 'story_arc':
+                            isscheck = helpers.issue_status(result['IssueArcID'])
+                        else:
+                            isscheck = helpers.issue_status(result['IssueID'])
+                        # isscheck will return True if already Downloaded / Snatched,
+                        # False if it's still in a Wanted status.
+                        if isscheck is True:
+                            logger.fdebug(
+                                'Issue is already in a Downloaded / Snatched status.'
+                            )
+                            continue
+
+                    OneOff = False
+                    storyarc_watchlist = False
+                    comic = myDB.selectone(
+                        "SELECT * from comics WHERE ComicID=? AND ComicName != 'None'",
+                        [result['ComicID']],
+                    ).fetchone()
+                    if all([comic is None, result['mode'] == 'story_arc']):
+                        comic = myDB.selectone(
+                            "SELECT * from storyarcs WHERE StoryArcID=? AND"
+                            " IssueArcID=?",
+                            [result['StoryArcID'], result['IssueArcID']],
+                        ).fetchone()
+                        if comic is None:
+                            logger.fdebug(
+                                '%s has no associated comic information in the Arc.'
+                                ' Skipping searching for this series.'
+                                % result['ComicID']
+                            )
+                            continue
+                        else:
+                            OneOff = True
+                    elif comic is None:
+                        logger.fdebug(
+                            '%s has no associated comic information in the Arc.'
+                            ' Skipping searching for this series.'
+                            % result['ComicID']
+                        )
+                        continue
                     else:
-                        isscheck = helpers.issue_status(result['IssueID'])
-                    #isscheck will return True if already Downloaded / Snatched, False if it's still in a Wanted status.
-                    if isscheck is True:
-                        logger.fdebug('Issue is already in a Downloaded / Snatched status.')
-                        continue
+                        storyarc_watchlist = True
+                    if (
+                        result['StoreDate'] == '0000-00-00'
+                        or result['StoreDate'] is None
+                    ):
+                        if (
+                            any(
+                                [
+                                    result['IssueDate'] is None,
+                                    result['IssueDate'] == '0000-00-00',
+                                ]
+                            )
+                            and result['DigitalDate'] == '0000-00-00'
+                        ):
+                            logger.fdebug(
+                                'ComicID: %s has invalid Date data. Skipping searching'
+                                ' for this series.'
+                                % result['ComicID']
+                            )
+                            continue
 
-                OneOff = False
-                storyarc_watchlist = False
-                comic = myDB.selectone("SELECT * from comics WHERE ComicID=? AND ComicName != 'None'", [result['ComicID']]).fetchone()
-                if all([comic is None, result['mode'] == 'story_arc']):
-                    comic = myDB.selectone("SELECT * from storyarcs WHERE StoryArcID=? AND IssueArcID=?", [result['StoryArcID'],result['IssueArcID']]).fetchone() 
-                    if comic is None:
-                        logger.fdebug('%s has no associated comic information in the Arc. Skipping searching for this series.' % result['ComicID'])
-                        continue
+                    foundNZB = "none"
+                    AllowPacks = False
+                    if all(
+                        [result['mode'] == 'story_arc', storyarc_watchlist is False]
+                    ):
+                        Comicname_filesafe = helpers.filesafe(comic['ComicName'])
+                        SeriesYear = comic['SeriesYear']
+                        Publisher = comic['Publisher']
+                        AlternateSearch = None
+                        UseFuzzy = None
+                        ComicVersion = comic['Volume']
+                        TorrentID_32p = None
+                        booktype = comic['Type']
+                        ignore_booktype = False
                     else:
-                        OneOff = True
-                elif comic is None:
-                    logger.fdebug('%s has no associated comic information in the Arc. Skipping searching for this series.' % result['ComicID'])
-                    continue
-                else:
-                    storyarc_watchlist = True
-                if result['StoreDate'] == '0000-00-00' or result['StoreDate'] is None:
-                    if any([result['IssueDate'] is None, result['IssueDate'] == '0000-00-00']) and result['DigitalDate'] == '0000-00-00':
-                        logger.fdebug('ComicID: %s has invalid Date data. Skipping searching for this series.' % result['ComicID'])
+                        Comicname_filesafe = comic['ComicName_Filesafe']
+                        SeriesYear = comic['ComicYear']
+                        Publisher = comic['ComicPublisher']
+                        AlternateSearch = comic['AlternateSearch']
+                        UseFuzzy = comic['UseFuzzy']
+                        ComicVersion = comic['ComicVersion']
+                        TorrentID_32p = comic['TorrentID_32P']
+                        booktype = comic['Type']
+                        if (
+                            comic['Corrected_Type'] is not None
+                            and comic['Type'] != comic['Corrected_Type']
+                        ):
+                            booktype = comic['Corrected_Type']
+                        ignore_booktype = bool(comic['IgnoreType'])
+                        if any([comic['AllowPacks'] == 1, comic['AllowPacks'] == '1']):
+                            AllowPacks = True
+
+                    IssueDate = result['IssueDate']
+                    StoreDate = result['StoreDate']
+                    DigitalDate = result['DigitalDate']
+
+                    if result['IssueDate'] is None:
+                        ComicYear = SeriesYear
+                    else:
+                        ComicYear = str(result['IssueDate'])[:4]
+
+                    if result['DateAdded'] is None:
+                        DA = datetime.datetime.today()
+                        DateAdded = DA.strftime('%Y-%m-%d')
+                        if result['mode'] == 'want':
+                            table = 'issues'
+                        elif result['mode'] == 'want_ann':
+                            table = 'annuals'
+                        elif result['mode'] == 'story_arc':
+                            table = 'storyarcs'
+                        else:
+                            table = None
+                            # not writing to the table here will mean the Tier won't
+                            # get changed
+                            logger.warn(
+                                '[SEARCH-ERROR] Error while trying to write DateAdded'
+                                ' value to non-existant table due to given search mode'
+                                ' of %s' % result['mode']
+                            )
+                        if table is not None:
+                            logger.fdebug(
+                                '%s #%s did not have a DateAdded recorded, setting it'
+                                ' : %s'
+                                % (
+                                    comic['ComicName'],
+                                    result['Issue_Number'],
+                                    DateAdded,
+                                )
+                            )
+                            myDB.upsert(
+                                table,
+                                {'DateAdded': DateAdded},
+                                {'IssueID': result['IssueID']},
+                            )
+
+                    else:
+                        DateAdded = result['DateAdded']
+
+                    if rsscheck is None and DateAdded >= mylar.SEARCH_TIER_DATE:
+                        logger.info(
+                            'adding: ComicID:%s  IssueiD: %s'
+                            % (result['ComicID'], result['IssueID'])
+                        )
+                        mylar.SEARCH_QUEUE.put(
+                            {
+                                'comicname': comic['ComicName'],
+                                'seriesyear': SeriesYear,
+                                'issuenumber': result['Issue_Number'],
+                                'issueid': result['IssueID'],
+                                'comicid': result['ComicID'],
+                                'booktype': booktype,
+                            }
+                        )
                         continue
 
-                foundNZB = "none"
-                AllowPacks = False
-                if all([result['mode'] == 'story_arc', storyarc_watchlist is False]):
-                    Comicname_filesafe = helpers.filesafe(comic['ComicName'])
-                    SeriesYear = comic['SeriesYear']
-                    Publisher = comic['Publisher']
-                    AlternateSearch = None
-                    UseFuzzy = None
-                    ComicVersion = comic['Volume']
-                    TorrentID_32p = None
-                    booktype = comic['Type']
-                    ignore_booktype = False
-                else:
-                    Comicname_filesafe = comic['ComicName_Filesafe']
-                    SeriesYear = comic['ComicYear']
-                    Publisher = comic['ComicPublisher']
-                    AlternateSearch = comic['AlternateSearch']
-                    UseFuzzy = comic['UseFuzzy']
-                    ComicVersion = comic['ComicVersion']
-                    TorrentID_32p = comic['TorrentID_32P']
-                    booktype = comic['Type']
-                    if comic['Corrected_Type'] is not None and comic['Type'] != comic['Corrected_Type']:
-                        booktype = comic['Corrected_Type']
-                    ignore_booktype = bool(comic['IgnoreType'])
-                    if any([comic['AllowPacks'] == 1, comic['AllowPacks'] == '1']):
-                        AllowPacks = True
+                    mode = result['mode']
+                    foundNZB, prov = search_init(
+                        comic['ComicName'],
+                        result['Issue_Number'],
+                        str(ComicYear),
+                        SeriesYear,
+                        Publisher,
+                        IssueDate,
+                        StoreDate,
+                        result['IssueID'],
+                        AlternateSearch,
+                        UseFuzzy,
+                        ComicVersion,
+                        SARC=result['SARC'],
+                        IssueArcID=result['IssueArcID'],
+                        mode=mode,
+                        rsscheck=rsscheck,
+                        ComicID=result['ComicID'],
+                        filesafe=Comicname_filesafe,
+                        allow_packs=AllowPacks,
+                        oneoff=OneOff,
+                        torrentid_32p=TorrentID_32p,
+                        digitaldate=DigitalDate,
+                        booktype=booktype,
+                        ignore_booktype=ignore_booktype,
+                    )
+                    if foundNZB['status'] is True:
+                        updater.foundsearch(
+                            result['ComicID'],
+                            result['IssueID'],
+                            mode=mode,
+                            provider=prov,
+                            SARC=result['SARC'],
+                            IssueArcID=result['IssueArcID'],
+                            hash=foundNZB['info']['t_hash'],
+                        )
 
-                IssueDate = result['IssueDate']
-                StoreDate = result['StoreDate']
-                DigitalDate = result['DigitalDate']
+                except Exception as err:
+                    exc_type, exc_value, exc_tb = sys.exc_info()
+                    filename, line_num, func_name, err_text = traceback.extract_tb(
+                        exc_tb
+                    )[-1]
+                    tracebackline = traceback.format_exc()
 
-                if result['IssueDate'] is None:
-                    ComicYear = SeriesYear
-                else:
-                    ComicYear = str(result['IssueDate'])[:4]
+                    except_line = {
+                        'exc_type': exc_type,
+                        'exc_value': exc_value,
+                        'exc_tb': exc_tb,
+                        'filename': filename,
+                        'line_num': line_num,
+                        'func_name': func_name,
+                        'err': str(err),
+                        'err_text': err_text,
+                        'traceback': tracebackline,
+                        'comicname': comic['ComicName'],
+                        'issuenumber': result['Issue_Number'],
+                        'seriesyear': SeriesYear,
+                        'issueid': result['IssueID'],
+                        'comicid': result['ComicID'],
+                        'mode': mode,
+                        'booktype': booktype,
+                    }
 
-                if result['DateAdded'] is None:
-                    DA = datetime.datetime.today()
-                    DateAdded = DA.strftime('%Y-%m-%d')
-                    if result['mode'] == 'want':
-                        table = 'issues'
-                    elif result['mode'] == 'want_ann':
-                        table = 'annuals'
-                    elif result['mode'] == 'story_arc':
-                        table = 'storyarcs'
-                    logger.fdebug('%s #%s did not have a DateAdded recorded, setting it : %s' % (comic['ComicName'], result['Issue_Number'], DateAdded))
-                    myDB.upsert(table, {'DateAdded': DateAdded}, {'IssueID': result['IssueID']})
+                    helpers.log_that_exception(except_line)
 
-                else:
-                    DateAdded = result['DateAdded']
-
-                if rsscheck is None and DateAdded >= mylar.SEARCH_TIER_DATE:
-                    logger.info('adding: ComicID:%s  IssueiD: %s' % (result['ComicID'], result['IssueID']))
-                    mylar.SEARCH_QUEUE.put({'comicname': comic['ComicName'], 'seriesyear': SeriesYear, 'issuenumber': result['Issue_Number'], 'issueid': result['IssueID'], 'comicid': result['ComicID'], 'booktype': booktype})
+                    # log it regardless..
+                    logger.exception(tracebackline)
                     continue
-
-                mode = result['mode']
-                foundNZB, prov = search_init(comic['ComicName'], result['Issue_Number'], str(ComicYear), SeriesYear, Publisher, IssueDate, StoreDate, result['IssueID'], AlternateSearch, UseFuzzy, ComicVersion, SARC=result['SARC'], IssueArcID=result['IssueArcID'], mode=mode, rsscheck=rsscheck, ComicID=result['ComicID'], filesafe=Comicname_filesafe, allow_packs=AllowPacks, oneoff=OneOff, torrentid_32p=TorrentID_32p, digitaldate=DigitalDate, booktype=booktype, ignore_booktype=ignore_booktype)
-                if foundNZB['status'] is True:
-                    updater.foundsearch(result['ComicID'], result['IssueID'], mode=mode, provider=prov, SARC=result['SARC'], IssueArcID=result['IssueArcID'], hash=foundNZB['info']['t_hash'])
 
             if rsscheck:
                 logger.info('Completed RSS Search scan')
-                if mylar.SEARCHLOCK is True:
-                    mylar.SEARCHLOCK = False
             else:
                 logger.info('Completed Queueing API Search scan')
-                if mylar.SEARCHLOCK is True:
-                    mylar.SEARCHLOCK = False
-
         else:
-            mylar.SEARCHLOCK = True
-            result = myDB.selectone('SELECT * FROM issues where IssueID=?', [issueid]).fetchone()
-            mode = 'want'
-            oneoff = False
-            if result is None:
-                result = myDB.selectone('SELECT * FROM annuals where IssueID=?', [issueid]).fetchone()
-                mode = 'want_ann'
+            try:
+                mylar.SEARCHLOCK = True
+                result = myDB.selectone(
+                    'SELECT * FROM issues where IssueID=?', [issueid]
+                ).fetchone()
+                mode = 'want'
+                oneoff = False
                 if result is None:
-                    result = myDB.selectone('SELECT * FROM storyarcs where IssueArcID=?', [issueid]).fetchone()
-                    mode = 'story_arc'
-                    oneoff = True
+                    result = myDB.selectone(
+                        'SELECT * FROM annuals where IssueID=?', [issueid]
+                    ).fetchone()
+                    mode = 'want_ann'
                     if result is None:
-                        result = myDB.selectone('SELECT * FROM weekly where IssueID=?', [issueid]).fetchone()
-                        mode = 'pullwant'
+                        result = myDB.selectone(
+                            'SELECT * FROM storyarcs where IssueArcID=?', [issueid]
+                        ).fetchone()
+                        mode = 'story_arc'
                         oneoff = True
                         if result is None:
-                            logger.fdebug("Unable to locate IssueID - you probably should delete/refresh the series.")
-                            mylar.SEARCHLOCK = False
-                            return
+                            result = myDB.selectone(
+                                'SELECT * FROM weekly where IssueID=?', [issueid]
+                            ).fetchone()
+                            mode = 'pullwant'
+                            oneoff = True
+                            if result is None:
+                                logger.fdebug(
+                                    'Unable to locate IssueID - you probably should'
+                                    ' delete/refresh the series.'
+                                )
+                                mylar.SEARCHLOCK = False
+                                return
 
-            allow_packs = False
-            ComicID = result['ComicID']
-            if mode == 'story_arc':
-                ComicName = result['ComicName']
-                Comicname_filesafe = helpers.filesafe(ComicName)
-                SeriesYear = result['SeriesYear']
-                IssueNumber = result['IssueNumber']
-                Publisher = result['Publisher']
-                AlternateSearch = None
-                UseFuzzy = None
-                ComicVersion = result['Volume']
-                SARC = result['StoryArc']
-                IssueArcID = issueid
-                actissueid = None
-                IssueDate = result['IssueDate']
-                StoreDate = result['ReleaseDate']
-                DigitalDate = result['DigitalDate']
-                TorrentID_32p = None
-                booktype = result['Type']
-                ignore_booktype = False
-            elif mode == 'pullwant':
-                ComicName = result['COMIC']
-                Comicname_filesafe = helpers.filesafe(ComicName)
-                SeriesYear = result['seriesyear']
-                IssueNumber = result['ISSUE']
-                Publisher = result['PUBLISHER']
-                AlternateSearch = None
-                UseFuzzy = None
-                ComicVersion = result['volume']
-                SARC = None
-                IssueArcID = None
-                actissueid = issueid
-                TorrentID_32p = None
-                IssueDate = result['SHIPDATE']
-                StoreDate = IssueDate
-                DigitalDate = '0000-00-00'
-                booktype = result['format']
-                ignore_booktype = False
-            else:
-                comic = myDB.selectone('SELECT * FROM comics where ComicID=?', [ComicID]).fetchone()
-                if mode == 'want_ann':
+                allow_packs = False
+                ComicID = result['ComicID']
+                if mode == 'story_arc':
                     ComicName = result['ComicName']
-                    Comicname_filesafe = None
+                    Comicname_filesafe = helpers.filesafe(ComicName)
+                    SeriesYear = result['SeriesYear']
+                    IssueNumber = result['IssueNumber']
+                    Publisher = result['Publisher']
                     AlternateSearch = None
+                    UseFuzzy = None
+                    ComicVersion = result['Volume']
+                    SARC = result['StoryArc']
+                    IssueArcID = issueid
+                    actissueid = None
+                    IssueDate = result['IssueDate']
+                    StoreDate = result['ReleaseDate']
+                    DigitalDate = result['DigitalDate']
+                    TorrentID_32p = None
+                    booktype = result['Type']
+                    ignore_booktype = False
+                elif mode == 'pullwant':
+                    ComicName = result['COMIC']
+                    Comicname_filesafe = helpers.filesafe(ComicName)
+                    SeriesYear = result['seriesyear']
+                    IssueNumber = result['ISSUE']
+                    Publisher = result['PUBLISHER']
+                    AlternateSearch = None
+                    UseFuzzy = None
+                    ComicVersion = result['volume']
+                    SARC = None
+                    IssueArcID = None
+                    actissueid = issueid
+                    TorrentID_32p = None
+                    IssueDate = result['SHIPDATE']
+                    StoreDate = IssueDate
+                    DigitalDate = '0000-00-00'
+                    booktype = result['format']
+                    ignore_booktype = False
                 else:
-                    ComicName = comic['ComicName']
-                    Comicname_filesafe = comic['ComicName_Filesafe']
-                    AlternateSearch = comic['AlternateSearch']
-                SeriesYear = comic['ComicYear']
-                IssueNumber = result['Issue_Number']
-                Publisher = comic['ComicPublisher']
-                UseFuzzy = comic['UseFuzzy']
-                ComicVersion = comic['ComicVersion']
-                IssueDate = result['IssueDate']
-                StoreDate = result['ReleaseDate']
-                DigitalDate = result['DigitalDate']
-                SARC = None
-                IssueArcID = None
-                actissueid = issueid
-                TorrentID_32p = comic['TorrentID_32P']
-                booktype = comic['Type']
-                if comic['Corrected_Type'] is not None and comic['Type'] != comic['Corrected_Type']:
-                    booktype = comic['Corrected_Type']
-                ignore_booktype = bool(comic['IgnoreType'])
-                if any([comic['AllowPacks'] == 1, comic['AllowPacks'] == '1']):
-                    allow_packs = True
+                    comic = myDB.selectone(
+                        'SELECT * FROM comics where ComicID=?', [ComicID]
+                    ).fetchone()
+                    if mode == 'want_ann':
+                        ComicName = result['ComicName']
+                        Comicname_filesafe = None
+                        AlternateSearch = None
+                    else:
+                        ComicName = comic['ComicName']
+                        Comicname_filesafe = comic['ComicName_Filesafe']
+                        AlternateSearch = comic['AlternateSearch']
+                    SeriesYear = comic['ComicYear']
+                    IssueNumber = result['Issue_Number']
+                    Publisher = comic['ComicPublisher']
+                    UseFuzzy = comic['UseFuzzy']
+                    ComicVersion = comic['ComicVersion']
+                    IssueDate = result['IssueDate']
+                    StoreDate = result['ReleaseDate']
+                    DigitalDate = result['DigitalDate']
+                    SARC = None
+                    IssueArcID = None
+                    actissueid = issueid
+                    TorrentID_32p = comic['TorrentID_32P']
+                    booktype = comic['Type']
+                    if (
+                        comic['Corrected_Type'] is not None
+                        and comic['Type'] != comic['Corrected_Type']
+                    ):
+                        booktype = comic['Corrected_Type']
+                    ignore_booktype = bool(comic['IgnoreType'])
+                    if any([comic['AllowPacks'] == 1, comic['AllowPacks'] == '1']):
+                        allow_packs = True
 
-            if IssueDate is None:
-                IssueYear = SeriesYear
-            else:
-                IssueYear = str(IssueDate)[:4]
+                if IssueDate is None:
+                    IssueYear = SeriesYear
+                else:
+                    IssueYear = str(IssueDate)[:4]
 
-            foundNZB, prov = search_init(ComicName, IssueNumber, str(IssueYear), SeriesYear, Publisher, IssueDate, StoreDate, actissueid, AlternateSearch, UseFuzzy, ComicVersion, SARC=SARC, IssueArcID=IssueArcID, mode=mode, rsscheck=rsscheck, ComicID=ComicID, filesafe=Comicname_filesafe, allow_packs=allow_packs, oneoff=oneoff, manual=manual, torrentid_32p=TorrentID_32p, digitaldate=DigitalDate, booktype=booktype, ignore_booktype=ignore_booktype)
-            if manual is True:
-                mylar.SEARCHLOCK = False
+                foundNZB, prov = search_init(
+                    ComicName,
+                    IssueNumber,
+                    str(IssueYear),
+                    SeriesYear,
+                    Publisher,
+                    IssueDate,
+                    StoreDate,
+                    actissueid,
+                    AlternateSearch,
+                    UseFuzzy,
+                    ComicVersion,
+                    SARC=SARC,
+                    IssueArcID=IssueArcID,
+                    mode=mode,
+                    rsscheck=rsscheck,
+                    ComicID=ComicID,
+                    filesafe=Comicname_filesafe,
+                    allow_packs=allow_packs,
+                    oneoff=oneoff,
+                    manual=manual,
+                    torrentid_32p=TorrentID_32p,
+                    digitaldate=DigitalDate,
+                    booktype=booktype,
+                    ignore_booktype=ignore_booktype,
+                )
+                if manual is True:
+                    mylar.SEARCHLOCK = False
+                    return foundNZB
+                if foundNZB['status'] is True:
+                    mylar.SEARCHLOCK = False
+                    logger.fdebug('I found %s #%s' % (ComicName, IssueNumber))
+                    updater.foundsearch(
+                        ComicID,
+                        actissueid,
+                        mode=mode,
+                        provider=prov,
+                        SARC=SARC,
+                        IssueArcID=IssueArcID,
+                        hash=foundNZB['info']['t_hash'],
+                    )
                 return foundNZB
-            if foundNZB['status'] is True:
-                logger.fdebug('I found %s #%s' % (ComicName, IssueNumber))
-                updater.foundsearch(ComicID, actissueid, mode=mode, provider=prov, SARC=SARC, IssueArcID=IssueArcID, hash=foundNZB['info']['t_hash'])
-            if mylar.SEARCHLOCK is True:
-                mylar.SEARCHLOCK = False
-            return foundNZB
 
+            except Exception as err:
+                exc_type, exc_value, exc_tb = sys.exc_info()
+                filename, line_num, func_name, err_text = traceback.extract_tb(exc_tb)[
+                    -1
+                ]
+                tracebackline = traceback.format_exc()
+
+                except_line = {
+                    'exc_type': exc_type,
+                    'exc_value': exc_value,
+                    'exc_tb': exc_tb,
+                    'filename': filename,
+                    'line_num': line_num,
+                    'func_name': func_name,
+                    'err': str(err),
+                    'err_text': err_text,
+                    'traceback': tracebackline,
+                    'comicname': comic['ComicName'],
+                    'issuenumber': result['Issue_Number'],
+                    'seriesyear': SeriesYear,
+                    'issueid': result['IssueID'],
+                    'comicid': result['ComicID'],
+                    'mode': mode,
+                    'booktype': booktype,
+                }
+
+                helpers.log_that_exception(except_line)
+
+                # log it regardless..
+                logger.exception(tracebackline)
+
+            finally:
+                mylar.SEARCHLOCK = False
     else:
         if rsscheck:
-            logger.warn('There are no search providers enabled atm - not performing an RSS check for obvious reasons')
+            logger.warn(
+                'There are no search providers enabled atm - not performing an RSS'
+                ' check for obvious reasons'
+            )
         else:
-            logger.warn('There are no search providers enabled atm - not performing an Force Check for obvious reasons')
+            logger.warn(
+                'There are no search providers enabled atm - not performing an Force'
+                ' Check for obvious reasons'
+            )
     return
+
 
 def searchIssueIDList(issuelist):
     myDB = db.DBConnection()
     ens = [x for x in mylar.CONFIG.EXTRA_NEWZNABS if x[5] == '1']
     ets = [x for x in mylar.CONFIG.EXTRA_TORZNABS if x[5] == '1']
-    if (any([mylar.CONFIG.ENABLE_DDL is True, mylar.CONFIG.NZBSU is True, mylar.CONFIG.DOGNZB is True, mylar.CONFIG.EXPERIMENTAL is True]) or all([mylar.CONFIG.NEWZNAB is True, len(ens) > 0]) and any([mylar.USE_SABNZBD is True, mylar.USE_NZBGET is True, mylar.USE_BLACKHOLE is True])) or (all([mylar.CONFIG.ENABLE_TORRENT_SEARCH is True, mylar.CONFIG.ENABLE_TORRENTS is True]) and (any([mylar.CONFIG.ENABLE_PUBLIC is True, mylar.CONFIG.ENABLE_32P is True]) or all([mylar.CONFIG.ENABLE_TORZNAB is True, len(ets) > 0]))):
+    if (
+        any(
+            [
+                mylar.CONFIG.ENABLE_DDL is True,
+                mylar.CONFIG.NZBSU is True,
+                mylar.CONFIG.DOGNZB is True,
+                mylar.CONFIG.EXPERIMENTAL is True,
+            ]
+        )
+        or all([mylar.CONFIG.NEWZNAB is True, len(ens) > 0])
+        and any(
+            [
+                mylar.USE_SABNZBD is True,
+                mylar.USE_NZBGET is True,
+                mylar.USE_BLACKHOLE is True,
+            ]
+        )
+    ) or (
+        all(
+            [
+                mylar.CONFIG.ENABLE_TORRENT_SEARCH is True,
+                mylar.CONFIG.ENABLE_TORRENTS is True,
+            ]
+        )
+        and (
+            any([mylar.CONFIG.ENABLE_PUBLIC is True, mylar.CONFIG.ENABLE_32P is True])
+            or all([mylar.CONFIG.ENABLE_TORZNAB is True, len(ets) > 0])
+        )
+    ):
         for issueid in issuelist:
             logger.info('searching for issueid: %s' % issueid)
-            issue = myDB.selectone('SELECT * from issues WHERE IssueID=?', [issueid]).fetchone()
-            mode = 'want'
+            issue = myDB.selectone(
+                'SELECT * from issues WHERE IssueID=?', [issueid]
+            ).fetchone()
             if issue is None:
-                issue = myDB.selectone('SELECT * from annuals WHERE IssueID=?', [issueid]).fetchone()
-                mode = 'want_ann'
+                issue = myDB.selectone(
+                    'SELECT * from annuals WHERE IssueID=?', [issueid]
+                ).fetchone()
                 if issue is None:
-                    logger.warn('Unable to determine IssueID - perhaps you need to delete/refresh series? Skipping this entry: %s' % issueid)
+                    logger.warn(
+                        'Unable to determine IssueID - perhaps you need to'
+                        ' delete/refresh series? Skipping this entry: %s'
+                        % issueid
+                    )
                     continue
 
             if any([issue['Status'] == 'Downloaded', issue['Status'] == 'Snatched']):
-                logger.fdebug('Issue is already in a Downloaded / Snatched status. If this is still wanted, perform a Manual search or mark issue as Skipped or Wanted.')
+                logger.fdebug(
+                    'Issue is already in a Downloaded / Snatched status. If this is'
+                    ' still wanted, perform a Manual search or mark issue as Skipped'
+                    ' or Wanted.'
+                )
                 continue
 
-            comic = myDB.selectone('SELECT * from comics WHERE ComicID=?', [issue['ComicID']]).fetchone()
-            foundNZB = "none"
+            comic = myDB.selectone(
+                'SELECT * from comics WHERE ComicID=?', [issue['ComicID']]
+            ).fetchone()
             SeriesYear = comic['ComicYear']
-            AlternateSearch = comic['AlternateSearch']
-            Publisher = comic['ComicPublisher']
-            UseFuzzy = comic['UseFuzzy']
-            ComicVersion = comic['ComicVersion']
-            TorrentID_32p = comic['TorrentID_32P']
             booktype = comic['Type']
-            if comic['Corrected_Type'] is not None and comic['Type'] != comic['Corrected_Type']:
+            if (
+                comic['Corrected_Type'] is not None
+                and comic['Type'] != comic['Corrected_Type']
+            ):
                 booktype = comic['Corrected_Type']
-            if issue['IssueDate'] == None:
-                IssueYear = comic['ComicYear']
-            else:
-                IssueYear = str(issue['IssueDate'])[:4]
-            if any([comic['AllowPacks'] == 1, comic['AllowPacks'] == '1']):
-                AllowPacks = True
-            else:
-                AllowPacks = False
 
-            mylar.SEARCH_QUEUE.put({'comicname': comic['ComicName'], 'seriesyear': SeriesYear, 'issuenumber':issue['Issue_Number'], 'issueid': issue['IssueID'], 'comicid': issue['ComicID'], 'booktype': booktype})
+            mylar.SEARCH_QUEUE.put(
+                {
+                    'comicname': comic['ComicName'],
+                    'seriesyear': SeriesYear,
+                    'issuenumber': issue['Issue_Number'],
+                    'issueid': issue['IssueID'],
+                    'comicid': issue['ComicID'],
+                    'booktype': booktype,
+                }
+            )
 
         logger.info('Completed queuing of search request.')
     else:
-        logger.warn('There are no search providers enabled atm - not performing the requested search for obvious reasons')
+        logger.warn(
+            'There are no search providers enabled atm - not performing the requested'
+            ' search for obvious reasons'
+        )
 
 
-def provider_sequence(nzbprovider, torprovider, newznab_hosts, torznab_hosts, ddlprovider):
-    #provider order sequencing here.
+def provider_sequence(
+    nzbprovider, torprovider, newznab_hosts, torznab_hosts, ddlprovider
+):
+    # provider order sequencing here.
     newznab_info = []
     torznab_info = []
     prov_order = []
@@ -2005,24 +3281,35 @@ def provider_sequence(nzbprovider, torprovider, newznab_hosts, torznab_hosts, dd
     ddlproviders_lower = [z.lower() for z in ddlprovider]
 
     if len(mylar.CONFIG.PROVIDER_ORDER) > 0:
-        for pr_order in sorted(list(mylar.CONFIG.PROVIDER_ORDER.items()), key=itemgetter(0), reverse=False):
-            if any(pr_order[1].lower() in y for y in torproviders_lower) or any(pr_order[1].lower() in x for x in nzbproviders_lower) or any(pr_order[1].lower() == z for z in ddlproviders_lower):
+        for pr_order in sorted(
+            list(mylar.CONFIG.PROVIDER_ORDER.items()), key=itemgetter(0), reverse=False
+        ):
+            if (
+                any(pr_order[1].lower() in y for y in torproviders_lower)
+                or any(pr_order[1].lower() in x for x in nzbproviders_lower)
+                or any(pr_order[1].lower() == z for z in ddlproviders_lower)
+            ):
                 if any(pr_order[1].lower() in x for x in nzbproviders_lower):
                     # this is for nzb providers
                     for np in nzbprovider:
                         if all(['newznab' in np, pr_order[1].lower() in np.lower()]):
                             for newznab_host in newznab_hosts:
                                 if newznab_host[0].lower() == pr_order[1].lower():
-                                    prov_order.append(np) #newznab_host)
-                                    newznab_info.append({"provider":     np,
-                                                         "info": newznab_host})
+                                    prov_order.append(np)
+                                    newznab_info.append(
+                                        {"provider": np, "info": newznab_host}
+                                    )
                                     break
                                 else:
                                     if newznab_host[0] == "":
-                                        if newznab_host[1].lower() == pr_order[1].lower():
-                                            prov_order.append(np) #newznab_host)
-                                            newznab_info.append({"provider":     np,
-                                                                 "info": newznab_host})
+                                        if (
+                                            newznab_host[1].lower()
+                                            == pr_order[1].lower()
+                                        ):
+                                            prov_order.append(np)
+                                            newznab_info.append(
+                                                {"provider": np, "info": newznab_host}
+                                            )
                                             break
                         elif pr_order[1].lower() in np.lower():
                             prov_order.append(pr_order[1])
@@ -2033,42 +3320,54 @@ def provider_sequence(nzbprovider, torprovider, newznab_hosts, torznab_hosts, dd
                             for torznab_host in torznab_hosts:
                                 if torznab_host[0].lower() == pr_order[1].lower():
                                     prov_order.append(tp)
-                                    torznab_info.append({"provider":     tp,
-                                                         "info": torznab_host})
+                                    torznab_info.append(
+                                        {"provider": tp, "info": torznab_host}
+                                    )
                                     break
                                 else:
                                     if torznab_host[0] == "":
-                                        if torznab_host[1].lower() == pr_order[1].lower():
+                                        if (
+                                            torznab_host[1].lower()
+                                            == pr_order[1].lower()
+                                        ):
                                             prov_order.append(tp)
-                                            torznab_info.append({"provider":     tp,
-                                                                 "info": torznab_host})
+                                            torznab_info.append(
+                                                {"provider": tp, "info": torznab_host}
+                                            )
                                             break
-                        elif (pr_order[1].lower() in tp.lower()):
+                        elif pr_order[1].lower() in tp.lower():
                             prov_order.append(pr_order[1])
                             break
                 elif any(pr_order[1].lower() == z for z in ddlproviders_lower):
                     for dd in ddlprovider:
-                        if (dd.lower() == pr_order[1].lower()):
+                        if dd.lower() == pr_order[1].lower():
                             prov_order.append(pr_order[1])
                             break
 
     return prov_order, torznab_info, newznab_info
 
+
 def nzbname_create(provider, title=None, info=None):
-    #the nzbname here is used when post-processing
-    # it searches nzblog which contains the nzbname to pull out the IssueID and start the post-processing
-    # it is also used to keep the hashinfo for the nzbname in case it fails downloading, it will get put into the failed db for future exclusions
+    """
+    The nzbname here is used when post-processing.
+    It searches nzblog which contains the nzbname to pull out the IssueID and start the
+    post-processing. It is also used to keep the hashinfo for the nzbname in case it
+    fails downloading, and then it will get put into the failed db for future exclusions
+    """
     nzbname = None
 
-    if mylar.USE_BLACKHOLE and all([provider != '32P', provider != 'WWT', provider != 'DEM']):
+    if mylar.USE_BLACKHOLE and all(
+        [provider != '32P', provider != 'WWT', provider != 'DEM']
+    ):
         if os.path.exists(mylar.CONFIG.BLACKHOLE_DIR):
-            #load in the required info to generate the nzb names when required (blackhole only)
+            # load in the required info to generate the nzb names when required
+            # (blackhole only)
             ComicName = info[0]['ComicName']
             IssueNumber = info[0]['IssueNumber']
             comyear = info[0]['comyear']
-            #pretty this biatch up.
-            BComicName = re.sub('[\:\,\/\?\']', '', str(ComicName))
-            Bl_ComicName = re.sub('[\&]', 'and', str(BComicName))
+            # pretty this biatch up.
+            BComicName = re.sub(r'[\:\,\/\?\']', '', str(ComicName))
+            Bl_ComicName = re.sub(r'[\&]', 'and', str(BComicName))
             if '\xbd' in IssueNumber:
                 str_IssueNumber = '0.5'
             elif '\xbc' in IssueNumber:
@@ -2079,36 +3378,42 @@ def nzbname_create(provider, title=None, info=None):
                 str_IssueNumber = 'infinity'
             else:
                 str_IssueNumber = IssueNumber
-            nzbname = '%s.%s.(%s)' % (re.sub(" ", ".", str(Bl_ComicName)), str_IssueNumber, comyear)
+            nzbname = '%s.%s.(%s)' % (
+                re.sub(" ", ".", str(Bl_ComicName)),
+                str_IssueNumber,
+                comyear,
+            )
 
             logger.fdebug('nzb name to be used for post-processing is : %s' % nzbname)
 
-    elif any([provider == '32P', provider == 'WWT', provider == 'DEM', provider == 'ddl']):
-        #filesafe the name cause people are idiots when they post sometimes.
-        nzbname = re.sub('\s{2,}', ' ', helpers.filesafe(title)).strip()
-        #let's change all space to decimals for simplicity
+    elif any(
+        [provider == '32P', provider == 'WWT', provider == 'DEM', provider == 'DDL']
+    ):
+        # filesafe the name cause people are idiots when they post sometimes.
+        nzbname = re.sub(r'\s{2,}', ' ', helpers.filesafe(title)).strip()
+        # let's change all space to decimals for simplicity
         nzbname = re.sub(" ", ".", nzbname)
-        #gotta replace & or escape it
-        nzbname = re.sub("\&", 'and', nzbname)
-        nzbname = re.sub('[\,\:\?\']', '', nzbname)
+        # gotta replace & or escape it
+        nzbname = re.sub(r'\&', 'and', nzbname)
+        nzbname = re.sub(r'[\,\:\?\']', '', nzbname)
         if nzbname.lower().endswith('.torrent'):
             nzbname = re.sub('.torrent', '', nzbname)
 
     else:
         # let's change all space to decimals for simplicity
         logger.fdebug('[SEARCHER] entry[title]: %s' % title)
-        #gotta replace & or escape it
-        nzbname = re.sub('\&amp;(amp;)?|\&', 'and', title)
-        nzbname = re.sub('[\,\:\?\'\+]', '', nzbname)
-        nzbname = re.sub('[\(\)]', ' ', nzbname)
+        # gotta replace & or escape it
+        nzbname = re.sub(r'\&amp;(amp;)?|\&', 'and', title)
+        nzbname = re.sub(r'[\,\:\?\'\+]', '', nzbname)
+        nzbname = re.sub(r'[\(\)]', ' ', nzbname)
         logger.fdebug('[SEARCHER] nzbname (remove chars): %s' % nzbname)
         nzbname = re.sub('.cbr', '', nzbname).strip()
         nzbname = re.sub('.cbz', '', nzbname).strip()
-        nzbname = re.sub('[\.\_]', ' ', nzbname).strip()
-        nzbname = re.sub('\s+', ' ', nzbname)  #make sure we remove the extra spaces.
-        logger.fdebug('[SEARCHER] nzbname (\s): %s' % nzbname)
-        nzbname = re.sub(' ', '.', nzbname)
-        #remove the [1/9] parts or whatever kinda crap (usually in experimental results)
+        nzbname = re.sub(r'[\.\_]', ' ', nzbname).strip()
+        nzbname = re.sub(r'\s+', ' ', nzbname)  # make sure we remove the extra spaces.
+        logger.fdebug('[SEARCHER] nzbname : %s' % nzbname)
+        nzbname = re.sub(r'\s', '.', nzbname)
+        # remove the [1/9] parts or whatever kinda crap (usually in experimental)
         pattern = re.compile(r'\W\d{1,3}\/\d{1,3}\W')
         match = pattern.search(nzbname)
         if match:
@@ -2121,47 +3426,53 @@ def nzbname_create(provider, title=None, info=None):
         logger.fdebug('nzbname used for post-processing: %s' % nzbname)
         return nzbname
 
-def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, directsend=None, newznab=None, torznab=None, rss=None):
+
+def searcher(
+    nzbprov,
+    nzbname,
+    comicinfo,
+    link,
+    IssueID,
+    ComicID,
+    tmpprov,
+    directsend=None,
+    newznab=None,
+    torznab=None,
+    rss=None,
+):
     alt_nzbname = None
-    #load in the details of the issue from the tuple.
+    # load in the details of the issue from the tuple.
     ComicName = comicinfo[0]['ComicName']
     IssueNumber = comicinfo[0]['IssueNumber']
     comyear = comicinfo[0]['comyear']
-    modcomicname = comicinfo[0]['modcomicname']
     oneoff = comicinfo[0]['oneoff']
     try:
-       SARC = comicinfo[0]['SARC']
-    except:
-       SARC = None
+        SARC = comicinfo[0]['SARC']
+    except Exception:
+        SARC = None
     try:
-       IssueArcID = comicinfo[0]['IssueArcID']
-    except:
-       IssueArcID = None
+        IssueArcID = comicinfo[0]['IssueArcID']
+    except Exception:
+        IssueArcID = None
 
-    #setup the priorities.
+    # setup the priorities.
     if mylar.CONFIG.SAB_PRIORITY:
-        if mylar.CONFIG.SAB_PRIORITY == "Default": sabpriority = "-100"
-        elif mylar.CONFIG.SAB_PRIORITY == "Low": sabpriority = "-1"
-        elif mylar.CONFIG.SAB_PRIORITY == "Normal": sabpriority = "0"
-        elif mylar.CONFIG.SAB_PRIORITY == "High": sabpriority = "1"
-        elif mylar.CONFIG.SAB_PRIORITY == "Paused": sabpriority = "-2"
+        if mylar.CONFIG.SAB_PRIORITY == 'Default':
+            sabpriority = '-100'
+        elif mylar.CONFIG.SAB_PRIORITY == 'Low':
+            sabpriority = '-1'
+        elif mylar.CONFIG.SAB_PRIORITY == 'Normal':
+            sabpriority = '0'
+        elif mylar.CONFIG.SAB_PRIORITY == 'High':
+            sabpriority = '1'
+        elif mylar.CONFIG.SAB_PRIORITY == 'Paused':
+            sabpriority = '-2'
     else:
-        #if sab priority isn't selected, default to Normal (0)
-        sabpriority = "0"
+        # if sab priority isn't selected, default to Normal (0)
+        sabpriority = '0'
 
-    if mylar.CONFIG.NZBGET_PRIORITY:
-        if mylar.CONFIG.NZBGET_PRIORITY == "Default": nzbgetpriority = "0"
-        elif mylar.CONFIG.NZBGET_PRIORITY == "Low": nzbgetpriority = "-50"
-        elif mylar.CONFIG.NZBGET_PRIORITY == "Normal": nzbgetpriority = "0"
-        elif mylar.CONFIG.NZBGET_PRIORITY == "High": nzbgetpriority = "50"
-        #there's no priority for "paused", so set "Very Low" and deal with that later...
-        elif mylar.CONFIG.NZBGET_PRIORITY == "Paused": nzbgetpriority = "-100"
-    else:
-        #if sab priority isn't selected, default to Normal (0)
-        nzbgetpriority = "0"
-
-    if nzbprov == 'torznab' or nzbprov == 'ddl':
-        if nzbprov == 'ddl':
+    if nzbprov == 'torznab' or nzbprov == 'DDL':
+        if nzbprov == 'DDL':
             nzbid = link['id']
         else:
             nzbid = generate_id(nzbprov, link['id'])
@@ -2169,7 +3480,7 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
     else:
         try:
             link = link['link']
-        except:
+        except Exception:
             link = link
         nzbid = generate_id(nzbprov, link)
 
@@ -2177,14 +3488,26 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
     if 'Public Torrents' in tmpprov and any([nzbprov == 'WWT', nzbprov == 'DEM']):
         tmpprov = re.sub('Public Torrents', nzbprov, tmpprov)
 
-    if comicinfo[0]['pack'] == True:
+    if comicinfo[0]['pack'] is True:
         if '0-Day Comics Pack' not in comicinfo[0]['ComicName']:
-            logger.info('Found %s (%s) issue: %s using %s within a pack containing issues %s' % (ComicName, comyear, IssueNumber, tmpprov, comicinfo[0]['pack_numbers']))
+            logger.info(
+                'Found %s (%s) issue: %s using %s within a pack containing issues %s'
+                % (
+                    ComicName,
+                    comyear,
+                    IssueNumber,
+                    tmpprov,
+                    comicinfo[0]['pack_numbers'],
+                )
+            )
         else:
-            logger.info('Found %s using %s for %s' % (ComicName, tmpprov, comicinfo[0]['IssueDate']))
+            logger.info(
+                'Found %s using %s for %s'
+                % (ComicName, tmpprov, comicinfo[0]['IssueDate'])
+            )
     else:
         if any([oneoff is True, IssueID is None]):
-            #one-off information
+            # one-off information
             logger.fdebug('ComicName: %s' % ComicName)
             logger.fdebug('Issue: %s' % IssueNumber)
             logger.fdebug('Year: %s' % comyear)
@@ -2192,7 +3515,10 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
         if IssueNumber is None:
             logger.info('Found %s (%s) using %s' % (ComicName, comyear, tmpprov))
         else:
-            logger.info('Found %s (%s) #%s using %s' % (ComicName, comyear, IssueNumber, tmpprov))
+            logger.info(
+                'Found %s (%s) #%s using %s'
+                % (ComicName, comyear, IssueNumber, tmpprov)
+            )
 
     logger.fdebug('link given by: %s' % nzbprov)
 
@@ -2200,49 +3526,79 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
         logger.info('nzbid: %s' % nzbid)
         logger.info('IssueID: %s' % IssueID)
         logger.info('oneoff: %s' % oneoff)
-        if all([nzbid is not None and nzbid != '', IssueID is not None, oneoff is False]):
-            # --- this causes any possible snatch to get marked as a Failed download when doing a one-off search...
-            #try:
+        if all(
+            [nzbid is not None and nzbid != '', IssueID is not None, oneoff is False]
+        ):
+            # --- this causes any possible snatch to get marked as a Failed download
+            # when doing a one-off search...
+            # try:
             #    # only nzb providers will have a filen, try it and pass exception
             #    if IssueID is None:
-            #        logger.fdebug('One-off mode was initiated - Failed Download handling for : ' + ComicName + ' #' + str(IssueNumber))
-            #        comicinfo = {"ComicName":   ComicName,
+            #        logger.fdebug(
+            #            'One-off mode was initiated - Failed Download'
+            #            ' handling for : ' + ComicName + ' #' + str(IssueNumber)
+            #        )
+            #        comicinfo = {"ComicName": ComicName,
             #                     "IssueNumber": IssueNumber}
-            #        return FailedMark(ComicID=ComicID, IssueID=IssueID, id=nzbid, nzbname=nzbname, prov=nzbprov, oneoffinfo=comicinfo)
-            #except:
+            #        return FailedMark(ComicID=ComicID, IssueID=IssueID, id=nzbid,
+            #                          nzbname=nzbname, prov=nzbprov,
+            #                          oneoffinfo=comicinfo)
+            # except:
             #    pass
-            call_the_fail = Failed.FailedProcessor(nzb_name=nzbname, id=nzbid, issueid=IssueID, comicid=ComicID, prov=tmpprov)
+            call_the_fail = Failed.FailedProcessor(
+                nzb_name=nzbname,
+                id=nzbid,
+                issueid=IssueID,
+                comicid=ComicID,
+                prov=tmpprov,
+            )
             check_the_fail = call_the_fail.failed_check()
             if check_the_fail == 'Failed':
-                logger.fdebug('[FAILED_DOWNLOAD_CHECKER] [%s] Marked as a bad download : %s' % (tmpprov, nzbid))
+                logger.fdebug(
+                    '[FAILED_DOWNLOAD_CHECKER] [%s] Marked as a bad download : %s'
+                    % (tmpprov, nzbid)
+                )
                 return "downloadchk-fail"
             elif check_the_fail == 'Good':
-                logger.fdebug('[FAILED_DOWNLOAD_CHECKER] This is not in the failed downloads list. Will continue with the download.')
+                logger.fdebug(
+                    '[FAILED_DOWNLOAD_CHECKER] This is not in the failed downloads'
+                    ' list. Will continue with the download.'
+                )
         else:
-            logger.fdebug('[FAILED_DOWNLOAD_CHECKER] Failed download checking is not available for one-off downloads atm. Fixed soon!')
- 
-    if link and all([nzbprov != 'WWT', nzbprov != 'DEM', nzbprov != '32P', nzbprov != 'torznab', nzbprov != 'ddl']):
+            logger.fdebug(
+                '[FAILED_DOWNLOAD_CHECKER] Failed download checking is not available'
+                ' for one-off downloads atm. Fixed soon!'
+            )
 
-        #generate nzbid here.
+    if link and all(
+        [
+            nzbprov != 'WWT',
+            nzbprov != 'DEM',
+            nzbprov != '32P',
+            nzbprov != 'torznab',
+            nzbprov != 'DDL',
+        ]
+    ):
+
+        # generate nzbid here.
 
         nzo_info = {}
         filen = None
         nzbhydra = False
         payload = None
         headers = {'User-Agent': str(mylar.USER_AGENT)}
-        #link doesn't have the apikey - add it and use ?t=get for newznab based.
+        # link doesn't have the apikey - add it and use ?t=get for newznab based.
         if nzbprov == 'newznab' or nzbprov == 'nzb.su':
-            #need to basename the link so it just has the id/hash.
-            #rss doesn't store apikey, have to put it back.
+            # need to basename the link so it just has the id/hash.
+            # rss doesn't store apikey, have to put it back.
             if nzbprov == 'newznab':
-                name_newznab = newznab[0].rstrip()
                 host_newznab = newznab[1].rstrip()
-                if host_newznab[len(host_newznab) -1:len(host_newznab)] != '/':
+                if host_newznab[len(host_newznab) - 1 : len(host_newznab)] != '/':
                     host_newznab_fix = str(host_newznab) + "/"
                 else:
                     host_newznab_fix = host_newznab
 
-                #account for nzbmegasearch & nzbhydra
+                # account for nzbmegasearch & nzbhydra
                 if 'searchresultid' in link:
                     logger.fdebug('NZBHydra V1 url detected. Adjusting...')
                     nzbhydra = True
@@ -2264,20 +3620,20 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
                 verify = False
             elif 'https://cdn.' in link:
                 down_url = host_newznab_fix + 'api'
-                logger.fdebug('Re-routing incorrect RSS URL response for NZBGeek to correct API')
-                payload = {'t': 'get',
-                           'id': str(nzbid),
-                           'apikey': str(apikey)}
+                logger.fdebug(
+                    'Re-routing incorrect RSS URL response for NZBGeek to correct API'
+                )
+                payload = {'t': 'get', 'id': str(nzbid), 'apikey': str(apikey)}
             else:
                 down_url = link
 
         elif nzbprov == 'dognzb':
-            #dognzb - need to add back in the dog apikey
+            # dognzb - need to add back in the dog apikey
             down_url = urljoin(link, str(mylar.CONFIG.DOGNZB_APIKEY))
             verify = bool(mylar.CONFIG.DOGNZB_VERIFY)
 
         else:
-            #experimental - direct link.
+            # experimental - direct link.
             down_url = link
             headers = None
             verify = False
@@ -2288,27 +3644,36 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
             tmp_url_st = tmp_url.find('apikey=')
             if tmp_url_st == -1:
                 tmp_url_st = tmp_url.find('r=')
-                tmp_line = tmp_url[:tmp_url_st+2]
+                tmp_line = tmp_url[: tmp_url_st + 2]
             else:
-                tmp_line = tmp_url[:tmp_url_st+7]
+                tmp_line = tmp_url[: tmp_url_st + 7]
             tmp_line += 'xYOUDONTNEEDTOKNOWTHISx'
             tmp_url_en = tmp_url.find('&', tmp_url_st)
             if tmp_url_en == -1:
                 tmp_url_en = len(tmp_url)
             tmp_line += tmp_url[tmp_url_en:]
-            #tmp_url = helpers.apiremove(down_url.copy(), '&') 
-            logger.fdebug('[PAYLOAD-NONE] Download URL: %s [VerifySSL: %s]' % (tmp_line, verify))
+            # tmp_url = helpers.apiremove(down_url.copy(), '&')
+            logger.fdebug(
+                '[PAYLOAD-NONE] Download URL: %s [VerifySSL: %s]' % (tmp_line, verify)
+            )
         else:
             tmppay = payload.copy()
             tmppay['apikey'] = 'YOUDONTNEEDTOKNOWTHIS'
-            logger.fdebug('[PAYLOAD] Download URL: %s?%s [VerifySSL: %s]' % (down_url, urllib.parse.urlencode(tmppay), verify))
+            logger.fdebug(
+                '[PAYLOAD] Download URL: %s?%s [VerifySSL: %s]'
+                % (down_url, urllib.parse.urlencode(tmppay), verify)
+            )
 
-        if down_url.startswith('https') and verify == False:
+        if down_url.startswith('https') and verify is False:
             try:
                 from requests.packages.urllib3 import disable_warnings
+
                 disable_warnings()
-            except:
-                logger.warn('Unable to disable https warnings. Expect some spam if using https nzb providers.')
+            except Exception:
+                logger.warn(
+                    'Unable to disable https warnings. Expect some spam if using https'
+                    ' nzb providers.'
+                )
 
         try:
             r = requests.get(down_url, params=payload, verify=verify, headers=headers)
@@ -2338,95 +3703,140 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
 
         if filen is None:
             try:
-                filen = r.headers['content-disposition'][r.headers['content-disposition'].index("filename=") + 9:].strip(';').strip('"')
+                filen = (
+                    r.headers['content-disposition'][
+                        r.headers['content-disposition'].index("filename=") + 9 :
+                    ]
+                    .strip(';')
+                    .strip('"')
+                )
                 logger.fdebug('filename within nzb: %s' % filen)
-            except:
+            except Exception:
                 pass
 
         if filen is None:
             if payload is None:
-                logger.error('[PAYLOAD:NONE] Unable to download nzb from link: %s [%s]' % (down_url, link))
+                logger.error(
+                    '[PAYLOAD:NONE] Unable to download nzb from link: %s [%s]'
+                    % (down_url, link)
+                )
             else:
                 errorlink = down_url + '?' + urllib.parse.urlencode(payload)
-                logger.error('[PAYLOAD:PRESENT] Unable to download nzb from link: %s [%s]' % (errorlink, link))
+                logger.error(
+                    '[PAYLOAD:PRESENT] Unable to download nzb from link: %s [%s]'
+                    % (errorlink, link)
+                )
             return "sab-fail"
         else:
-            #convert to a generic type of format to help with post-processing.
-            filen = re.sub("\&", 'and', filen)
-            filen = re.sub('[\,\:\?\']', '', filen)
-            filen = re.sub('[\(\)]', ' ', filen)
-            filen = re.sub('[\s\s+]', '', filen)  #make sure we remove the extra spaces.
+            # convert to a generic type of format to help with post-processing.
+            filen = re.sub(r'\&', 'and', filen)
+            filen = re.sub(r'[\,\:\?\']', '', filen)
+            filen = re.sub(r'[\(\)]', ' ', filen)
+            filen = re.sub(
+                r'[\s\s+]', '', filen
+            )  # make sure we remove the extra spaces.
             logger.fdebug('[FILENAME] filename (remove chars): %s' % filen)
             filen = re.sub('.cbr', '', filen).strip()
             filen = re.sub('.cbz', '', filen).strip()
-            logger.fdebug('[FILENAME] nzbname (\s): %s' % filen)
-            #filen = re.sub('\s', '.', filen)
+            logger.fdebug('[FILENAME] nzbname : %s' % filen)
+            # filen = re.sub('\s', '.', filen)
             logger.fdebug('[FILENAME] end nzbname: %s' % filen)
 
-            if re.sub('.nzb', '', filen.lower()).strip() != re.sub('.nzb', '', nzbname.lower()).strip():
+            if (
+                re.sub('.nzb', '', filen.lower()).strip()
+                != re.sub('.nzb', '', nzbname.lower()).strip()
+            ):
                 alt_nzbname = re.sub('.nzb', '', filen).strip()
-                alt_nzbname = re.sub('[\s+]', ' ', alt_nzbname)
-                alt_nzbname = re.sub('[\s\_]', '.', alt_nzbname)
-                logger.info('filen: %s -- nzbname: %s are not identical. Storing extra value as : %s' % (filen, nzbname, alt_nzbname))
+                alt_nzbname = re.sub(r'[\s+]', ' ', alt_nzbname)
+                alt_nzbname = re.sub(r'[\s\_]', '.', alt_nzbname)
+                logger.info(
+                    'filen: %s -- nzbname: %s are not identical.'
+                    ' Storing extra value as : %s' % (filen, nzbname, alt_nzbname)
+                )
 
-            #make sure the cache directory exists - if not, create it (used for storing nzbs).
+            # make sure the cache directory exists - if not, create it
+            # (used for storing nzbs).
             if os.path.exists(mylar.CONFIG.CACHE_DIR):
                 if mylar.CONFIG.ENFORCE_PERMS:
-                    logger.fdebug('Cache Directory successfully found at : %s. Ensuring proper permissions.' % mylar.CONFIG.CACHE_DIR)
-                    #enforce the permissions here to ensure the lower portion writes successfully
+                    logger.fdebug(
+                        'Cache Directory successfully found at : %s.'
+                        ' Ensuring proper permissions.' % mylar.CONFIG.CACHE_DIR
+                    )
+                    # enforce the permissions here to ensure the lower portion writes
+                    # successfully
                     filechecker.setperms(mylar.CONFIG.CACHE_DIR, True)
                 else:
-                    logger.fdebug('Cache Directory successfully found at : %s' % mylar.CONFIG.CACHE_DIR)
+                    logger.fdebug(
+                        'Cache Directory successfully found at : %s'
+                        % mylar.CONFIG.CACHE_DIR
+                    )
             else:
-                #let's make the dir.
-                logger.fdebug('Could not locate Cache Directory, attempting to create at : %s' % mylar.CONFIG.CACHE_DIR)
+                # let's make the dir.
+                logger.fdebug(
+                    'Could not locate Cache Directory, attempting to create at : %s'
+                    % mylar.CONFIG.CACHE_DIR
+                )
                 try:
                     filechecker.validateAndCreateDirectory(mylar.CONFIG.CACHE_DIR, True)
-                    logger.info('Temporary NZB Download Directory successfully created at: %s' % mylar.CONFIG.CACHE_DIR)
+                    logger.info(
+                        'Temporary NZB Download Directory successfully created at: %s'
+                        % mylar.CONFIG.CACHE_DIR
+                    )
                 except OSError:
                     raise
 
-            #save the nzb grabbed, so we can bypass all the 'send-url' crap.
+            # save the nzb grabbed, so we can bypass all the 'send-url' crap.
             if not nzbname.endswith('.nzb'):
                 nzbname = nzbname + '.nzb'
             nzbpath = os.path.join(mylar.CONFIG.CACHE_DIR, nzbname)
 
             with open(nzbpath, 'wb') as f:
                 for chunk in r.iter_content(chunk_size=1024):
-                    if chunk: # filter out keep-alive new chunks
+                    if chunk:  # filter out keep-alive new chunks
                         f.write(chunk)
                         f.flush()
 
-    #blackhole
+    # blackhole
     sent_to = None
     t_hash = None
-    if mylar.CONFIG.ENABLE_DDL is True and nzbprov == 'ddl':
+    if mylar.CONFIG.ENABLE_DDL is True and nzbprov == 'DDL':
         if all([IssueID is None, IssueArcID is not None]):
             tmp_issueid = IssueArcID
         else:
             tmp_issueid = IssueID
         ggc = getcomics.GC(issueid=tmp_issueid, comicid=ComicID)
-        sendsite = ggc.loadsite(nzbid, link)
+        ggc.loadsite(nzbid, link)
         ddl_it = ggc.parse_downloadresults(nzbid, link)
         if ddl_it['success'] is True:
-            logger.info('Successfully snatched %s from DDL site. It is currently being queued to download in position %s' % (nzbname, mylar.DDL_QUEUE.qsize()))
+            logger.info(
+                'Successfully snatched %s from DDL site. It is currently being queued'
+                ' to download in position %s' % (nzbname, mylar.DDL_QUEUE.qsize())
+            )
         else:
             logger.info('Failed to retrieve %s from the DDL site.' % nzbname)
             return "ddl-fail"
 
         sent_to = "is downloading it directly via DDL"
 
-    elif mylar.USE_BLACKHOLE and all([nzbprov != '32P', nzbprov != 'WWT', nzbprov != 'DEM', nzbprov != 'torznab']):
+    elif mylar.USE_BLACKHOLE and all(
+        [nzbprov != '32P', nzbprov != 'WWT', nzbprov != 'DEM', nzbprov != 'torznab']
+    ):
         logger.fdebug('Using blackhole directory at : %s' % mylar.CONFIG.BLACKHOLE_DIR)
         if os.path.exists(mylar.CONFIG.BLACKHOLE_DIR):
-            #copy the nzb from nzbpath to blackhole dir.
+            # copy the nzb from nzbpath to blackhole dir.
             try:
                 shutil.move(nzbpath, os.path.join(mylar.CONFIG.BLACKHOLE_DIR, nzbname))
             except (OSError, IOError):
-                logger.warn('Failed to move nzb into blackhole directory - check blackhole directory and/or permissions.')
+                logger.warn(
+                    'Failed to move nzb into blackhole directory - check blackhole'
+                    ' directory and/or permissions.'
+                )
                 return "blackhole-fail"
             logger.fdebug('Filename saved to your blackhole as : %s' % nzbname)
-            logger.info('Successfully sent .nzb to your Blackhole directory : %s' % os.path.join(mylar.CONFIG.BLACKHOLE_DIR, nzbname))
+            logger.info(
+                'Successfully sent .nzb to your Blackhole directory : %s'
+                % (os.path.join(mylar.CONFIG.BLACKHOLE_DIR, nzbname))
+            )
             sent_to = "has sent it to your Blackhole Directory"
 
             if mylar.CONFIG.ENABLE_SNATCH_SCRIPT:
@@ -2435,69 +3845,111 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
                     plist = None
                 else:
                     pnumbers = '|'.join(comicinfo[0]['pack_numbers'])
-                    plist= '|'.join(comicinfo[0]['pack_issuelist'])
-                snatch_vars = {'nzbinfo':       {'link':           link,
-                                                 'id':             nzbid,
-                                                 'nzbname':        nzbname,
-                                                 'nzbpath':        nzbpath,
-                                                 'blackhole':      mylar.CONFIG.BLACKHOLE_DIR},
-                               'comicinfo':     {'comicname':      ComicName,
-                                                'volume':         comicinfo[0]['ComicVolume'],
-                                                 'comicid':        ComicID,
-                                                 'issueid':        IssueID,
-                                                 'issuearcid':     IssueArcID,
-                                                 'issuenumber':    IssueNumber,
-                                                 'issuedate':      comicinfo[0]['IssueDate'],
-                                                 'seriesyear':     comyear},
-                               'pack':           comicinfo[0]['pack'],
-                               'pack_numbers':   pnumbers,
-                               'pack_issuelist': plist,
-                               'provider':       nzbprov,
-                               'method':         'nzb',
-                               'clientmode':     'blackhole'}
+                    plist = '|'.join(comicinfo[0]['pack_issuelist'])
+                snatch_vars = {
+                    'nzbinfo': {
+                        'link': link,
+                        'id': nzbid,
+                        'nzbname': nzbname,
+                        'nzbpath': nzbpath,
+                        'blackhole': mylar.CONFIG.BLACKHOLE_DIR,
+                    },
+                    'comicinfo': {
+                        'comicname': ComicName,
+                        'volume': comicinfo[0]['ComicVolume'],
+                        'comicid': ComicID,
+                        'issueid': IssueID,
+                        'issuearcid': IssueArcID,
+                        'issuenumber': IssueNumber,
+                        'issuedate': comicinfo[0]['IssueDate'],
+                        'seriesyear': comyear,
+                    },
+                    'pack': comicinfo[0]['pack'],
+                    'pack_numbers': pnumbers,
+                    'pack_issuelist': plist,
+                    'provider': nzbprov,
+                    'method': 'nzb',
+                    'clientmode': 'blackhole',
+                }
 
-                snatchitup = helpers.script_env('on-snatch',snatch_vars)
+                snatchitup = helpers.script_env('on-snatch', snatch_vars)
                 if snatchitup is True:
                     logger.info('Successfully submitted on-grab script as requested.')
                 else:
-                    logger.info('Could not Successfully submit on-grab script as requested. Please check logs...')
-    #end blackhole
+                    logger.info(
+                        'Could not Successfully submit on-grab script as requested.'
+                        ' Please check logs...'
+                    )
+    # end blackhole
 
-    #torrents (32P & DEM)
-    elif any([nzbprov == '32P', nzbprov == 'WWT', nzbprov == 'DEM', nzbprov == 'torznab']):
+    # torrents (32P & DEM)
+    elif any(
+        [nzbprov == '32P', nzbprov == 'WWT', nzbprov == 'DEM', nzbprov == 'torznab']
+    ):
         logger.fdebug('ComicName: %s' % ComicName)
         logger.fdebug('link: %s' % link)
         logger.fdebug('Torrent Provider: %s' % nzbprov)
 
-        rcheck = rsscheck.torsend2client(ComicName, IssueNumber, comyear, link, nzbprov, nzbid)  #nzbid = hash for usage with public torrents
+        # nzbid = hash for usage with public torrents
+        rcheck = rsscheck.torsend2client(
+            ComicName, IssueNumber, comyear, link, nzbprov, nzbid
+        )
         if rcheck == "fail":
             if mylar.CONFIG.FAILED_DOWNLOAD_HANDLING:
-                logger.error('Unable to send torrent to client. Assuming incomplete link - sending to Failed Handler and continuing search.')
+                logger.error(
+                    'Unable to send torrent to client. Assuming incomplete link -'
+                    ' sending to Failed Handler and continuing search.'
+                )
                 if any([oneoff is True, IssueID is None]):
-                    logger.fdebug('One-off mode was initiated - Failed Download handling for : %s #%s' % (ComicName, IssueNumber))
-                    comicinfo = {"ComicName":   ComicName,
-                                 "IssueNumber": IssueNumber}
+                    logger.fdebug(
+                        'One-off mode was initiated - Failed Download handling for :'
+                        ' %s #%s' % (ComicName, IssueNumber)
+                    )
+                    comicinfo = {"ComicName": ComicName, "IssueNumber": IssueNumber}
                 else:
-                    comicinfo_temp = {"ComicName":     comicinfo[0]['ComicName'],
-                                      "modcomicname":  comicinfo[0]['modcomicname'],
-                                      "IssueNumber":   comicinfo[0]['IssueNumber'],
-                                      "comyear":       comicinfo[0]['comyear']}
+                    comicinfo_temp = {
+                        "ComicName": comicinfo[0]['ComicName'],
+                        "modcomicname": comicinfo[0]['modcomicname'],
+                        "IssueNumber": comicinfo[0]['IssueNumber'],
+                        "comyear": comicinfo[0]['comyear'],
+                    }
                     comicinfo = comicinfo_temp
-                return FailedMark(ComicID=ComicID, IssueID=IssueID, id=nzbid, nzbname=nzbname, prov=nzbprov, oneoffinfo=comicinfo)
+                return FailedMark(
+                    ComicID=ComicID,
+                    IssueID=IssueID,
+                    id=nzbid,
+                    nzbname=nzbname,
+                    prov=nzbprov,
+                    oneoffinfo=comicinfo,
+                )
             else:
-                logger.error('Unable to send torrent - check logs and settings (this would be marked as a BAD torrent if Failed Handling was enabled)')
+                logger.error(
+                    'Unable to send torrent - check logs and settings (this would be'
+                    ' marked as a BAD torrent if Failed Handling was enabled)'
+                )
                 return "torrent-fail"
         else:
-            #start the auto-snatch segway here (if rcheck isn't False, it contains the info of the torrent)
-            #since this is torrentspecific snatch, the vars will be different than nzb snatches.
-            #torrent_info{'folder','name',['total_filesize','label','hash','files','time_started'}
+            """
+            Start the auto-snatch segway here (if rcheck isn't False, it contains the
+            info of the torrent). Since this is torrentspecific snatch, the vars will
+            be different than nzb snatches.
+            torrent_info{'folder','name','total_filesize','label','hash',
+                         'files','time_started'}
+            """
             t_hash = rcheck['hash']
             rcheck.update({'torrent_filename': nzbname})
 
             if any([mylar.USE_RTORRENT, mylar.USE_DELUGE]) and mylar.CONFIG.AUTO_SNATCH:
-                mylar.SNATCHED_QUEUE.put({'issueid': IssueID, 'comicid': ComicID, 'hash': rcheck['hash']})
-            elif any([mylar.USE_RTORRENT, mylar.USE_DELUGE]) and mylar.CONFIG.LOCAL_TORRENT_PP:
-                mylar.SNATCHED_QUEUE.put({'issueid': IssueID, 'comicid': ComicID, 'hash': rcheck['hash']})
+                mylar.SNATCHED_QUEUE.put(
+                    {'issueid': IssueID, 'comicid': ComicID, 'hash': rcheck['hash']}
+                )
+            elif (
+                any([mylar.USE_RTORRENT, mylar.USE_DELUGE])
+                and mylar.CONFIG.LOCAL_TORRENT_PP
+            ):
+                mylar.SNATCHED_QUEUE.put(
+                    {'issueid': IssueID, 'comicid': ComicID, 'hash': rcheck['hash']}
+                )
             else:
                 if mylar.CONFIG.ENABLE_SNATCH_SCRIPT:
                     try:
@@ -2506,60 +3958,74 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
                             plist = None
                         else:
                             if '0-Day Comics Pack' in ComicName:
-                                helpers.lookupthebitches(rcheck['files'], rcheck['folder'], nzbname, nzbid, nzbprov, t_hash, comicinfo[0]['IssueDate'])
+                                helpers.lookupthebitches(
+                                    rcheck['files'],
+                                    rcheck['folder'],
+                                    nzbname,
+                                    nzbid,
+                                    nzbprov,
+                                    t_hash,
+                                    comicinfo[0]['IssueDate'],
+                                )
                                 pnumbers = None
                                 plist = None
                             else:
                                 pnumbers = '|'.join(comicinfo[0]['pack_numbers'])
                                 plist = '|'.join(comicinfo[0]['pack_issuelist'])
-                        snatch_vars = {'comicinfo':       {'comicname':        ComicName,
-                                                           'volume':           comicinfo[0]['ComicVolume'],
-                                                           'issuenumber':      IssueNumber,
-                                                           'issuedate':        comicinfo[0]['IssueDate'],
-                                                           'seriesyear':       comyear,
-                                                           'comicid':          ComicID,
-                                                           'issueid':          IssueID,
-                                                           'issuearcid':       IssueArcID},
-                                       'pack':             comicinfo[0]['pack'],
-                                       'pack_numbers':     pnumbers,
-                                       'pack_issuelist':   plist,
-                                       'provider':         nzbprov,
-                                       'method':           'torrent',
-                                       'clientmode':       rcheck['clientmode'],
-                                       'torrentinfo':      rcheck}
+                        snatch_vars = {
+                            'comicinfo': {
+                                'comicname': ComicName,
+                                'volume': comicinfo[0]['ComicVolume'],
+                                'issuenumber': IssueNumber,
+                                'issuedate': comicinfo[0]['IssueDate'],
+                                'seriesyear': comyear,
+                                'comicid': ComicID,
+                                'issueid': IssueID,
+                                'issuearcid': IssueArcID,
+                            },
+                            'pack': comicinfo[0]['pack'],
+                            'pack_numbers': pnumbers,
+                            'pack_issuelist': plist,
+                            'provider': nzbprov,
+                            'method': 'torrent',
+                            'clientmode': rcheck['clientmode'],
+                            'torrentinfo': rcheck,
+                        }
 
-
-                        snatchitup = helpers.script_env('on-snatch',snatch_vars)
+                        snatchitup = helpers.script_env('on-snatch', snatch_vars)
                         if snatchitup is True:
-                            logger.info('Successfully submitted on-grab script as requested.')
+                            logger.info(
+                                'Successfully submitted on-grab script as requested.'
+                            )
                         else:
-                            logger.info('Could not Successfully submit on-grab script as requested. Please check logs...')
+                            logger.info(
+                                'Could not Successfully submit on-grab script as'
+                                ' requested. Please check logs...'
+                            )
                     except Exception as e:
                         logger.warn('error: %s' % e)
 
         if mylar.USE_WATCHDIR is True:
             if mylar.CONFIG.TORRENT_LOCAL is True:
-                sent_to = "has sent it to your local Watch folder"
+                sent_to = 'has sent it to your local Watch folder'
             else:
-                sent_to = "has sent it to your seedbox Watch folder"
+                sent_to = 'has sent it to your seedbox Watch folder'
         elif mylar.USE_UTORRENT is True:
-            sent_to = "has sent it to your uTorrent client"
+            sent_to = 'has sent it to your uTorrent client'
         elif mylar.USE_RTORRENT is True:
-            sent_to = "has sent it to your rTorrent client"
+            sent_to = 'has sent it to your rTorrent client'
         elif mylar.USE_TRANSMISSION is True:
-            sent_to = "has sent it to your Transmission client"
+            sent_to = 'has sent it to your Transmission client'
         elif mylar.USE_DELUGE is True:
-            sent_to = "has sent it to your Deluge client"
+            sent_to = 'has sent it to your Deluge client'
         elif mylar.USE_QBITTORRENT is True:
-            sent_to = "has sent it to your qBittorrent client"
-    #end torrents
+            sent_to = 'has sent it to your qBittorrent client'
+    # end torrents
 
     else:
-        #SABnzbd / NZBGet
+        # SABnzbd / NZBGet
 
-        #logger.fdebug("link to retrieve via api:" + str(helpers.apiremove(linkapi,'$')))
-
-        #nzb.get
+        # nzb.get
         if mylar.USE_NZBGET:
             ss = nzbget.NZBGet()
             send_to_nzbget = ss.sender(nzbpath)
@@ -2575,7 +4041,10 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
                 elif send_to_nzbget['status'] == 'double-pp':
                     return send_to_nzbget['status']
                 else:
-                    logger.warn('Unable to send nzb file to NZBGet. There was an unknown parameter error.')
+                    logger.warn(
+                        'Unable to send nzb file to NZBGet. There was an unknown'
+                        ' parameter error'
+                    )
                     return "nzbget-fail"
 
             if send_to_nzbget['status'] is True:
@@ -2585,19 +4054,23 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
                 return "nzbget-fail"
             sent_to = "has sent it to your NZBGet"
 
-        #end nzb.get
+        # end nzb.get
 
         elif mylar.USE_SABNZBD:
             sab_params = None
             # let's build the send-to-SAB string now:
             # changed to just work with direct links now...
 
-            #generate the api key to download here and then kill it immediately after.
+            # generate the api key to download here and then kill it immediately after.
             if mylar.DOWNLOAD_APIKEY is None:
-                import hashlib, random
-                mylar.DOWNLOAD_APIKEY = hashlib.sha224(str(random.getrandbits(256)).encode('utf-8')).hexdigest()[0:32]
+                import hashlib
+                import random
 
-            #generate the mylar host address if applicable.
+                mylar.DOWNLOAD_APIKEY = hashlib.sha224(
+                    str(random.getrandbits(256)).encode('utf-8')
+                ).hexdigest()[0:32]
+
+            # generate the mylar host address if applicable.
             if mylar.CONFIG.ENABLE_HTTPS:
                 proto = 'https://'
             else:
@@ -2614,93 +4087,133 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
                     hroot = mylar.CONFIG.HTTP_ROOT
 
             if mylar.LOCAL_IP is None:
-                #if mylar's local, get the local IP using socket.
+                # if mylar's local, get the local IP using socket.
                 try:
                     import socket
+
                     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
                     s.connect(('8.8.8.8', 80))
                     mylar.LOCAL_IP = s.getsockname()[0]
                     s.close()
-                except:
-                    logger.warn('Unable to determine local IP. Defaulting to host address for Mylar provided as : %s' % mylar.CONFIG.HTTP_HOST)
+                except Exception as e:
+                    logger.warn(
+                        'Unable to determine local IP. Defaulting to host address for'
+                        ' Mylar provided as : %s. Error returned: %s'
+                        % (mylar.CONFIG.HTTP_HOST, e)
+                    )
 
             if mylar.CONFIG.HOST_RETURN:
-                #mylar has the return value already provided (easier and will work if it's right)
+                # mylar has the return value already provided
+                # (easier and will work if it's right)
                 if mylar.CONFIG.HOST_RETURN.endswith('/'):
                     mylar_host = mylar.CONFIG.HOST_RETURN
                 else:
                     mylar_host = mylar.CONFIG.HOST_RETURN + '/'
 
             elif mylar.CONFIG.SAB_TO_MYLAR:
-                #if sab & mylar are on different machines, check to see if they are local or external IP's provided for host.
-                if mylar.CONFIG.HTTP_HOST == 'localhost' or mylar.CONFIG.HTTP_HOST == '0.0.0.0' or mylar.CONFIG.HTTP_HOST.startswith('10.') or mylar.CONFIG.HTTP_HOST.startswith('192.') or mylar.CONFIG.HTTP_HOST.startswith('172.'):
-                    #if mylar's local, use the local IP already assigned to LOCAL_IP.
-                    mylar_host = proto + str(mylar.LOCAL_IP) + ':' + str(mylar.CONFIG.HTTP_PORT) + hroot
+                # if sab & mylar are on different machines, check to see if they are
+                # local or external IP's provided for host.
+                if (
+                    mylar.CONFIG.HTTP_HOST == 'localhost'
+                    or mylar.CONFIG.HTTP_HOST == '0.0.0.0'
+                    or mylar.CONFIG.HTTP_HOST.startswith('10.')
+                    or mylar.CONFIG.HTTP_HOST.startswith('192.')
+                    or mylar.CONFIG.HTTP_HOST.startswith('172.')
+                ):
+                    # if mylar's local, use the local IP already assigned to LOCAL_IP.
+                    mylar_host = (
+                        '%s%s:%s%s'
+                        % (proto, mylar.LOCAL_IP, mylar.CONFIG_HTTP_ROOT, hroot)
+                     )
                 else:
                     if mylar.EXT_IP is None:
-                        #if mylar isn't local, get the external IP using pystun.
+                        # if mylar isn't local, get the external IP using pystun.
                         import stun
+
                         sip = mylar.CONFIG.HTTP_HOST
                         port = int(mylar.CONFIG.HTTP_PORT)
                         try:
-                            nat_type, ext_ip, ext_port = stun.get_ip_info(sip,port)
-                            mylar_host = proto + str(ext_ip) + ':' + str(mylar.CONFIG.HTTP_PORT) + hroot
+                            nat_type, ext_ip, ext_port = stun.get_ip_info(sip, port)
+                            mylar_host = (
+                                '%s%s:%s%s'
+                                % (proto, ext_ip, mylar.CONFIG.HTTP_ROOT, hroot)
+                             )
                             mylar.EXT_IP = ext_ip
-                        except:
-                            logger.warn('Unable to retrieve External IP - try using the host_return option in the config.ini.')
-                            mylar_host = proto + str(mylar.CONFIG.HTTP_HOST) + ':' + str(mylar.CONFIG.HTTP_PORT) + hroot
+                        except Exception as e:
+                            logger.warn(
+                                'Unable to retrieve External IP - try using the'
+                                ' host_return option in the config.ini. Error: %s' % e
+                            )
+                            mylar_host = (
+                                '%s%s:%s%s'
+                                % (proto, mylar.CONFIG.HTTP_ROOT,
+                                   mylar.CONFIG.HTTP_ROOT, hroot)
+                            )
                     else:
-                        mylar_host = proto + str(mylar.EXT_IP) + ':' + str(mylar.CONFIG.HTTP_PORT) + hroot
+                        mylar_host = (
+                            '%s%s:%s%s'
+                            % (proto, mylar.EXT_IP, mylar.CONFIG.HTTP_ROOT, hroot)
+                        )
 
             else:
-                #if all else fails, drop it back to the basic host:port and try that.
+                # if all else fails, drop it back to the basic host:port and try that.
                 if mylar.LOCAL_IP is None:
                     tmp_host = mylar.CONFIG.HTTP_HOST
                 else:
                     tmp_host = mylar.LOCAL_IP
-                mylar_host = proto + str(tmp_host) + ':' + str(mylar.CONFIG.HTTP_PORT) + hroot
+                mylar_host = (
+                    proto + str(tmp_host) + ':' + str(mylar.CONFIG.HTTP_PORT) + hroot
+                )
 
+            fileURL = (
+                mylar_host
+                + 'api?apikey='
+                + mylar.DOWNLOAD_APIKEY
+                + '&cmd=downloadNZB&nzbname='
+                + nzbname
+            )
 
-            fileURL = mylar_host + 'api?apikey=' + mylar.DOWNLOAD_APIKEY + '&cmd=downloadNZB&nzbname=' + nzbname
-
-            sab_params = {'apikey':     mylar.CONFIG.SAB_APIKEY,
-                          'mode':       'addurl',
-                          'name':       fileURL,
-                          'cmd':        'downloadNZB',
-                          'nzbname':    nzbname,
-                          'output':     'json'}
+            sab_params = {
+                'apikey': mylar.CONFIG.SAB_APIKEY,
+                'mode': 'addurl',
+                'name': fileURL,
+                'cmd': 'downloadNZB',
+                'nzbname': nzbname,
+                'output': 'json',
+            }
 
             # determine SAB priority
             if mylar.CONFIG.SAB_PRIORITY:
-                #setup the priorities.
-                if mylar.CONFIG.SAB_PRIORITY == "Default": sabpriority = "-100"
-                elif mylar.CONFIG.SAB_PRIORITY == "Low": sabpriority = "-1"
-                elif mylar.CONFIG.SAB_PRIORITY == "Normal": sabpriority = "0"
-                elif mylar.CONFIG.SAB_PRIORITY == "High": sabpriority = "1"
-                elif mylar.CONFIG.SAB_PRIORITY == "Paused": sabpriority = "-2"
+                # setup the priorities.
+                if mylar.CONFIG.SAB_PRIORITY == 'Default':
+                    sabpriority = '-100'
+                elif mylar.CONFIG.SAB_PRIORITY == 'Low':
+                    sabpriority = '-1'
+                elif mylar.CONFIG.SAB_PRIORITY == 'Normal':
+                    sabpriority = '0'
+                elif mylar.CONFIG.SAB_PRIORITY == 'High':
+                    sabpriority = '1'
+                elif mylar.CONFIG.SAB_PRIORITY == 'Paused':
+                    sabpriority = '-2'
             else:
-                #if sab priority isn't selected, default to Normal (0)
-                sabpriority = "0"
+                # if sab priority isn't selected, default to Normal (0)
+                sabpriority = '0'
 
             sab_params['priority'] = sabpriority
 
             # if category is blank, let's adjust
             if mylar.CONFIG.SAB_CATEGORY:
                 sab_params['cat'] = mylar.CONFIG.SAB_CATEGORY
-            #if mylar.CONFIG.POST_PROCESSING: #or mylar.CONFIG.RENAME_FILES:
-            #    if mylar.CONFIG.POST_PROCESSING_SCRIPT:
-            #        #this is relative to the SABnzbd script directory (ie. no path)
-            #        tmpapi = tmpapi + "&script=" + mylar.CONFIG.POST_PROCESSING_SCRIPT
-            #    else:
-            #        tmpapi = tmpapi + "&script=ComicRN.py"
-            #    logger.fdebug("...attaching rename script: " + str(helpers.apiremove(tmpapi, '&')))
-            #final build of send-to-SAB
-            #logger.fdebug("Completed send-to-SAB link: " + str(helpers.apiremove(tmpapi, '&')))
 
             if sab_params is not None:
                 ss = sabnzbd.SABnzbd(sab_params)
                 sendtosab = ss.sender()
-                if all([sendtosab['status'] is True, mylar.CONFIG.SAB_CLIENT_POST_PROCESSING is True]):
+                if all(
+                    [
+                        sendtosab['status'] is True,
+                        mylar.CONFIG.SAB_CLIENT_POST_PROCESSING is True,
+                    ]
+                ):
                     sendtosab['comicid'] = ComicID
                     if IssueID is not None:
                         sendtosab['issueid'] = IssueID
@@ -2712,14 +4225,18 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
                 elif sendtosab['status'] == 'double-pp':
                     return sendtosab['status']
                 elif sendtosab['status'] is False:
-                    return "sab-fail"
+                    return 'sab-fail'
             else:
-                logger.warn('Unable to send nzb file to SABnzbd. There was a parameter error as there are no values present: %s' % sab_params)
+                logger.warn(
+                    'Unable to send nzb file to SABnzbd. There was a parameter error as'
+                    ' there are no values present: %s'
+                    % sab_params
+                )
                 mylar.DOWNLOAD_APIKEY = None
-                return "sab-fail"
+                return 'sab-fail'
 
-            sent_to = "has sent it to your SABnzbd+"
-            logger.info("Successfully sent nzb file to SABnzbd")
+            sent_to = 'has sent it to your SABnzbd+'
+            logger.info('Successfully sent nzb file to SABnzbd')
 
         if mylar.CONFIG.ENABLE_SNATCH_SCRIPT:
             if mylar.USE_NZBGET:
@@ -2734,74 +4251,116 @@ def searcher(nzbprov, nzbname, comicinfo, link, IssueID, ComicID, tmpprov, direc
                 plist = None
             else:
                 pnumbers = '|'.join(comicinfo[0]['pack_numbers'])
-                plist= '|'.join(comicinfo[0]['pack_issuelist'])
-            snatch_vars = {'nzbinfo':        {'link':           link,
-                                              'id':             nzbid,
-                                              'client_id':      client_id,
-                                              'nzbname':        nzbname,
-                                              'nzbpath':        nzbpath},
-                           'comicinfo':      {'comicname':      comicinfo[0]['ComicName'].encode('utf-8'),
-                                              'volume':         comicinfo[0]['ComicVolume'],
-                                              'comicid':        ComicID,
-                                              'issueid':        IssueID,
-                                              'issuearcid':     IssueArcID,
-                                              'issuenumber':    IssueNumber,
-                                              'issuedate':      comicinfo[0]['IssueDate'],
-                                              'seriesyear':     comyear},
-                           'pack':            comicinfo[0]['pack'],
-                           'pack_numbers':    pnumbers,
-                           'pack_issuelist':  plist,
-                           'provider':        nzbprov,
-                           'method':          'nzb',
-                           'clientmode':      clientmode}
+                plist = '|'.join(comicinfo[0]['pack_issuelist'])
+            snatch_vars = {
+                'nzbinfo': {
+                    'link': link,
+                    'id': nzbid,
+                    'client_id': client_id,
+                    'nzbname': nzbname,
+                    'nzbpath': nzbpath,
+                },
+                'comicinfo': {
+                    'comicname': comicinfo[0]['ComicName'].encode('utf-8'),
+                    'volume': comicinfo[0]['ComicVolume'],
+                    'comicid': ComicID,
+                    'issueid': IssueID,
+                    'issuearcid': IssueArcID,
+                    'issuenumber': IssueNumber,
+                    'issuedate': comicinfo[0]['IssueDate'],
+                    'seriesyear': comyear,
+                },
+                'pack': comicinfo[0]['pack'],
+                'pack_numbers': pnumbers,
+                'pack_issuelist': plist,
+                'provider': nzbprov,
+                'method': 'nzb',
+                'clientmode': clientmode,
+            }
 
-            snatchitup = helpers.script_env('on-snatch',snatch_vars)
+            snatchitup = helpers.script_env('on-snatch', snatch_vars)
             if snatchitup is True:
                 logger.info('Successfully submitted on-grab script as requested.')
             else:
-                logger.info('Could not Successfully submit on-grab script as requested. Please check logs...')
+                logger.info(
+                    'Could not Successfully submit on-grab script as requested.'
+                    ' Please check logs...'
+                )
 
-    #nzbid, nzbname, sent_to
+    # nzbid, nzbname, sent_to
     nzbname = re.sub('.nzb', '', nzbname).strip()
 
     return_val = {}
-    return_val = {"nzbid":       nzbid,
-                  "nzbname":     nzbname,
-                  "sent_to":     sent_to,
-                  "SARC":        SARC,
-                  "alt_nzbname": alt_nzbname,
-                  "t_hash":      t_hash}
+    return_val = {
+        "nzbid": nzbid,
+        "nzbname": nzbname,
+        "sent_to": sent_to,
+        "SARC": SARC,
+        "alt_nzbname": alt_nzbname,
+        "t_hash": t_hash,
+    }
 
-    #if it's a directsend link (ie. via a retry).
+    # if it's a directsend link (ie. via a retry).
     if directsend is None:
         return return_val
     else:
         if 'Public Torrents' in tmpprov and any([nzbprov == 'WWT', nzbprov == 'DEM']):
             tmpprov = re.sub('Public Torrents', nzbprov, tmpprov)
-        #update the db on the snatch.
+        # update the db on the snatch.
         if alt_nzbname is None or alt_nzbname == '':
-            logger.fdebug("Found matching comic...preparing to send to Updater with IssueID %s and nzbname of %s [Oneoff:%s]" % (IssueID, nzbname, oneoff))
-            if '[RSS]' in tmpprov: tmpprov = re.sub('\[RSS\]', '', tmpprov).strip()
-            updater.nzblog(IssueID, nzbname, ComicName, SARC=SARC, IssueArcID=IssueArcID, id=nzbid, prov=tmpprov, oneoff=oneoff)
+            logger.fdebug(
+                'Found matching comic...preparing to send to Updater with IssueID %s'
+                ' and nzbname of %s [Oneoff:%s]'
+                % (IssueID, nzbname, oneoff)
+            )
+            if '[RSS]' in tmpprov:
+                tmpprov = re.sub(r'\[RSS\]', '', tmpprov).strip()
+            updater.nzblog(
+                IssueID,
+                nzbname,
+                ComicName,
+                SARC=SARC,
+                IssueArcID=IssueArcID,
+                id=nzbid,
+                prov=tmpprov,
+                oneoff=oneoff,
+            )
         else:
-            logger.fdebug("Found matching comic...preparing to send to Updater with IssueID %s and nzbname of %s [ALTNZBNAME:%s][OneOff:%s]" % (IssueID, nzbname, alt_nzbname, oneoff))
-            if '[RSS]' in tmpprov: tmpprov = re.sub('\[RSS\]', '', tmpprov).strip()
-            updater.nzblog(IssueID, nzbname, ComicName, SARC=SARC, IssueArcID=IssueArcID, id=nzbid, prov=tmpprov, alt_nzbname=alt_nzbname, oneoff=oneoff)
-        #send out notifications for on snatch after the updater incase notification fails (it would bugger up the updater/pp scripts)
+            logger.fdebug(
+                'Found matching comic...preparing to send to Updater with IssueID %s'
+                ' and nzbname of %s [ALTNZBNAME:%s][OneOff:%s]'
+                % (IssueID, nzbname, alt_nzbname, oneoff)
+            )
+            if '[RSS]' in tmpprov:
+                tmpprov = re.sub(r'\[RSS\]', '', tmpprov).strip()
+            updater.nzblog(
+                IssueID,
+                nzbname,
+                ComicName,
+                SARC=SARC,
+                IssueArcID=IssueArcID,
+                id=nzbid,
+                prov=tmpprov,
+                alt_nzbname=alt_nzbname,
+                oneoff=oneoff,
+            )
+        # send out notifications for on snatch after the updater incase notification
+        # fails (it would bugger up the updater/pp scripts)
         notify_snatch(sent_to, ComicName, comyear, IssueNumber, nzbprov, False)
         mylar.TMP_PROV = nzbprov
         return return_val
+
 
 def notify_snatch(sent_to, comicname, comyear, IssueNumber, nzbprov, pack):
     if pack is False:
         snline = 'Issue snatched!'
     else:
         snline = 'Pack snatched!'
- 
+
     if IssueNumber is not None:
         snatched_name = '%s (%s) #%s' % (comicname, comyear, IssueNumber)
     else:
-        snatched_name= '%s (%s)' % (comicname, comyear)
+        snatched_name = '%s (%s)' % (comicname, comyear)
 
     if mylar.CONFIG.PROWL_ENABLED and mylar.CONFIG.PROWL_ONSNATCH:
         logger.info("Sending Prowl notification")
@@ -2810,7 +4369,9 @@ def notify_snatch(sent_to, comicname, comyear, IssueNumber, nzbprov, pack):
     if mylar.CONFIG.PUSHOVER_ENABLED and mylar.CONFIG.PUSHOVER_ONSNATCH:
         logger.info("Sending Pushover notification")
         pushover = notifiers.PUSHOVER()
-        pushover.notify(snline, snatched_nzb=snatched_name, prov=nzbprov, sent_to=sent_to)
+        pushover.notify(
+            snline, snatched_nzb=snatched_name, prov=nzbprov, sent_to=sent_to
+        )
     if mylar.CONFIG.BOXCAR_ENABLED and mylar.CONFIG.BOXCAR_ONSNATCH:
         logger.info("Sending Boxcar notification")
         boxcar = notifiers.BOXCAR()
@@ -2818,7 +4379,13 @@ def notify_snatch(sent_to, comicname, comyear, IssueNumber, nzbprov, pack):
     if mylar.CONFIG.PUSHBULLET_ENABLED and mylar.CONFIG.PUSHBULLET_ONSNATCH:
         logger.info("Sending Pushbullet notification")
         pushbullet = notifiers.PUSHBULLET()
-        pushbullet.notify(snline=snline, snatched=snatched_name, sent_to=sent_to, prov=nzbprov, method='POST')
+        pushbullet.notify(
+            snline=snline,
+            snatched=snatched_name,
+            sent_to=sent_to,
+            prov=nzbprov,
+            method='POST',
+        )
     if mylar.CONFIG.TELEGRAM_ENABLED and mylar.CONFIG.TELEGRAM_ONSNATCH:
         logger.info("Sending Telegram notification")
         telegram = notifiers.TELEGRAM()
@@ -2826,182 +4393,251 @@ def notify_snatch(sent_to, comicname, comyear, IssueNumber, nzbprov, pack):
     if mylar.CONFIG.SLACK_ENABLED and mylar.CONFIG.SLACK_ONSNATCH:
         logger.info("Sending Slack notification")
         slack = notifiers.SLACK()
-        slack.notify("Snatched", snline, snatched_nzb=snatched_name, sent_to=sent_to, prov=nzbprov)
+        slack.notify(
+            "Snatched",
+            snline,
+            snatched_nzb=snatched_name,
+            sent_to=sent_to,
+            prov=nzbprov,
+        )
     if mylar.CONFIG.DISCORD_ENABLED and mylar.CONFIG.DISCORD_ONSNATCH:
         logger.info("Sending Discord notification")
         discord = notifiers.DISCORD()
-        discord.notify("Snatched", snline, snatched_nzb=snatched_name, sent_to=sent_to, prov=nzbprov)
+        discord.notify(
+            "Snatched",
+            snline,
+            snatched_nzb=snatched_name,
+            sent_to=sent_to,
+            prov=nzbprov,
+        )
     if mylar.CONFIG.EMAIL_ENABLED and mylar.CONFIG.EMAIL_ONGRAB:
         logger.info("Sending email notification")
         email = notifiers.EMAIL()
-        email.notify(snline + " - " + snatched_name, "Mylar notification - Snatch", module="[SEARCH]")
+        email.notify(
+            snline + " - " + snatched_name,
+            "Mylar notification - Snatch",
+            module="[SEARCH]",
+        )
 
     return
 
+
 def FailedMark(IssueID, ComicID, id, nzbname, prov, oneoffinfo=None):
-        # Used to pass a failed attempt at sending a download to a client, to the failed handler, and then back again to continue searching.
+    # Used to pass a failed attempt at sending a download to a client, to the failed
+    # handler, and then back again to continue searching.
 
-        from mylar import Failed
+    from mylar import Failed
 
-        FailProcess = Failed.FailedProcessor(issueid=IssueID, comicid=ComicID, id=id, nzb_name=nzbname, prov=prov, oneoffinfo=oneoffinfo)
-        Markit = FailProcess.markFailed()
+    FailProcess = Failed.FailedProcessor(
+        issueid=IssueID,
+        comicid=ComicID,
+        id=id,
+        nzb_name=nzbname,
+        prov=prov,
+        oneoffinfo=oneoffinfo,
+    )
+    FailProcess.markFailed()
 
-        if prov == '32P' or prov == 'Public Torrents': return "torrent-fail"
-        else: return "downloadchk-fail"
+    if prov == '32P' or prov == 'Public Torrents':
+        return "torrent-fail"
+    else:
+        return "downloadchk-fail"
 
-def IssueTitleCheck(issuetitle, watchcomic_split, splitit, splitst, issue_firstword, hyphensplit, orignzb=None):
-        vals = []
-        initialchk = 'ok'
-        isstitle_chk = False
 
-        logger.fdebug("incorrect comic lengths...not a match")
+def IssueTitleCheck(
+    issuetitle,
+    watchcomic_split,
+    splitit,
+    splitst,
+    issue_firstword,
+    hyphensplit,
+    orignzb=None,
+):
+    vals = []
+    isstitle_chk = False
 
-        issuetitle = re.sub('[\-\:\,\?\.]', ' ', str(issuetitle))
-        issuetitle_words = issuetitle.split(None)
-        #issue title comparison here:
-        logger.fdebug('there are %s words in the issue title of : %s' % (len(issuetitle_words), issuetitle))
-        # we minus 1 the splitst since the issue # is included in there.
-        if (splitst - 1) > len(watchcomic_split):
-            logger.fdebug('splitit:' + str(splitit))
-            logger.fdebug('splitst:' + str(splitst))
-            logger.fdebug('len-watchcomic:' + str(len(watchcomic_split)))
-            possibleissue_num = splitit[len(watchcomic_split)] #[splitst]
-            logger.fdebug('possible issue number of : %s' % possibleissue_num)
-            extra_words = splitst - len(watchcomic_split)
-            logger.fdebug('there are %s left over after we remove the series title.' % extra_words)
-            wordcount = 1
-            #remove the series title here so we just have the 'hopefully' issue title
-            for word in splitit:
-                #logger.info('word: ' + str(word))
-                if wordcount > len(watchcomic_split):
-                    #logger.info('wordcount: ' + str(wordcount))
-                    #logger.info('watchcomic_split: ' + str(len(watchcomic_split)))
-                    if wordcount - len(watchcomic_split) == 1:
-                        search_issue_title = word
-                        possibleissue_num = word
-                    else:
-                        search_issue_title += ' ' + word
-                wordcount +=1
+    logger.fdebug("incorrect comic lengths...not a match")
 
-            decit = search_issue_title.split(None)
-            if decit[0].isdigit() and decit[1].isdigit():
-                logger.fdebug('possible decimal - referencing position from original title.')
-                chkme = orignzb.find(decit[0])
-                chkend = orignzb.find(decit[1], chkme + len(decit[0]))
-                chkspot = orignzb[chkme:chkend +1]
-                print(chkme, chkend)
-                print(chkspot)
-                # we add +1 to decit totals in order to account for the '.' that's missing and we assume is there.
-                if len(chkspot) == (len(decit[0]) + len(decit[1]) + 1):
-                    logger.fdebug('lengths match for possible decimal issue.')
-                    if '.' in chkspot:
-                        logger.fdebug('decimal located within : %s' % chkspot)
-                        possibleissue_num = chkspot
-                        splitst = splitst -1  #remove the second numeric as it's a decimal and would add an extra char to
+    issuetitle = re.sub(r'[\-\:\,\?\.]', ' ', str(issuetitle))
+    issuetitle_words = issuetitle.split(None)
+    # issue title comparison here:
+    logger.fdebug(
+        'there are %s words in the issue title of : %s'
+        % (len(issuetitle_words), issuetitle)
+    )
+    # we minus 1 the splitst since the issue # is included in there.
+    if (splitst - 1) > len(watchcomic_split):
+        logger.fdebug('splitit:' + str(splitit))
+        logger.fdebug('splitst:' + str(splitst))
+        logger.fdebug('len-watchcomic:' + str(len(watchcomic_split)))
+        possibleissue_num = splitit[len(watchcomic_split)]  # [splitst]
+        logger.fdebug('possible issue number of : %s' % possibleissue_num)
+        extra_words = splitst - len(watchcomic_split)
+        logger.fdebug(
+            'there are %s left over after we remove the series title.' % extra_words
+        )
+        wordcount = 1
+        # remove the series title here so we just have the 'hopefully' issue title
+        for word in splitit:
+            # logger.info('word: ' + str(word))
+            if wordcount > len(watchcomic_split):
+                # logger.info('wordcount: ' + str(wordcount))
+                # logger.info('watchcomic_split: ' + str(len(watchcomic_split)))
+                if wordcount - len(watchcomic_split) == 1:
+                    search_issue_title = word
+                    possibleissue_num = word
+                else:
+                    search_issue_title += ' ' + word
+            wordcount += 1
 
-            logger.fdebug('search_issue_title is : %s' % search_issue_title)
-            logger.fdebug('possible issue number of : %s' % possibleissue_num)
+        decit = search_issue_title.split(None)
+        if decit[0].isdigit() and decit[1].isdigit():
+            logger.fdebug(
+                'possible decimal - referencing position from original title.'
+            )
+            chkme = orignzb.find(decit[0])
+            chkend = orignzb.find(decit[1], chkme + len(decit[0]))
+            chkspot = orignzb[chkme : chkend + 1]
+            print(chkme, chkend)
+            print(chkspot)
+            # we add +1 to decit totals in order to account for the '.' that's
+            # missing and we assume is there.
+            if len(chkspot) == (len(decit[0]) + len(decit[1]) + 1):
+                logger.fdebug('lengths match for possible decimal issue.')
+                if '.' in chkspot:
+                    logger.fdebug('decimal located within : %s' % chkspot)
+                    possibleissue_num = chkspot
+                    splitst = (
+                        splitst - 1
+                    )  # remove the second numeric it's a decimal & would add extra char
 
-            if hyphensplit is not None and 'of' not in search_issue_title:
-                logger.fdebug('hypen split detected.')
-                try:
-                    issue_start = search_issue_title.find(issue_firstword)
-                    logger.fdebug('located first word of : %s at position : %s' % (issue_firstword,  issue_start))
-                    search_issue_title = search_issue_title[issue_start:]
-                    logger.fdebug('corrected search_issue_title is now : %s' % search_issue_title)
-                except TypeError:
-                    logger.fdebug('invalid parsing detection. Ignoring this result.')
-                    return vals.append({"splitit":  splitit,
-                                        "splitst":  splitst,
-                                        "isstitle_chk": isstitle_chk,
-                                        "status":   "continue"})
-            #now we have the nzb issue title (if it exists), let's break it down further.
-            sit_split = search_issue_title.split(None)
-            watch_split_count = len(issuetitle_words)
-            isstitle_removal = []
-            isstitle_match = 0   #counter to tally % match
-            misword = 0 # counter to tally words that probably don't need to be an 'exact' match.
-            for wsplit in issuetitle_words:
+        logger.fdebug('search_issue_title is : %s' % search_issue_title)
+        logger.fdebug('possible issue number of : %s' % possibleissue_num)
+
+        if hyphensplit is not None and 'of' not in search_issue_title:
+            logger.fdebug('hypen split detected.')
+            try:
+                issue_start = search_issue_title.find(issue_firstword)
+                logger.fdebug(
+                    'located first word of : %s at position : %s'
+                    % (issue_firstword, issue_start)
+                )
+                search_issue_title = search_issue_title[issue_start:]
+                logger.fdebug(
+                    'corrected search_issue_title is now : %s' % search_issue_title
+                )
+            except TypeError:
+                logger.fdebug('invalid parsing detection. Ignoring this result.')
+                return vals.append(
+                    {
+                        "splitit": splitit,
+                        "splitst": splitst,
+                        "isstitle_chk": isstitle_chk,
+                        "status": "continue",
+                    }
+                )
+        # now we have the nzb issue title (if it exists), let's break it down further.
+        sit_split = search_issue_title.split(None)
+        watch_split_count = len(issuetitle_words)
+        isstitle_removal = []
+        isstitle_match = 0  # counter to tally % match
+        misword = (
+            0  # counter to tally words that probably don't need to be an 'exact' match.
+        )
+        for wsplit in issuetitle_words:
+            of_chk = False
+            if wsplit.lower() == 'part' or wsplit.lower() == 'of':
+                if wsplit.lower() == 'of':
+                    of_chk = True
+                logger.fdebug('not worrying about this word : %s' % wsplit)
+                misword += 1
+                continue
+            if wsplit.isdigit() and of_chk is True:
+                logger.fdebug('of %s detected. Ignoring for matching.' % wsplit)
                 of_chk = False
-                if wsplit.lower() == 'part' or wsplit.lower() == 'of':
-                    if wsplit.lower() == 'of':
-                        of_chk = True
-                    logger.fdebug('not worrying about this word : %s' % wsplit)
-                    misword +=1
-                    continue
-                if wsplit.isdigit() and of_chk == True:
-                    logger.fdebug('of %s detected. Ignoring for matching.' % wsplit)
-                    of_chk = False
-                    continue
+                continue
 
-                for sit in sit_split:
-                    logger.fdebug('looking at : %s -TO- %s' % (sit.lower(), wsplit.lower()))
-                    if sit.lower() == 'part':
-                        logger.fdebug('not worrying about this word : %s' % sit)
-                        misword +=1
-                        isstitle_removal.append(sit)
-                        break
-                    elif sit.lower() == wsplit.lower():
-                        logger.fdebug('word match: %s' % sit)
-                        isstitle_match +=1
-                        isstitle_removal.append(sit)
-                        break
-                    else:
-                        try:
-                            if int(sit) == int(wsplit):
-                                logger.fdebug('found matching numeric: %s' % wsplit)
-                                isstitle_match +=1
-                                isstitle_removal.append(sit)
-                                break
-                        except:
-                            pass
+            for sit in sit_split:
+                logger.fdebug('looking at : %s -TO- %s' % (sit.lower(), wsplit.lower()))
+                if sit.lower() == 'part':
+                    logger.fdebug('not worrying about this word : %s' % sit)
+                    misword += 1
+                    isstitle_removal.append(sit)
+                    break
+                elif sit.lower() == wsplit.lower():
+                    logger.fdebug('word match: %s' % sit)
+                    isstitle_match += 1
+                    isstitle_removal.append(sit)
+                    break
+                else:
+                    try:
+                        if int(sit) == int(wsplit):
+                            logger.fdebug('found matching numeric: %s' % wsplit)
+                            isstitle_match += 1
+                            isstitle_removal.append(sit)
+                            break
+                    except Exception:
+                        pass
 
-            logger.fdebug('isstitle_match count : %s' % isstitle_match)
-            if isstitle_match > 0:
-                iss_calc = ((isstitle_match + misword) / watch_split_count) * 100
-                logger.fdebug('iss_calc: %s %s with %s unaccounted for words' % (iss_calc, '%', misword))
-            else:
-                iss_calc = 0
-                logger.fdebug('0 words matched on issue title.')
-            if iss_calc >= 80:    #mylar.ISSUE_TITLEMATCH - user-defined percentage to match against for issue name comparisons.
-                logger.fdebug('>80% match on issue name. If this were implemented, this would be considered a match.')
-                logger.fdebug('we should remove %s words : %s' % (len(isstitle_removal), isstitle_removal))
-                logger.fdebug('Removing issue title from nzb filename to improve matching algorithims.')
-                splitst = splitst - len(isstitle_removal)
-                isstitle_chk = True
-                vals.append({"splitit":  splitit,
-                             "splitst":  splitst,
-                             "isstitle_chk": isstitle_chk,
-                             "possibleissue_num": possibleissue_num,
-                             "isstitle_removal": isstitle_removal,
-                             "status":   'ok'})
-                return vals
-        return
+        logger.fdebug('isstitle_match count : %s' % isstitle_match)
+        if isstitle_match > 0:
+            iss_calc = ((isstitle_match + misword) / watch_split_count) * 100
+            logger.fdebug(
+                'iss_calc: %s %s with %s unaccounted for words'
+                % (iss_calc, '%', misword)
+            )
+        else:
+            iss_calc = 0
+            logger.fdebug('0 words matched on issue title.')
+        if (
+            iss_calc >= 80
+        ):
+            # mylar.ISSUE_TITLEMATCH
+            # user-defined percentage to match against for issue name comparisons.
+            logger.fdebug(
+                '>80% match on issue name. If this were implemented, this would be'
+                ' considered a match.'
+            )
+            logger.fdebug(
+                'we should remove %s words : %s'
+                % (len(isstitle_removal), isstitle_removal)
+            )
+            logger.fdebug(
+                'Removing issue title from nzb filename to improve matching algorithims'
+            )
+            splitst = splitst - len(isstitle_removal)
+            isstitle_chk = True
+            vals.append(
+                {
+                    "splitit": splitit,
+                    "splitst": splitst,
+                    "isstitle_chk": isstitle_chk,
+                    "possibleissue_num": possibleissue_num,
+                    "isstitle_removal": isstitle_removal,
+                    "status": 'ok',
+                }
+            )
+            return vals
+    return
+
 
 def generate_id(nzbprov, link):
-    #logger.fdebug('[%s] generate_id - link: %s' % (nzbprov, link))
+    # logger.fdebug('[%s] generate_id - link: %s' % (nzbprov, link))
     if nzbprov == 'experimental':
-        #id is located after the /download/ portion
+        # id is located after the /download/ portion
         url_parts = urllib.parse.urlparse(link)
         path_parts = url_parts[2].rpartition('/')
         nzbtempid = path_parts[0].rpartition('/')
         nzblen = len(nzbtempid)
-        nzbid = nzbtempid[nzblen -1]
+        nzbid = nzbtempid[nzblen - 1]
     elif nzbprov == '32P':
-        #32P just has the torrent id stored.
+        # 32P just has the torrent id stored.
         nzbid = link
     elif any([nzbprov == 'WWT', nzbprov == 'DEM']):
-        #if nzbprov == 'TPSE':
-        #    #TPSE is magnet links only.
-        #    info_hash = re.findall("urn:btih:([\w]{32,40})", link)[0]
-        #    if len(info_hash) == 32:
-        #        info_hash = b16encode(b32decode(info_hash))
-        #    nzbid = info_hash.upper()
-        #else:
         if 'http' not in link and any([nzbprov == 'WWT', nzbprov == 'DEM']):
             nzbid = link
         else:
-            #for users that already have the cache in place.
+            # for users that already have the cache in place.
             url_parts = urllib.parse.urlparse(link)
             path_parts = url_parts[2].rpartition('/')
             nzbtempid = path_parts[2]
@@ -3013,10 +4649,12 @@ def generate_id(nzbprov, link):
         path_parts = url_parts[2].rpartition('/')
         nzbid = path_parts[0].rsplit('/', 1)[1]
     elif 'newznab' in nzbprov:
-        #if in format of http://newznab/getnzb/<id>.nzb&i=1&r=apikey
-        tmpid = urllib.parse.urlparse(link)[4]  #param 4 is the query string from the url.
+        # if in format of http://newznab/getnzb/<id>.nzb&i=1&r=apikey
+        tmpid = urllib.parse.urlparse(link)[
+            4
+        ]  # param 4 is the query string from the url.
         if 'searchresultid' in tmpid:
-            nzbid = os.path.splitext(link)[0].rsplit('searchresultid=',1)[1]
+            nzbid = os.path.splitext(link)[0].rsplit('searchresultid=', 1)[1]
         elif tmpid == '' or tmpid is None:
             nzbid = os.path.splitext(link)[0].rsplit('/', 1)[1]
         else:
@@ -3025,14 +4663,14 @@ def generate_id(nzbprov, link):
             if nzbid is not None:
                 nzbid = ''.join(nzbid)
         if nzbid is None:
-            #if apikey is passed in as a parameter and the id is in the path
+            # if apikey is passed in as a parameter and the id is in the path
             findend = tmpid.find('&')
             if findend == -1:
                 findend = len(tmpid)
-                nzbid = tmpid[findend+1:].strip()
+                nzbid = tmpid[findend + 1 :].strip()
             else:
                 findend = tmpid.find('apikey=', findend)
-                nzbid = tmpid[findend+1:].strip()
+                nzbid = tmpid[findend + 1 :].strip()
             if '&id' not in tmpid or nzbid == '':
                 tmpid = urllib.parse.urlparse(link)[2]
                 nzbid = tmpid.rsplit('/', 1)[1]

--- a/mylar/weeklypull.py
+++ b/mylar/weeklypull.py
@@ -27,6 +27,7 @@ import time
 import re
 import datetime
 import shutil
+import traceback
 
 import mylar
 from mylar import db, updater, helpers, logger, newpull, importer, mb, locg
@@ -653,76 +654,77 @@ def pullitcheck(comic1off_name=None, comic1off_id=None, forcecheck=None, futurep
                     weekly = myDB.select('SELECT PUBLISHER, ISSUE, COMIC, EXTRA, SHIPDATE FROM future WHERE COMIC LIKE (?) COLLATE NOCASE', [sqlsearch])
                 #cur.execute('SELECT PUBLISHER, ISSUE, COMIC, EXTRA, SHIPDATE FROM weekly WHERE COMIC LIKE (?)', [lines[cnt]])
                 for week in weekly:
-                    if week == None:
-                        break
-                    for nono in not_t:
-                        if nono in week['PUBLISHER']:
-                            #logger.fdebug("nono present")
-                            continue
-                        if nono in week['ISSUE']:
-                            #logger.fdebug("graphic novel/tradeback detected..ignoring.")
-                            continue
-                    for nothere in not_c:
-                        if week['EXTRA'] is not None:
-                            if nothere in week['EXTRA']:
+                    try:
+                        if week == None:
+                            break
+                        for nono in not_t:
+                            if nono in week['PUBLISHER']:
+                                #logger.fdebug("nono present")
                                 continue
-
-                    comicnm = week['COMIC']
-                    dyn_comicnm = week['DynamicName']
-                    dyn_watchnm = dynamic_name
-                    logger.fdebug("comparing" + comicnm + "..to.." + unlines[cnt].upper())
-                    watchcomic = unlines[cnt]
-
-                    logger.fdebug("watchcomic : " + watchcomic)  # / mod :" + str(modwatchcomic))
-                    logger.fdebug("comicnm : " + comicnm) # / mod :" + str(modcomicnm))
-
-                    if dyn_comicnm == dyn_watchnm:
-                        if mylar.CONFIG.ANNUALS_ON:
-                            if 'annual' in watchcomic.lower() and 'annual' not in comicnm.lower():
-                                logger.fdebug('Annual detected in issue, but annuals are not enabled and no series match in wachlist.')
+                            if nono in week['ISSUE']:
+                                #logger.fdebug("graphic novel/tradeback detected..ignoring.")
                                 continue
-                            else:
-                                #(annual in comicnm & in watchcomic) or (annual in comicnm & not in watchcomic)(with annuals on) = match.
-                                pass
-                        else:
-                            #annuals off
-                            if ('annual' in comicnm.lower() and 'annual' not in watchcomic.lower()) or ('annual' in watchcomic.lower() and 'annual' not in comicnm.lower()):
-                                logger.fdebug('Annual detected in issue, but annuals are not enabled and no series match in wachlist.')
-                                continue
-                            else:
-                                #annual in comicnm & in watchcomic (with annuals off) = match.
-                                pass
-                        logger.fdebug("matched on:" + comicnm + "..." + watchcomic.upper())
+                        for nothere in not_c:
+                            if week['EXTRA'] is not None:
+                                if nothere in week['EXTRA']:
+                                    continue
+
+                        comicnm = week['COMIC']
+                        dyn_comicnm = week['DynamicName']
+                        dyn_watchnm = dynamic_name
+                        logger.fdebug("comparing" + comicnm + "..to.." + unlines[cnt].upper())
                         watchcomic = unlines[cnt]
-                    else:
-                        continue
 
+                        logger.fdebug("watchcomic : " + watchcomic)  # / mod :" + str(modwatchcomic))
+                        logger.fdebug("comicnm : " + comicnm) # / mod :" + str(modcomicnm))
 
-                    if ("NA" not in week['ISSUE']) and ("HC" not in week['ISSUE']):
-                        if week['EXTRA'] is not None and any(["COMBO PACK" in week['EXTRA'],"2ND PTG" in week['EXTRA'], "3RD PTG" in week['EXTRA']]):
-                            continue
+                        if dyn_comicnm == dyn_watchnm:
+                            if mylar.CONFIG.ANNUALS_ON:
+                                if 'annual' in watchcomic.lower() and 'annual' not in comicnm.lower():
+                                    logger.fdebug('Annual detected in issue, but annuals are not enabled and no series match in wachlist.')
+                                    continue
+                                else:
+                                    #(annual in comicnm & in watchcomic) or (annual in comicnm & not in watchcomic)(with annuals on) = match.
+                                    pass
+                            else:
+                                #annuals off
+                                if ('annual' in comicnm.lower() and 'annual' not in watchcomic.lower()) or ('annual' in watchcomic.lower() and 'annual' not in comicnm.lower()):
+                                    logger.fdebug('Annual detected in issue, but annuals are not enabled and no series match in wachlist.')
+                                    continue
+                                else:
+                                    #annual in comicnm & in watchcomic (with annuals off) = match.
+                                    pass
+                            logger.fdebug("matched on:" + comicnm + "..." + watchcomic.upper())
+                            watchcomic = unlines[cnt]
                         else:
-                                    #this all needs to get redone, so the ability to compare issue dates can be done systematically.
-                                    #Everything below should be in it's own function - at least the callable sections - in doing so, we can
-                                    #then do comparisons when two titles of the same name exist and are by definition 'current'. Issue date comparisons
-                                    #would identify the difference between two #1 titles within the same series year, but have different publishing dates.
-                                    #Wolverine (2013) & Wolverine (2014) are good examples of this situation.
-                                    #of course initially, the issue data for the newer series wouldn't have any issue data associated with it so it would be
-                                    #a null value, but given that the 2013 series (as an example) would be from 2013-05-01, it obviously wouldn't be a match to
-                                    #the current date & year (2014). Throwing out that, we could just assume that the 2014 would match the #1.
+                            continue
 
-                                    #get the issue number of the 'weeklypull' series.
-                                    #load in the actual series issue number's store-date (not publishing date)
-                                    #---use a function to check db, then return the results in a tuple/list to avoid db locks.
-                                    #if the store-date is >= weeklypull-list date then continue processing below.
-                                    #if the store-date is <= weeklypull-list date then break.
-                                    ### week['ISSUE']  #issue # from pullist
-                                    ### week['SHIPDATE']  #weeklypull-list date
-                                    ### comicid[cnt] #comicid of matched series
 
-                                    ## if it's a futurepull, the dates get mixed up when two titles exist of the same name
-                                    ## ie. Wolverine-2011 & Wolverine-2014
-                                    ## we need to set the compare date to today's date ( Now() ) in this case.
+                        if ("NA" not in week['ISSUE']) and ("HC" not in week['ISSUE']):
+                            if week['EXTRA'] is not None and any(["COMBO PACK" in week['EXTRA'],"2ND PTG" in week['EXTRA'], "3RD PTG" in week['EXTRA']]):
+                                continue
+                            else:
+                                #this all needs to get redone, so the ability to compare issue dates can be done systematically.
+                                #Everything below should be in it's own function - at least the callable sections - in doing so, we can
+                                #then do comparisons when two titles of the same name exist and are by definition 'current'. Issue date comparisons
+                                #would identify the difference between two #1 titles within the same series year, but have different publishing dates.
+                                #Wolverine (2013) & Wolverine (2014) are good examples of this situation.
+                                #of course initially, the issue data for the newer series wouldn't have any issue data associated with it so it would be
+                                #a null value, but given that the 2013 series (as an example) would be from 2013-05-01, it obviously wouldn't be a match to
+                                #the current date & year (2014). Throwing out that, we could just assume that the 2014 would match the #1.
+                                #get the issue number of the 'weeklypull' series.
+                                #load in the actual series issue number's store-date (not publishing date)
+                                #---use a function to check db, then return the results in a tuple/list to avoid db locks.
+                                #if the store-date is >= weeklypull-list date then continue processing below.
+                                #if the store-date is <= weeklypull-list date then break.
+                                ### week['ISSUE']  #issue # from pullist
+                                ### week['SHIPDATE']  #weeklypull-list date
+                                ### comicid[cnt] #comicid of matched series
+
+                                ## if it's a futurepull, the dates get mixed up when two titles exist of the same name
+                                ## ie. Wolverine-2011 & Wolverine-2014
+                                ## we need to set the compare date to today's date ( Now() ) in this case.
+                                pass
                             if futurepull:
                                 usedate = datetime.datetime.now().strftime('%Y%m%d')  #convert to yyyymmdd
                             else:
@@ -799,7 +801,7 @@ def pullitcheck(comic1off_name=None, comic1off_id=None, forcecheck=None, futurep
                                     ComicIssue = str(watchfndiss[tot -1])
                                 ComicDate = str(week['SHIPDATE'])
                                 logger.fdebug("Watchlist hit for : " + ComicName + " ISSUE: " + str(watchfndiss[tot -1]))
- 
+
                                 # here we add to comics.latest
                                 updater.latest_update(ComicID=ComicID, LatestIssue=ComicIssue, LatestDate=ComicDate)
                                 # here we add to upcoming table...
@@ -824,7 +826,34 @@ def pullitcheck(comic1off_name=None, comic1off_id=None, forcecheck=None, futurep
                                     updater.weekly_update(ComicName=week['COMIC'], IssueNumber=ComicIssue, CStatus=cstatus, CID=cstatusid, weeknumber=mylar.CURRENT_WEEKNUMBER, year=mylar.CURRENT_YEAR, altissuenumber=altissuenum)
                                 else:
                                     updater.weekly_update(ComicName=week['COMIC'], IssueNumber=ComicIssue, CStatus=date_downloaded, CID=cstatusid, weeknumber=mylar.CURRENT_WEEKNUMBER, year=mylar.CURRENT_YEAR, altissuenumber=altissuenum)
-                    break
+                        break
+
+                    except Exception as err:
+                        exc_type, exc_value, exc_tb = sys.exc_info()
+                        filename, line_num, func_name, err_text = traceback.extract_tb(exc_tb)[-1]
+                        tracebackline = traceback.format_exc()
+
+                        except_line = {'exc_type': exc_type,
+                                       'exc_value': exc_value,
+                                       'exc_tb': exc_tb,
+                                       'filename': filename,
+                                       'line_num': line_num,
+                                       'func_name': func_name,
+                                       'err': str(err),
+                                       'err_text': err_text,
+                                       'traceback': tracebackline,
+                                       'comicname': None,
+                                       'issuenumber': None,
+                                       'seriesyear': None,
+                                       'issueid': None,
+                                       'comicid': None,
+                                       'mode': None,
+                                       'booktype': None}
+
+                        helpers.log_that_exception(except_line)
+
+                        # log it regardless..
+                        logger.exception(tracebackline)
                 cnt-=1
 
         logger.fdebug("There are " + str(otot) + " comics this week to get!")
@@ -951,250 +980,276 @@ def new_pullcheck(weeknumber, pullyear, comic1off_name=None, comic1off_id=None, 
             # this is to pick up new #1 annuals that don't exist in the db yet, and won't until a refresh of the series happens.
             pass
         for week in weekly:
-            #logger.fdebug('week: %s [%s]' % (week['ComicName'], week['comicid']))
-            idmatch = None
-            annualidmatch = None
-            namematch = None
-            if week is None:
-                break
-            idmatch = [x for x in weeklylist if week['comicid'] is not None and int(x['ComicID']) == int(week['comicid'])]
-            if mylar.CONFIG.ANNUALS_ON is True:
-                annualidmatch = [x for x in weeklylist if week['comicid'] is not None and ([xa for xa in x['AnnualIDs'] if int(xa['ComicID']) == int(week['comicid'])])]
-                if not annualidmatch:
-                    annualidmatch = [x for x in weeklylist if week['annuallink'] is not None and (int(x['ComicID']) == int(week['annuallink']))]
-            #The above will auto-match against ComicID if it's populated on the pullsite, otherwise do name-matching.
-            namematch = [ab for ab in weeklylist if ab['DynamicName'] == week['dynamicname']]
-            #logger.fdebug('rowid: ' + str(week['rowid']))
-            #logger.fdebug('idmatch: ' + str(idmatch))
-            #logger.fdebug('annualidmatch: ' + str(annualidmatch))
-            #logger.fdebug('namematch: ' + str(namematch))
-            if any([idmatch,namematch,annualidmatch]):
-                if idmatch and not annualidmatch:
-                    comicname = idmatch[0]['ComicName'].strip()
-                    latestiss = idmatch[0]['latestIssue'].strip()
-                    comicid = idmatch[0]['ComicID'].strip()
-                    logger.fdebug('[WEEKLY-PULL-ID] Series Match to ID --- ' + comicname + ' [' + comicid + ']')
-                elif annualidmatch:
-                    try:
-                        if 'annual' in week['ComicName'].lower():
-                            comicname = annualidmatch[0]['AnnualIDs'][0]['ComicName'].strip()
-                        else:
+            try:
+                #logger.fdebug('week: %s [%s]' % (week['ComicName'], week['comicid']))
+                idmatch = None
+                annualidmatch = None
+                namematch = None
+                if week is None:
+                    break
+                idmatch = [x for x in weeklylist if week['comicid'] is not None and int(x['ComicID']) == int(week['comicid'])]
+                if mylar.CONFIG.ANNUALS_ON is True:
+                    annualidmatch = [x for x in weeklylist if week['comicid'] is not None and ([xa for xa in x['AnnualIDs'] if int(xa['ComicID']) == int(week['comicid'])])]
+                    if not annualidmatch:
+                        annualidmatch = [x for x in weeklylist if week['annuallink'] is not None and (int(x['ComicID']) == int(week['annuallink']))]
+                #The above will auto-match against ComicID if it's populated on the pullsite, otherwise do name-matching.
+                namematch = [ab for ab in weeklylist if ab['DynamicName'] == week['dynamicname']]
+                #logger.fdebug('rowid: ' + str(week['rowid']))
+                #logger.fdebug('idmatch: ' + str(idmatch))
+                #logger.fdebug('annualidmatch: ' + str(annualidmatch))
+                #logger.fdebug('namematch: ' + str(namematch))
+                if any([idmatch,namematch,annualidmatch]):
+                    if idmatch and not annualidmatch:
+                        comicname = idmatch[0]['ComicName'].strip()
+                        latestiss = idmatch[0]['latestIssue'].strip()
+                        comicid = idmatch[0]['ComicID'].strip()
+                        logger.fdebug('[WEEKLY-PULL-ID] Series Match to ID --- ' + comicname + ' [' + comicid + ']')
+                    elif annualidmatch:
+                        try:
+                            if 'annual' in week['ComicName'].lower():
+                                comicname = annualidmatch[0]['AnnualIDs'][0]['ComicName'].strip()
+                            else:
+                                comicname = week['ComicName']
+                        except:
                             comicname = week['ComicName']
-                    except:
-                        comicname = week['ComicName']
-                    latestiss = annualidmatch[0]['latestIssue'].strip()
-                    if mylar.CONFIG.ANNUALS_ON:
-                        comicid = annualidmatch[0]['ComicID'].strip()
+                        latestiss = annualidmatch[0]['latestIssue'].strip()
+                        if mylar.CONFIG.ANNUALS_ON:
+                            comicid = annualidmatch[0]['ComicID'].strip()
+                        else:
+                            comicid = annualidmatch[0]['AnnualIDs'][0]['ComicID'].strip()
+                        logger.fdebug('[WEEKLY-PULL-ANNUAL] Series Match to ID --- ' + comicname + ' [' + comicid + ']')
                     else:
-                        comicid = annualidmatch[0]['AnnualIDs'][0]['ComicID'].strip()
-                    logger.fdebug('[WEEKLY-PULL-ANNUAL] Series Match to ID --- ' + comicname + ' [' + comicid + ']')
-                else:
-                    #if it's a name metch, it means that CV hasn't been populated yet with the necessary data
-                    #do a quick issue check to see if the next issue number is in sequence and not a #1, or like #900
-                    latestiss = namematch[0]['latestIssue'].strip()
+                        #if it's a name metch, it means that CV hasn't been populated yet with the necessary data
+                        #do a quick issue check to see if the next issue number is in sequence and not a #1, or like #900
+                        latestiss = namematch[0]['latestIssue'].strip()
+                        try:
+                            diff = int(week['Issue']) - int(latestiss)
+                        except ValueError as e:
+                            logger.warn('[WEEKLY-PULL] Invalid issue number detected. Skipping this entry for the time being.')
+                            continue
+                        if diff >= 0 and diff < 3:
+                            comicname = namematch[0]['ComicName'].strip()
+                            comicid = namematch[0]['ComicID'].strip()
+                            logger.fdebug('[WEEKLY-PULL-NAME] Series Match to Name --- ' + comicname + ' [' + comicid + ']')
+                        else:
+                            logger.fdebug('[WEEKLY-PULL] Series ID:' + namematch[0]['ComicID'] + ' not a match based on issue number comparison [LatestIssue:' + latestiss + '][MatchIssue:' + week['Issue'] + ']')
+                            continue
+
+                    date_downloaded = None
+                    todaydate = datetime.datetime.today()
                     try:
-                        diff = int(week['Issue']) - int(latestiss)
-                    except ValueError as e:
-                        logger.warn('[WEEKLY-PULL] Invalid issue number detected. Skipping this entry for the time being.')
-                        continue
-                    if diff >= 0 and diff < 3:
-                        comicname = namematch[0]['ComicName'].strip()
-                        comicid = namematch[0]['ComicID'].strip()
-                        logger.fdebug('[WEEKLY-PULL-NAME] Series Match to Name --- ' + comicname + ' [' + comicid + ']')
+                        ComicDate = str(week['shipdate'])
+                    except TypeError as e:
+                        ComicDate = todaydate.strftime('%Y-%m-%d')
+                        logger.fdebug('[WEEKLY-PULL] Invalid Cover date. Forcing to weekly pull date of : ' + str(ComicDate))
+
+                    if week['issueid'] is not None:
+                        logger.fdebug('[WEEKLY-PULL] Issue Match to ID --- ' + comicname + ' #' + str(week['issue']) + '[' + comicid + '/' + week['issueid'] + ']')
+                        issueid = week['issueid']
                     else:
-                        logger.fdebug('[WEEKLY-PULL] Series ID:' + namematch[0]['ComicID'] + ' not a match based on issue number comparison [LatestIssue:' + latestiss + '][MatchIssue:' + week['Issue'] + ']')
-                        continue
+                        issueid = None
 
-                date_downloaded = None
-                todaydate = datetime.datetime.today()
-                try:
-                    ComicDate = str(week['shipdate'])
-                except TypeError as e:
-                    ComicDate = todaydate.strftime('%Y-%m-%d')
-                    logger.fdebug('[WEEKLY-PULL] Invalid Cover date. Forcing to weekly pull date of : ' + str(ComicDate))
+                        if 'annual' in comicname.lower():
+                            chktype = 'annual'
+                        else:
+                            chktype = 'series'
 
-                if week['issueid'] is not None:
-                    logger.fdebug('[WEEKLY-PULL] Issue Match to ID --- ' + comicname + ' #' + str(week['issue']) + '[' + comicid + '/' + week['issueid'] + ']')
-                    issueid = week['issueid']
-                else:
-                    issueid = None
-  
-                    if 'annual' in comicname.lower():
-                        chktype = 'annual'
-                    else:
-                        chktype = 'series'
+                        datevalues = loaditup(comicname, comicid, week['issue'], chktype)
+                        logger.fdebug('datevalues: ' + str(datevalues))
 
-                    datevalues = loaditup(comicname, comicid, week['issue'], chktype)
-                    logger.fdebug('datevalues: ' + str(datevalues))
+                        usedate = re.sub("[^0-9]", "", ComicDate).strip()
+                        if datevalues == 'no results':
+                            if week['issue'].isdigit() == False and '.' not in week['issue']:
+                                altissuenum = re.sub("[^0-9]", "", week['issue'])  # carry this through to get added to db later if matches
+                                logger.fdebug('altissuenum is: ' + str(altissuenum))
+                                altvalues = loaditup(comicname, comicid, altissuenum, chktype)
+                                if altvalues == 'no results':
+                                    logger.fdebug('No alternate Issue numbering - something is probably wrong somewhere.')
+                                    continue
 
-                    usedate = re.sub("[^0-9]", "", ComicDate).strip()
-                    if datevalues == 'no results':
-                        if week['issue'].isdigit() == False and '.' not in week['issue']:
-                            altissuenum = re.sub("[^0-9]", "", week['issue'])  # carry this through to get added to db later if matches
-                            logger.fdebug('altissuenum is: ' + str(altissuenum))
-                            altvalues = loaditup(comicname, comicid, altissuenum, chktype)
-                            if altvalues == 'no results':
-                                logger.fdebug('No alternate Issue numbering - something is probably wrong somewhere.')
-                                continue
-
-                            validcheck = checkthis(altvalues[0]['issuedate'], altvalues[0]['status'], usedate)
-                            if validcheck == False:
+                                validcheck = checkthis(altvalues[0]['issuedate'], altvalues[0]['status'], usedate)
+                                if validcheck == False:
+                                    if date_downloaded is None:
+                                        continue
+                            if chktype == 'series':
+                                latest_int = helpers.issuedigits(latestiss)
+                                weekiss_int = helpers.issuedigits(week['issue'])
+                                logger.fdebug('comparing ' + str(latest_int) + ' to ' + str(weekiss_int))
+                                if (latest_int > weekiss_int) and (latest_int != 0 or weekiss_int != 0):
+                                    logger.fdebug(str(week['issue']) + ' should not be the next issue in THIS volume of the series.')
+                                    logger.fdebug('it should be either greater than ' + latestiss + ' or an issue #0')
+                                    continue
+                        else:
+                            logger.fdebug('issuedate:' + str(datevalues[0]['issuedate']))
+                            logger.fdebug('status:' + str(datevalues[0]['status']))
+                            datestatus = datevalues[0]['status']
+                            validcheck = checkthis(datevalues[0]['issuedate'], datestatus, usedate)
+                            if validcheck == True:
+                                if datestatus != 'Downloaded' and datestatus != 'Archived':
+                                    pass
+                                else:
+                                    logger.fdebug('Issue #' + str(week['issue']) + ' already downloaded.')
+                                    date_downloaded = datestatus
+                            else:
                                 if date_downloaded is None:
                                     continue
-                        if chktype == 'series':
-                            latest_int = helpers.issuedigits(latestiss)
-                            weekiss_int = helpers.issuedigits(week['issue'])
-                            logger.fdebug('comparing ' + str(latest_int) + ' to ' + str(weekiss_int))
-                            if (latest_int > weekiss_int) and (latest_int != 0 or weekiss_int != 0):
-                                logger.fdebug(str(week['issue']) + ' should not be the next issue in THIS volume of the series.')
-                                logger.fdebug('it should be either greater than ' + x['latestIssue'] + ' or an issue #0')
-                                continue
-                    else:
-                        logger.fdebug('issuedate:' + str(datevalues[0]['issuedate']))
-                        logger.fdebug('status:' + str(datevalues[0]['status']))
-                        datestatus = datevalues[0]['status']
-                        validcheck = checkthis(datevalues[0]['issuedate'], datestatus, usedate)
-                        if validcheck == True:
-                            if datestatus != 'Downloaded' and datestatus != 'Archived':
-                                pass
-                            else:
-                                logger.fdebug('Issue #' + str(week['issue']) + ' already downloaded.')
-                                date_downloaded = datestatus
-                        else:
-                            if date_downloaded is None:
-                                continue
 
-                logger.fdebug("Watchlist hit for : " + week['ComicName'] + " #: " + str(week['issue']))
-                if mylar.CURRENT_WEEKNUMBER is None:
-                    mylar.CURRENT_WEEKNUMBER = todaydate.strftime("%U")
+                    logger.fdebug("Watchlist hit for : " + week['ComicName'] + " #: " + str(week['issue']))
+                    if mylar.CURRENT_WEEKNUMBER is None:
+                        mylar.CURRENT_WEEKNUMBER = todaydate.strftime("%U")
 
-#                if int(mylar.CURRENT_WEEKNUMBER) == int(weeknumber):
-                # here we add to comics.latest
-                updater.latest_update(ComicID=comicid, LatestIssue=week['issue'], LatestDate=ComicDate)
-                # here we add to upcoming table...
-                statusupdate = updater.upcoming_update(ComicID=comicid, ComicName=comicname, IssueNumber=week['issue'], IssueDate=ComicDate, forcecheck=forcecheck, weekinfo={'weeknumber':weeknumber,'year':pullyear})
-                logger.fdebug('statusupdate: ' + str(statusupdate))
+#                   if int(mylar.CURRENT_WEEKNUMBER) == int(weeknumber):
+                    # here we add to comics.latest
+                    updater.latest_update(ComicID=comicid, LatestIssue=week['issue'], LatestDate=ComicDate)
+                    # here we add to upcoming table...
+                    statusupdate = updater.upcoming_update(ComicID=comicid, ComicName=comicname, IssueNumber=week['issue'], IssueDate=ComicDate, forcecheck=forcecheck, weekinfo={'weeknumber':weeknumber,'year':pullyear})
+                    logger.fdebug('statusupdate: ' + str(statusupdate))
 
-                # here we update status of weekly table...
-                try:
-                    if statusupdate is not None:
-                        cstatusid = []
-                        cstatus = statusupdate['Status']
-                        cstatusid = {"ComicID": statusupdate['ComicID'],
-                                     "IssueID": statusupdate['IssueID']}
-                    else:
-                        cstatus = None
-                        cstatusid = None
-                except:
-                    cstatusid = None
-                    cstatus = None
-
-                logger.fdebug('date_downloaded: ' + str(date_downloaded))
-                controlValue = {"rowid": int(week['rowid'])}
-                if any([(idmatch and not namematch),(idmatch and annualidmatch and namematch),(annualidmatch and not namematch),(annualidmatch or idmatch and not namematch)]):
-                    if annualidmatch:
-                        newValue = {"ComicID":       annualidmatch[0]['ComicID']}
-                    else:
-                        #if it matches to id, but not name - consider this an alternate and use the cv name and update based on ID so we don't get duplicates
-                        newValue = {"ComicID":       cstatusid['ComicID']}
-
-                    newValue['COMIC'] = comicname
-                    newValue['ISSUE'] = week['issue']
-                    newValue['WEEKNUMBER'] = int(weeknumber)
-                    newValue['YEAR'] = pullyear
-
-                    if issueid:
-                        newValue['IssueID'] = issueid
-
-                else:
-                    newValue = {"ComicID":       comicid,
-                                "COMIC":         week['ComicName'],
-                                "ISSUE":         week['issue'],
-                                "WEEKNUMBER":    int(weeknumber),
-                                "YEAR":          pullyear}
-
-                #logger.fdebug('controlValue:' + str(controlValue))
-
-                if not issueid:
+                    # here we update status of weekly table...
                     try:
-                        if cstatusid['IssueID']:
-                            newValue['IssueID'] = cstatusid['IssueID']
+                        if statusupdate is not None:
+                            cstatusid = []
+                            cstatus = statusupdate['Status']
+                            cstatusid = {"ComicID": statusupdate['ComicID'],
+                                         "IssueID": statusupdate['IssueID']}
                         else:
-                            cidissueid = None
+                            cstatus = None
+                            cstatusid = None
                     except:
-                        cidissueid = None
+                        cstatusid = None
+                        cstatus = None
 
+                    logger.fdebug('date_downloaded: ' + str(date_downloaded))
+                    controlValue = {"rowid": int(week['rowid'])}
+                    if any([(idmatch and not namematch),(idmatch and annualidmatch and namematch),(annualidmatch and not namematch),(annualidmatch or idmatch and not namematch)]):
+                        if annualidmatch:
+                            newValue = {"ComicID":       annualidmatch[0]['ComicID']}
+                        else:
+                            #if it matches to id, but not name - consider this an alternate and use the cv name and update based on ID so we don't get duplicates
+                            newValue = {"ComicID":       cstatusid['ComicID']}
 
-                #logger.fdebug('cstatus:' + str(cstatus))
-                if any([date_downloaded, cstatus]):
-                    if date_downloaded:
-                        cst = date_downloaded
+                        newValue['COMIC'] = comicname
+                        newValue['ISSUE'] = week['issue']
+                        newValue['WEEKNUMBER'] = int(weeknumber)
+                        newValue['YEAR'] = pullyear
+
+                        if issueid:
+                            newValue['IssueID'] = issueid
+
                     else:
-                        cst = cstatus
-                    newValue['Status'] = cst
-                else:
-                    if mylar.CONFIG.AUTOWANT_UPCOMING:
-                        newValue['Status'] = 'Wanted'
+                        newValue = {"ComicID":       comicid,
+                                    "COMIC":         week['ComicName'],
+                                    "ISSUE":         week['issue'],
+                                    "WEEKNUMBER":    int(weeknumber),
+                                    "YEAR":          pullyear}
+
+                    #logger.fdebug('controlValue:' + str(controlValue))
+
+                    if not issueid:
+                        try:
+                            if cstatusid['IssueID']:
+                                newValue['IssueID'] = cstatusid['IssueID']
+                            else:
+                                cidissueid = None
+                        except:
+                            cidissueid = None
+
+
+                    #logger.fdebug('cstatus:' + str(cstatus))
+                    if any([date_downloaded, cstatus]):
+                        if date_downloaded:
+                            cst = date_downloaded
+                        else:
+                            cst = cstatus
+                        newValue['Status'] = cst
                     else:
-                        newValue['Status'] = 'Skipped'
+                        if mylar.CONFIG.AUTOWANT_UPCOMING:
+                            newValue['Status'] = 'Wanted'
+                        else:
+                            newValue['Status'] = 'Skipped'
 
 
-                #setting this here regardless, as it will be a match for a watchlist hit at this point anyways - so link it here what's availalbe.
-                #logger.fdebug('newValue:' + str(newValue))
-                myDB.upsert("weekly", newValue, controlValue)
+                    #setting this here regardless, as it will be a match for a watchlist hit at this point anyways - so link it here what's availalbe.
+                    #logger.fdebug('newValue:' + str(newValue))
+                    myDB.upsert("weekly", newValue, controlValue)
 
-                #if the issueid exists on the pull, but not in the series issue list, we need to forcibly refresh the series so it's in line
-                if issueid:
-                    #logger.info('issue id check passed.')
-                    if annualidmatch:
-                        isschk = myDB.selectone('SELECT * FROM annuals where IssueID=?', [issueid]).fetchone()
-                    else:
-                        isschk = myDB.selectone('SELECT * FROM issues where IssueID=?', [issueid]).fetchone()
+                    #if the issueid exists on the pull, but not in the series issue list, we need to forcibly refresh the series so it's in line
+                    if issueid:
+                        #logger.info('issue id check passed.')
+                        if annualidmatch:
+                            isschk = myDB.selectone('SELECT * FROM annuals where IssueID=?', [issueid]).fetchone()
+                        else:
+                            isschk = myDB.selectone('SELECT * FROM issues where IssueID=?', [issueid]).fetchone()
 
-                    if isschk is None:
-                        isschk = myDB.selectone('SELECT * FROM annuals where IssueID=?', [issueid]).fetchone()
                         if isschk is None:
-                            logger.fdebug('[WEEKLY-PULL] Forcing a refresh of the series to ensure it is current [' + str(comicid) +'].')
-                            anncid = None
-                            seriesyear = None
-                            try:
-                                if all([mylar.CONFIG.ANNUALS_ON is True, len(annualidmatch[0]['AnnualIDs']) == 0]) or all([mylar.CONFIG.ANNUALS_ON is True, annualidmatch[0]['AnnualIDs'][0]['ComicID'] != week['comicid']]):
-                                #if the annual/special on the weekly is not a part of the series, pass in the anncomicid so that it can get added.
-                                    anncid = week['comicid']
-                                    seriesyear = annualidmatch[0]['SeriesYear']
-                            except Exception as e:
+                            isschk = myDB.selectone('SELECT * FROM annuals where IssueID=?', [issueid]).fetchone()
+                            if isschk is None:
+                                logger.fdebug('[WEEKLY-PULL] Forcing a refresh of the series to ensure it is current [' + str(comicid) +'].')
+                                anncid = None
+                                seriesyear = None
+                                try:
+                                    if all([mylar.CONFIG.ANNUALS_ON is True, len(annualidmatch[0]['AnnualIDs']) == 0]) or all([mylar.CONFIG.ANNUALS_ON is True, annualidmatch[0]['AnnualIDs'][0]['ComicID'] != week['comicid']]):
+                                    #if the annual/special on the weekly is not a part of the series, pass in the anncomicid so that it can get added.
+                                        anncid = week['comicid']
+                                        seriesyear = annualidmatch[0]['SeriesYear']
+                                except Exception as e:
+                                    pass
+
+                                #refresh series.
+                                if anncid is None:
+                                    cchk = mylar.importer.updateissuedata(comicid, comicname, calledfrom='weeklycheck')
+                                else:
+                                    cchk = mylar.importer.manualAnnual(anncid, comicname, seriesyear, comicid)
+
+                            else:
+                                logger.fdebug('annual issue exists in db already: ' + str(issueid))
                                 pass
 
-                            #refresh series.
-                            if anncid is None:
-                                cchk = mylar.importer.updateissuedata(comicid, comicname, calledfrom='weeklycheck')
+                        else:
+                            logger.fdebug('issue exists in db already: ' + str(issueid))
+                            if isschk['Status'] == newValue['Status']:
+                                pass
                             else:
-                                cchk = mylar.importer.manualAnnual(anncid, comicname, seriesyear, comicid)
+                                if all([isschk['Status'] != 'Downloaded', isschk['Status'] != 'Snatched', isschk['Status'] != 'Archived', isschk['Status'] != 'Ignored']) and newValue['Status'] == 'Wanted':
+                                #make sure the status is Wanted and that the issue status is identical if not.
+                                    newStat = {'Status': 'Wanted'}
+                                    ctrlStat = {'IssueID': issueid}
+                                    if all([annualidmatch, mylar.CONFIG.ANNUALS_ON]):
+                                        myDB.upsert("annuals", newStat, ctrlStat)
+                                    else:
+                                        myDB.upsert("issues", newStat, ctrlStat)
+                else:
+                    continue
+#                    else:
+#                        #if it's polling against a future week, don't update anything but the This Week table.
+#                        updater.weekly_update(ComicName=comicname, IssueNumber=week['issue'], CStatus='Wanted', CID=comicid, weeknumber=weeknumber, year=pullyear, altissuenumber=None)
 
-                        else:
-                            logger.fdebug('annual issue exists in db already: ' + str(issueid))
-                            pass
+            except Exception as err:
+                exc_type, exc_value, exc_tb = sys.exc_info()
+                filename, line_num, func_name, err_text = traceback.extract_tb(exc_tb)[-1]
+                tracebackline = traceback.format_exc()
 
-                    else:
-                        logger.fdebug('issue exists in db already: ' + str(issueid))
-                        if isschk['Status'] == newValue['Status']:
-                            pass
-                        else:
-                            if all([isschk['Status'] != 'Downloaded', isschk['Status'] != 'Snatched', isschk['Status'] != 'Archived', isschk['Status'] != 'Ignored']) and newValue['Status'] == 'Wanted':
-                            #make sure the status is Wanted and that the issue status is identical if not.
-                                newStat = {'Status': 'Wanted'}
-                                ctrlStat = {'IssueID': issueid}
-                                if all([annualidmatch, mylar.CONFIG.ANNUALS_ON]):
-                                    myDB.upsert("annuals", newStat, ctrlStat)
-                                else:
-                                    myDB.upsert("issues", newStat, ctrlStat)
-            else:
-                continue
-#                else:
-#                    #if it's polling against a future week, don't update anything but the This Week table.
-#                    updater.weekly_update(ComicName=comicname, IssueNumber=week['issue'], CStatus='Wanted', CID=comicid, weeknumber=weeknumber, year=pullyear, altissuenumber=None)
+                except_line = {'exc_type': exc_type,
+                               'exc_value': exc_value,
+                               'exc_tb': exc_tb,
+                               'filename': filename,
+                               'line_num': line_num,
+                               'func_name': func_name,
+                               'err': str(err),
+                               'err_text': err_text,
+                               'traceback': tracebackline,
+                               'comicname': comicname,
+                               'issuenumber': week['ISSUE'],
+                               'seriesyear': None,
+                               'issueid': issueid,
+                               'comicid': comicid,
+                               'mode': None,
+                               'booktype': None}
 
+                helpers.log_that_exception(except_line)
 
+                # log it regardless..
+                logger.exception(tracebackline)
 
 
 


### PR DESCRIPTION
- Try / Except handling around the main aspects of the search and weeklypull modules, which should make every traceback therein not queue-ending (meaning even after the error, the searches can continue as if they never happened).
- Added a special popup in the Logs tab (```History``` / ```View Logs``` / ```Exceptions / Tracebacks```) where all recorded tracebacks are logged - ability to view specifics, delete entries, and view log snippets pertaining to that specific traceback error, just prior to the error occuring.
- Fixed a problem with DDL provider being lower-cased which might have resulted in some missed searched calls.

- Formatted entire search.py file with black to conform to a soft-line limit of 88.
- linted search.py with flake8
