### PR TITLE
FIX: changed table name from exceptions to exceptions_log

### DIFF
--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -700,7 +700,7 @@ def dbcheck():
     c.execute('CREATE TABLE IF NOT EXISTS manualresults (provider TEXT, id TEXT, kind TEXT, comicname TEXT, volume TEXT, oneoff TEXT, fullprov TEXT, issuenumber TEXT, modcomicname TEXT, name TEXT, link TEXT, size TEXT, pack_numbers TEXT, pack_issuelist TEXT, comicyear TEXT, issuedate TEXT, tmpprov TEXT, pack TEXT, issueid TEXT, comicid TEXT, sarc TEXT, issuearcid TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS storyarcs(StoryArcID TEXT, ComicName TEXT, IssueNumber TEXT, SeriesYear TEXT, IssueYEAR TEXT, StoryArc TEXT, TotalIssues TEXT, Status TEXT, inCacheDir TEXT, Location TEXT, IssueArcID TEXT, ReadingOrder INT, IssueID TEXT, ComicID TEXT, ReleaseDate TEXT, IssueDate TEXT, Publisher TEXT, IssuePublisher TEXT, IssueName TEXT, CV_ArcID TEXT, Int_IssueNumber INT, DynamicComicName TEXT, Volume TEXT, Manual TEXT, DateAdded TEXT, DigitalDate TEXT, Type TEXT, Aliases TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS ddl_info (ID TEXT UNIQUE, series TEXT, year TEXT, filename TEXT, size TEXT, issueid TEXT, comicid TEXT, link TEXT, status TEXT, remote_filesize TEXT, updated_date TEXT, mainlink TEXT, issues TEXT)')
-    c.execute('CREATE TABLE IF NOT EXISTS exceptions(date TEXT UNIQUE, comicname TEXT, issuenumber TEXT, seriesyear TEXT, issueid TEXT, comicid TEXT, booktype TEXT, searchmode TEXT, error TEXT, error_text TEXT, filename TEXT, line_num TEXT, func_name TEXT, traceback TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS exceptions_log(date TEXT UNIQUE, comicname TEXT, issuenumber TEXT, seriesyear TEXT, issueid TEXT, comicid TEXT, booktype TEXT, searchmode TEXT, error TEXT, error_text TEXT, filename TEXT, line_num TEXT, func_name TEXT, traceback TEXT)')
     conn.commit
     c.close
 

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -4249,10 +4249,10 @@ def log_that_exception(except_info):
     #write it to the exceptions table.
     logdate = now()
     myDB = db.DBConnection()
-    myDB.upsert("exceptions", gather_info, {'date': logdate})
+    myDB.upsert("exceptions_log", gather_info, {'date': logdate})
 
     #write the leadup log lines that were tailed above to the external file here...
-    fileline = myDB.selectone("SELECT rowid from exceptions where date = ?", [logdate]).fetchone()
+    fileline = myDB.selectone("SELECT rowid from exceptions_log where date = ?", [logdate]).fetchone()
     with open(os.path.join(mylar.CONFIG.LOG_DIR, 'specific_' + str(fileline['rowid']) + '.log'), 'w') as f:
         f.writelines(leadup)
         f.write(except_info.get('traceback', None))

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6452,7 +6452,7 @@ class WebInterface(object):
     def deleteSpecificLog(self, log_id):
         logger.info('log_id: %s' % log_id)
         myDB = db.DBConnection()
-        myDB.action('DELETE from exceptions WHERE rowid=?', [log_id])
+        myDB.action('DELETE from exceptions_log WHERE rowid=?', [log_id])
         try:
             os.remove(os.path.join(mylar.CONFIG.LOG_DIR, 'specific_' + log_id + '.log'))
         except Exception as e:
@@ -6465,7 +6465,7 @@ class WebInterface(object):
     def manageExceptions(self):
         exception_list = []
         myDB = db.DBConnection()
-        elist = myDB.select("SELECT rowid, * FROM exceptions")
+        elist = myDB.select("SELECT rowid, * FROM exceptions_log")
         for et in elist:
             exception_list.append({'id':   et['rowid'],
                                    'date': et['date'],


### PR DESCRIPTION
Older installations (upgrades from mylar2), might still having an exceptions table in db which would cause the needed table to not be created on startup.