### PR TITLE
Fix Mako error in opds.html

### DIFF
--- a/data/interfaces/default/opds.html
+++ b/data/interfaces/default/opds.html
@@ -13,15 +13,20 @@
     <name>Mylar Server</name>
     <uri>https://github.com/mylar3/mylar3</uri>
   </author>
-  %for link in opds['links']: <% linktitle = '' if 'title' in link: linktitle =
-  ' title="%s"' % link['title'] %>
+    %for link in opds['links']:
+  <%
+      linktitle = ''
+      if 'title' in link:
+          linktitle = ' title="%s"' % link['title']
+  %>
   <link
     rel="${link['rel']}"
     href="${link['href']}"
     type="${link['type']}"
     ${linktitle}
   />
-  %endfor %for entry in opds['entries']:
+  %endfor
+  %for entry in opds['entries']:
   <entry>
     <title>${entry['title']}</title>
     <id>${entry['id']}</id>

--- a/data/interfaces/default/opds.html
+++ b/data/interfaces/default/opds.html
@@ -13,7 +13,7 @@
     <name>Mylar Server</name>
     <uri>https://github.com/mylar3/mylar3</uri>
   </author>
-    %for link in opds['links']:
+  %for link in opds['links']:
   <%
       linktitle = ''
       if 'title' in link:
@@ -49,20 +49,23 @@
       rel="${entry['rel']}"
       type="application/atom+xml; profile=opds-catalog; kind=${entry['kind']}"
     />
-    %endif %if 'stream' in entry and 'pse_count' in entry:
+    %endif 
+    %if 'stream' in entry and 'pse_count' in entry:
     <link
       href="${entry['stream']}&amp;page={pageNumber}&amp;width={maxWidth}"
       rel="http://vaemendis.net/opds-pse/stream"
       type="image/jpeg"
       pse:count="${entry['pse_count']}"
     />
-    %endif %if 'thumbnail' in entry and entry['thumbnail']:
+    %endif 
+    %if 'thumbnail' in entry and entry['thumbnail']:
     <link
       href="${entry['thumbnail']}"
       type="image/jpeg"
       rel="http://opds-spec.org/image/thumbnail"
     />
-    %endif %if 'image' in entry and entry['image']:
+    %endif 
+    %if 'image' in entry and entry['image']:
     <link
       href="${entry['image']}"
       type="image/jpeg"


### PR DESCRIPTION
Fix for a mako error when trying to use opds:

CompileException: Fragment 'for link in opds['links']: <% linktitle = '' if 'title' in link: linktitle =' is not a partial control statement in file '/volume1/mylar/share/mylar3/data/interfaces/default/opds.html' at line: 16 char: 1
 
fixed by reverting some of the original file formatting from a previous version of opds.html