### PR TITLE
DDL fixes for traceback logging + other related items

### DIFF
--- a/data/interfaces/default/logs.html
+++ b/data/interfaces/default/logs.html
@@ -92,7 +92,6 @@
                 var delall_icon = document.getElementById("deleteall").value;
                 var listview_icon = document.getElementById("listview").value;
                 $.ajax({
-                        cache: false,
                         url: "manageExceptions",
                         dataType: "json",
                         success: function (data) {
@@ -105,26 +104,23 @@
                                                 if (data[i].count > 1) {
                                                     $('#exception_table_body').append('<tr><td id="date">'+data[i].date+'</a></td><td id="line_num">'+data[i].line_num+'</td><td id="func_name">'+data[i].func_name+'</td><td id="filename">'+data[i].filename+'</td><td id="error">'+data[i].error + '</td><td id="times">' + data[i].count + '</td><td id="error_text">'+data[i].error_text+'</td><td id="options"><a id="delete" onclick="delete_log(' + data[i].id + ', \'' + data[i].id + '\')" name="delete" href="#"><img style="padding:3px;" src="' + del_icon + '" height="20" width="20" title="delete latest entry" class="highqual" /></a><a id="delete_all" onclick="openDelete(' + data[i].id + ')" name="delete_all" href="#"><img style="padding:3px;" src="' + delall_icon + '" height="25" width="25" title="delete all occurances of this specific error" class="highqual" /></a><a id="view" onclick="view_log(' + data[i].id + ')" name="view" class="view" href="#"><img style="padding:3px;" src="' + listview_icon + '" height="20" title="view latest log snippet" width="20" class="highqual" /></a></td></tr>');
                                                 } else { 
-                                                    $('#exception_table_body').append('<tr><td id="date">'+data[i].date+'</a></td><td id="line_num">'+data[i].line_num+'</td><td id="func_name">'+data[i].func_name+'</td><td id="filename">'+data[i].filename+'</td><td id="error">'+data[i].error + '</td><td id="count"></td><td id="error_text">'+data[i].error_text+'</td><td id="options"><a id="delete" onclick="delete_log(' + data[i].id + ', \\' + data[i].id + '\')" name="delete" href="#"><img style="padding:10px;" src="' + del_icon + '" height="20" width="20" title="delete entry" class="highqual" /></a> <a id="view" onclick="view_log(' + data[i].id + ')" name="view" class="view" href="#"><img style="padding:10px;" src="' + listview_icon + '" height="20" title="view log snippet" width="20" class="highqual" /></a></td></tr>');
+                                                    $('#exception_table_body').append('<tr><td id="date">'+data[i].date+'</a></td><td id="line_num">'+data[i].line_num+'</td><td id="func_name">'+data[i].func_name+'</td><td id="filename">'+data[i].filename+'</td><td id="error">'+data[i].error + '</td><td id="count"></td><td id="error_text">'+data[i].error_text+'</td><td id="options"><a id="delete" onclick="delete_log(' + data[i].id + ', ' + data[i].id + ')" name="delete" href="#"><img style="padding:10px;" src="' + del_icon + '" height="20" width="20" title="delete entry" class="highqual" /></a> <a id="view" onclick="view_log(' + data[i].id + ')" name="view" class="view" href="#"><img style="padding:10px;" src="' + listview_icon + '" height="20" title="view log snippet" width="20" class="highqual" /></a></td></tr>');
                                                 }
                                         };
-                                        $('#exceptions_table').dataTable({
-                                                "aoColumns": [
-                                                        null,
-                                                        null,
-                                                        null,
-                                                        null,
-                                                        null,
-                                                        null,
-                                                        null,
-                                                        null
-                                                ],
+                                        if ($.fn.dataTable.isDataTable('#exceptions_table')) {
+                                            $.fn.dataTable.ext.errMode = 'none';
+                                            var table = $('#exceptions_table').DataTable();
+                                            table.ajax.reload(null, false); 
+                                            $.fn.dataTable.ext.errMode = 'throw';
+                                        } else {
+                                            var table = $('#exceptions_table').dataTable({
                                                 "aaSorting": [[ 1, 'desc']],
                                                 "bFilter": false,
                                                 "bInfo": false,
                                                 "bPaginate": false,
                                                 "bDestroy": true
-                                        });
+                                            });
+                                        }
                                 } else {
                                         document.getElementById("exception_table_body").innerHTML = '</br><td colspan="3"><center>There are no errors/tracebacks logged thus far...</center></td>';
                                 }
@@ -148,16 +144,15 @@
                 all = document.getElementById("all").value;
             }
             $.ajax({
-                contentType: "application/json; charset=utf-8;",
                 url: "deleteSpecificLog",
                 data: { log_id: log_id, all: all },
-                dataType: "json",
                 success: function (data) {
-                   if (all != 'all') {
+                   var obj = JSON.parse(data);
+                   if ( !isNaN(all) ) {
                        if (data.error != undefined) {
                            $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Unable to delete specific log file</div>");
                            $('#ajaxMsg').addClass('failure').fadeIn().delay(3000).fadeOut();
-                       } else if ( data.indexOf("success") > -1 )  {
+                       } else if ( obj['status'].indexOf("success") > -1 )  {
                            $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Successfully deleted log file</div>");
                            $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
                        } else {
@@ -168,7 +163,7 @@
                        if (data.error != undefined) {
                            $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Unable to delete log files</div>");
                            $('#ajaxMsg').addClass('failure').fadeIn().delay(3000).fadeOut();
-                       } else if ( data.indexOf("success") > -1 ) {
+                       } else if ( obj['status'].indexOf("success") > -1 )  {
                            $("#deleteConfirm").dialog("close");
                            $("#deleteConfirm").dialog('destroy').empty();
                            $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Successfully deleted log files</div>");
@@ -180,10 +175,10 @@
                    }
                 }
             }).done(function() {
-                document.getElementById("exception_table_body").innerHTML = '';
-                $("#manage_exceptions_dialog").dialog("close");
+                //document.getElementById("exception_table_body").innerHTML = '';
+                //$("#manage_exceptions_dialog").dialog("close");
+                //$("#manage_exceptions_dialog").dialog("destroy"); 
                 //$('#exception_table_body').empty(); //dialog('destroy');
-                $("#manage_exceptions_dialog").dialog('destroy'); 
                 manageTheExceptions();
             });
         }

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -14,26 +14,24 @@
 # You should have received a copy of the GNU General Public License
 # along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
 
-from io import StringIO
-import urllib.request, urllib.parse, urllib.error
-from threading import Thread
+
+import requests
+import urllib.parse
 import os
 import sys
+import traceback
+import errno
 import re
-import gzip
 import time
 import datetime
-import json
 from bs4 import BeautifulSoup
-import requests
 import cfscrape
 import zipfile
-from . import logger
 import mylar
-from mylar import db
+from mylar import db, logger, helpers
+
 
 class GC(object):
-
     def __init__(self, query=None, issueid=None, comicid=None, oneoff=False):
 
         self.valreturn = []
@@ -43,53 +41,136 @@ class GC(object):
         self.query = query
 
         self.comicid = comicid
- 
+
         self.issueid = issueid
 
         self.oneoff = oneoff
 
         self.local_filename = os.path.join(mylar.CONFIG.CACHE_DIR, "getcomics.html")
 
-        self.headers = {'Accept-encoding': 'gzip', 'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1', 'Referer': 'https://getcomics.info/'}
+        self.headers = {
+            'Accept-encoding': 'gzip',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1',
+            'Referer': 'https://getcomics.info/',
+        }
 
     def search(self):
 
-        with cfscrape.create_scraper() as s:
-            try:
-                cf_cookievalue, cf_user_agent = s.get_tokens(self.url, headers=self.headers)
-            except Exception as e:
-                logger.warn('[WARNING] Unable to scrape remote site, stopped by a small tank. Error returned as : %s' % e)
-                return self.search_results()
+        try:
+            with cfscrape.create_scraper() as s:
+                cf_cookievalue, cf_user_agent = s.get_tokens(
+                    self.url, headers=self.headers
+                )
 
-            t = s.get(self.url+'/', params={'s': self.query}, verify=True, cookies=cf_cookievalue, headers=self.headers, stream=True, timeout=30)
+            t = s.get(
+                self.url + '/',
+                params={'s': self.query},
+                verify=True,
+                cookies=cf_cookievalue,
+                headers=self.headers,
+                stream=True,
+                timeout=30,
+            )
 
             with open(self.local_filename, 'wb') as f:
                 for chunk in t.iter_content(chunk_size=1024):
-                   if chunk: # filter out keep-alive new chunks
-                       f.write(chunk)
-                       f.flush()
+                    if chunk:  # filter out keep-alive new chunks
+                        f.write(chunk)
+                        f.flush()
 
-        return self.search_results()
+        except requests.exceptions.Timeout as e:
+            logger.warn(
+                'Timeout occured fetching data from DDL: %s' % e
+            )
+            return 'no results'
+        except requests.exceptions.ConnectionError as e:
+            logger.warn(
+                '[WARNING] Connection refused to DDL site, stopped by a small tank.'
+                ' Error returned as : %s' % e
+            )
+            if any(
+                [
+                    errno.ETIMEDOUT,
+                    errno.ECONNREFUSED,
+                    errno.EHOSTDOWN,
+                    errno.EHOSTUNREACH,
+                ]
+            ):
+                helpers.disable_provider('DDL', 'Connection Refused.')
+            return 'no results'
+        except Exception as err:
+            logger.warn(
+                '[WARNING] Unable to scrape remote site, stopped by a small tank.'
+                ' Error returned as : %s' % err
+            )
+            if 'Unable to identify Cloudflare IUAM' in str(err):
+                helpers.disable_provider(
+                    'DDL', 'Unable to identify Cloudflare IUAM Javascript on website'
+                )
+
+            # since we're capturing exceptions here, searches from the search module
+            # won't get capture. So we need to do this so they get tracked.
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            filename, line_num, func_name, err_text = traceback.extract_tb(
+                exc_tb
+            )[-1]
+            tracebackline = traceback.format_exc()
+
+            except_line = {
+                'exc_type': exc_type,
+                'exc_value': exc_value,
+                'exc_tb': exc_tb,
+                'filename': filename,
+                'line_num': line_num,
+                'func_name': func_name,
+                'err': str(err),
+                'err_text': err_text,
+                'traceback': tracebackline,
+                'comicname': None,
+                'issuenumber': None,
+                'seriesyear': None,
+                'issueid': self.issueid,
+                'comicid': self.comicid,
+                'mode': None,
+                'booktype': None,
+            }
+
+            helpers.log_that_exception(except_line)
+
+            return 'no results'
+        else:
+            return self.search_results()
 
     def loadsite(self, id, link):
         title = os.path.join(mylar.CONFIG.CACHE_DIR, 'getcomics-' + id)
         with cfscrape.create_scraper() as s:
-            self.cf_cookievalue, cf_user_agent = s.get_tokens(link, headers=self.headers)
+            self.cf_cookievalue, cf_user_agent = s.get_tokens(
+                link, headers=self.headers
+            )
 
-            t = s.get(link, verify=True, cookies=self.cf_cookievalue, headers=self.headers, stream=True, timeout=30)
+            t = s.get(
+                link,
+                verify=True,
+                cookies=self.cf_cookievalue,
+                headers=self.headers,
+                stream=True,
+                timeout=30,
+            )
 
-            with open(title+'.html', 'wb') as f:
+            with open(title + '.html', 'wb') as f:
                 for chunk in t.iter_content(chunk_size=1024):
-                   if chunk: # filter out keep-alive new chunks
-                       f.write(chunk)
-                       f.flush()
+                    if chunk:  # filter out keep-alive new chunks
+                        f.write(chunk)
+                        f.flush()
 
     def search_results(self):
         results = {}
         resultlist = []
         soup = BeautifulSoup(open(self.local_filename, encoding='utf-8'), 'html.parser')
 
-        resultline = soup.find("span", {"class": "cover-article-count"}).get_text(strip=True)
+        resultline = soup.find("span", {"class": "cover-article-count"}).get_text(
+            strip=True
+        )
         logger.info('There are %s results' % re.sub('Articles', '', resultline).strip())
 
         for f in soup.findAll("article"):
@@ -102,28 +183,38 @@ class GC(object):
             filename = title
             issues = None
             pack = False
-            #see if it's a pack type
+            # see if it's a pack type
             issfind_st = title.find('#')
             issfind_en = title.find('-', issfind_st)
             if issfind_en != -1:
-                if all([title[issfind_en+1] == ' ', title[issfind_en+2].isdigit()]):
-                    iss_en = title.find(' ', issfind_en+2)
+                if all([title[issfind_en + 1] == ' ', title[issfind_en + 2].isdigit()]):
+                    iss_en = title.find(' ', issfind_en + 2)
                     if iss_en != -1:
-                        issues = title[issfind_st+1:iss_en]
+                        issues = title[issfind_st + 1 : iss_en]
                         pack = True
-                if title[issfind_en+1].isdigit():
-                    iss_en = title.find(' ', issfind_en+1)
+                if title[issfind_en + 1].isdigit():
+                    iss_en = title.find(' ', issfind_en + 1)
                     if iss_en != -1:
-                        issues = title[issfind_st+1:iss_en]
+                        issues = title[issfind_st + 1 : iss_en]
                         pack = True
 
-            # if it's a pack - remove the issue-range and the possible issue years (cause it most likely will span) and pass thru as separate items
+            # if it's a pack - remove the issue-range and the possible issue years
+            # (cause it most likely will span) and pass thru as separate items
             if pack is True:
                 title = re.sub(issues, '', title).strip()
+                # kill any brackets in the issue line here.
+                issues = re.sub(r'[\(\)\[\]]', '', issues).strip()
                 if title.endswith('#'):
                     title = title[:-1].strip()
             else:
-                if any(['Marvel Week+' in title, 'INDIE Week+' in title, 'Image Week' in title, 'DC Week+' in title]):
+                if any(
+                    [
+                        'Marvel Week+' in title,
+                        'INDIE Week+' in title,
+                        'Image Week' in title,
+                        'DC Week+' in title,
+                    ]
+                ):
                     continue
 
             option_find = f.find("p", {"style": "text-align: center;"})
@@ -131,42 +222,53 @@ class GC(object):
             if option_find is None:
                 continue
             else:
-                while (i <= 2 and option_find is not None):
+                while i <= 2 and option_find is not None:
                     option_find = option_find.findNext(text=True)
                     if 'Year' in option_find:
                         year = option_find.findNext(text=True)
-                        year = re.sub('\|', '', year).strip()
+                        year = re.sub(r'\|', '', year).strip()
                         if pack is True and '-' in year:
-                            title = re.sub('\('+year+'\)', '', title).strip()
+                            title = re.sub(r'\(' + year + r'\)', '', title).strip()
                     else:
                         size = option_find.findNext(text=True)
-                        if all([re.sub(':', '', size).strip() != 'Size', len(re.sub('[^0-9]', '', size).strip()) > 0]):
+                        if all(
+                            [
+                                re.sub(':', '', size).strip() != 'Size',
+                                len(re.sub('r[^0-9]', '', size).strip()) > 0,
+                            ]
+                        ):
                             if 'MB' in size:
                                 size = re.sub('MB', 'M', size).strip()
                             if 'GB' in size:
                                 size = re.sub('GB', 'G', size).strip()
                             if '//' in size:
                                 nwsize = size.find('//')
-                                size = re.sub('\[', '', size[:nwsize]).strip()
+                                size = re.sub(r'\[', '', size[:nwsize]).strip()
                             elif '/' in size:
                                 nwsize = size.find('/')
-                                size = re.sub('\[', '', size[:nwsize]).strip()
+                                size = re.sub(r'\[', '', size[:nwsize]).strip()
                         else:
                             size = '0M'
-                    i+=1
+                    i += 1
             dateline = f.find('time')
             datefull = dateline['datetime']
             datestamp = time.mktime(time.strptime(datefull, "%Y-%m-%d"))
-            resultlist.append({"title":    title,
-                               "pubdate":  datetime.datetime.fromtimestamp(float(datestamp)).strftime('%a, %d %b %Y %H:%M:%S'),
-                               "filename": filename,
-                               "size":     re.sub(' ', '', size).strip(),
-                               "pack":     pack,
-                               "issues":   issues,
-                               "link":     link,
-                               "year":     year,
-                               "id":       re.sub('post-', '', id).strip(),
-                               "site":     'DDL'})
+            resultlist.append(
+                {
+                    "title": title,
+                    "pubdate": datetime.datetime.fromtimestamp(
+                        float(datestamp)
+                    ).strftime('%a, %d %b %Y %H:%M:%S'),
+                    "filename": filename,
+                    "size": re.sub(' ', '', size).strip(),
+                    "pack": pack,
+                    "issues": issues,
+                    "link": link,
+                    "year": year,
+                    "id": re.sub('post-', '', id).strip(),
+                    "site": 'DDL',
+                }
+            )
 
             logger.fdebug('%s [%s]' % (title, size))
 
@@ -179,61 +281,71 @@ class GC(object):
         year = None
         size = None
         title = os.path.join(mylar.CONFIG.CACHE_DIR, 'getcomics-' + id)
-        soup = BeautifulSoup(open(title+'.html', encoding='utf-8'), 'html.parser')
+        soup = BeautifulSoup(open(title + '.html', encoding='utf-8'), 'html.parser')
         orig_find = soup.find("p", {"style": "text-align: center;"})
         i = 0
         option_find = orig_find
         possible_more = None
-        while True: #i <= 10:
+        while True:  # i <= 10:
             prev_option = option_find
             option_find = option_find.findNext(text=True)
             if i == 0 and series is None:
                 series = option_find
             elif 'Year' in option_find:
                 year = option_find.findNext(text=True)
-                year = re.sub('\|', '', year).strip()
+                year = re.sub(r'\|', '', year).strip()
             else:
                 if 'Size' in prev_option:
-                    size = option_find #.findNext(text=True)
+                    size = option_find  # .findNext(text=True)
                     possible_more = orig_find.next_sibling
                     break
-            i+=1
+            i += 1
 
-        logger.fdebug('Now downloading: %s [%s] / %s ... this can take a while (go get some take-out)...' % (series, year, size))
+        logger.fdebug(
+            'Now downloading: %s [%s] / %s ... this can take a while'
+            ' (go get some take-out)...' % (series, year, size)
+        )
 
         link = None
         for f in soup.findAll("div", {"class": "aio-pulse"}):
             lk = f.find('a')
             if lk['title'] == 'Download Now':
-                link = {"series":  series,
-                         "site":   lk['title'],
-                         "year":   year,
-                         "issues": None,
-                         "size":   size,
-                         "link":   lk['href']}
+                link = {
+                    "series": series,
+                    "site": lk['title'],
+                    "year": year,
+                    "issues": None,
+                    "size": size,
+                    "link": lk['href'],
+                }
 
-                break #get the first link just to test
+                break  # get the first link just to test
 
         links = []
 
         if link is None and possible_more.name == 'ul':
             try:
                 bb = possible_more.findAll('li')
-            except:
+            except Exception:
                 pass
             else:
                 for x in bb:
                     linkline = x.find('a')
                     try:
                         tmp = linkline['href']
-                    except:
+                    except Exception:
                         continue
                     if tmp:
-                        if any(['run.php' in linkline['href'], 'go.php' in linkline['href']]):
+                        if any(
+                            [
+                                'run.php' in linkline['href'],
+                                'go.php' in linkline['href'],
+                            ]
+                        ):
                             volume = x.findNext(text=True)
                             if '\u2013' in volume:
-                                volume = re.sub('\u2013', '-', volume)
-                            #volume label contains series, issue(s), year(s), and size
+                                volume = re.sub(r'\u2013', '-', volume)
+                            # volume label contains series, issue(s), year(s), and size
                             series_st = volume.find('(')
                             issues_st = volume.find('#')
                             series = volume[:series_st]
@@ -241,20 +353,28 @@ class GC(object):
                                 issues = None
                             else:
                                 series = volume[:issues_st].strip()
-                                issues = volume[issues_st+1:series_st].strip()
-                            year_end = volume.find(')', series_st+1)
-                            year = re.sub('[\(\)]', '', volume[series_st+1: year_end]).strip()
-                            size_end = volume.find(')', year_end+1)
-                            size = re.sub('[\(\)]', '', volume[year_end+1: size_end]).strip()
+                                issues = volume[issues_st + 1 : series_st].strip()
+                            year_end = volume.find(')', series_st + 1)
+                            year = re.sub(
+                                r'[\(\)]', '', volume[series_st + 1 : year_end]
+                            ).strip()
+                            size_end = volume.find(')', year_end + 1)
+                            size = re.sub(
+                                r'[\(\)]', '', volume[year_end + 1 : size_end]
+                            ).strip()
                             linked = linkline['href']
                             site = linkline.findNext(text=True)
                             if site == 'Main Server':
-                                links.append({"series": series,
-                                              "site":   site,
-                                              "year":   year,
-                                              "issues": issues,
-                                              "size":   size,
-                                              "link":   linked})
+                                links.append(
+                                    {
+                                        "series": series,
+                                        "site": site,
+                                        "year": year,
+                                        "issues": issues,
+                                        "size": size,
+                                        "link": linked,
+                                    }
+                                )
         else:
             check_extras = soup.findAll("h3")
             for sb in check_extras:
@@ -266,77 +386,109 @@ class GC(object):
                         for x in bb:
                             volume = x.findNext(text=True)
                             if '\u2013' in volume:
-                                volume = re.sub('\u2013', '-', volume)
+                                volume = re.sub(r'\u2013', '-', volume)
                             series_st = volume.find('(')
                             issues_st = volume.find('#')
                             series = volume[:issues_st].strip()
                             issues = volume[issues_st:series_st].strip()
-                            year_end = volume.find(')', series_st+1)
-                            year = re.sub('[\(\)\|]', '', volume[series_st+1: year_end]).strip()
-                            size_end = volume.find(')', year_end+1)
-                            size = re.sub('[\(\)\|]', '', volume[year_end+1: size_end]).strip()
+                            year_end = volume.find(')', series_st + 1)
+                            year = re.sub(
+                                r'[\(\)\|]', '', volume[series_st + 1 : year_end]
+                            ).strip()
+                            size_end = volume.find(')', year_end + 1)
+                            size = re.sub(
+                                r'[\(\)\|]', '', volume[year_end + 1 : size_end]
+                            ).strip()
                             linkline = x.find('a')
                             linked = linkline['href']
                             site = linkline.findNext(text=True)
-                            links.append({"series": series,
-                                          "volume": volume,
-                                          "site":   site,
-                                          "year":   year,
-                                          "issues": issues,
-                                          "size":   size,
-                                          "link":   linked})
+                            links.append(
+                                {
+                                    "series": series,
+                                    "volume": volume,
+                                    "site": site,
+                                    "year": year,
+                                    "issues": issues,
+                                    "size": size,
+                                    "link": linked,
+                                }
+                            )
 
         if all([link is None, len(links) == 0]):
-            logger.warn('Unable to retrieve any valid immediate download links. They might not exist.')
-            return {'success':  False}
+            logger.warn(
+                'Unable to retrieve any valid immediate download links.'
+                ' They might not exist.'
+            )
+            return {'success': False}
         if all([link is not None, len(links) == 0]):
-            logger.info('only one item discovered, changing queue length to accomodate: %s [%s]' % (link, type(link)))
+            logger.info(
+                'Only one item discovered, changing queue length to accomodate: %s [%s]'
+                % (link, type(link))
+            )
             links = [link]
         elif len(links) > 0:
             if link is not None:
                 links.append(link)
-                logger.fdebug('[DDL-QUEUE] Making sure we download the original item in addition to the extra packs.')
+                logger.fdebug(
+                    '[DDL-QUEUE] Making sure we download the original item in addition'
+                    ' to the extra packs.'
+                )
             if len(links) > 1:
-                logger.fdebug('[DDL-QUEUER] This pack has been broken up into %s separate packs - queueing each in sequence for your enjoyment.' % len(links))
+                logger.fdebug(
+                    '[DDL-QUEUER] This pack has been broken up into %s separate packs -'
+                    ' queueing each in sequence for your enjoyment.' % len(links)
+                )
         cnt = 1
         for x in links:
             if len(links) == 1:
                 mod_id = id
             else:
-                mod_id = id+'-'+str(cnt)
-            #logger.fdebug('[%s] %s (%s) %s [%s][%s]' % (x['site'], x['series'], x['year'], x['issues'], x['size'],  x['link']))
+                mod_id = id + '-' + str(cnt)
+            # logger.fdebug('[%s] %s (%s) %s [%s][%s]'
+            #     % (x['site'], x['series'], x['year'], x['issues'],
+            #     x['size'],  x['link'])
+            #     )
 
-            ctrlval = {'id':        mod_id}
-            vals = {'series':       x['series'],
-                    'year':         x['year'],
-                    'size':         x['size'],
-                    'issues':       x['issues'],
-                    'issueid':      self.issueid,
-                    'comicid':      self.comicid,
-                    'link':         x['link'],
-                    'mainlink':     mainlink,
-                    'updated_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M'),
-                    'status':       'Queued'}
+            ctrlval = {'id': mod_id}
+            vals = {
+                'series': x['series'],
+                'year': x['year'],
+                'size': x['size'],
+                'issues': x['issues'],
+                'issueid': self.issueid,
+                'comicid': self.comicid,
+                'link': x['link'],
+                'mainlink': mainlink,
+                'updated_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M'),
+                'status': 'Queued',
+            }
             myDB.upsert('ddl_info', vals, ctrlval)
 
-            mylar.DDL_QUEUE.put({'link':     x['link'],
-                                 'mainlink': mainlink,
-                                 'series':   x['series'],
-                                 'year':     x['year'],
-                                 'size':     x['size'],
-                                 'comicid':  self.comicid,
-                                 'issueid':  self.issueid,
-                                 'oneoff':   self.oneoff,
-                                 'id':       mod_id,
-                                 'resume':   None})
-            cnt+=1
+            mylar.DDL_QUEUE.put(
+                {
+                    'link': x['link'],
+                    'mainlink': mainlink,
+                    'series': x['series'],
+                    'year': x['year'],
+                    'size': x['size'],
+                    'comicid': self.comicid,
+                    'issueid': self.issueid,
+                    'oneoff': self.oneoff,
+                    'id': mod_id,
+                    'resume': None,
+                }
+            )
+            cnt += 1
 
         return {'success': True}
 
     def downloadit(self, id, link, mainlink, resume=None):
-        #logger.info('[%s] %s -- mainlink: %s' % (id, link, mainlink))
+        # logger.info('[%s] %s -- mainlink: %s' % (id, link, mainlink))
         if mylar.DDL_LOCK is True:
-            logger.fdebug('[DDL] Another item is currently downloading via DDL. Only one item can be downloaded at a time using DDL. Patience.')
+            logger.fdebug(
+                '[DDL] Another item is currently downloading via DDL. Only one item can'
+                ' be downloaded at a time using DDL. Patience.'
+            )
             return
         else:
             mylar.DDL_LOCK = True
@@ -346,12 +498,25 @@ class GC(object):
         try:
             with cfscrape.create_scraper() as s:
                 if resume is not None:
-                    logger.info('[DDL-RESUME] Attempting to resume from: %s bytes' % resume)
+                    logger.info(
+                        '[DDL-RESUME] Attempting to resume from: %s bytes' % resume
+                    )
                     self.headers['Range'] = 'bytes=%d-' % resume
-                cf_cookievalue, cf_user_agent = s.get_tokens(mainlink, headers=self.headers, timeout=30)
-                t = s.get(link, verify=True, cookies=cf_cookievalue, headers=self.headers, stream=True, timeout=30)
+                cf_cookievalue, cf_user_agent = s.get_tokens(
+                    mainlink, headers=self.headers, timeout=30
+                )
+                t = s.get(
+                    link,
+                    verify=True,
+                    cookies=cf_cookievalue,
+                    headers=self.headers,
+                    stream=True,
+                    timeout=30,
+                )
 
-                filename = os.path.basename(urllib.parse.unquote(t.url)) #.decode('utf-8'))
+                filename = os.path.basename(
+                    urllib.parse.unquote(t.url)
+                )  # .decode('utf-8'))
                 if 'GetComics.INFO' in filename:
                     filename = re.sub('GetComics.INFO', '', filename, re.I).strip()
 
@@ -362,45 +527,79 @@ class GC(object):
                     if 'run.php-urls' not in link:
                         link = re.sub('run.php-url=', 'run.php-urls', link)
                         link = re.sub('go.php-url=', 'run.php-urls', link)
-                        t = s.get(link, verify=True, cookies=cf_cookievalue, headers=self.headers, stream=True, timeout=30)
-                        filename = os.path.basename(urllib.parse.unquote(t.url)) #.decode('utf-8'))
+                        t = s.get(
+                            link,
+                            verify=True,
+                            cookies=cf_cookievalue,
+                            headers=self.headers,
+                            stream=True,
+                            timeout=30,
+                        )
+                        filename = os.path.basename(
+                            urllib.parse.unquote(t.url)
+                        )  # .decode('utf-8'))
                         if 'GetComics.INFO' in filename:
-                            filename = re.sub('GetComics.INFO', '', filename, re.I).strip()
+                            filename = re.sub(
+                                'GetComics.INFO', '', filename, re.I
+                            ).strip()
                         try:
                             remote_filesize = int(t.headers['Content-length'])
                             logger.fdebug('remote filesize: %s' % remote_filesize)
                         except Exception as e:
-                            logger.warn('[WARNING] Unable to retrieve remote file size - this is usually due to the page being behind a different click-bait/ad page. Error returned as : %s' % e)
-                            logger.warn('[WARNING] Considering this particular download as invalid and will ignore this result.')
+                            logger.warn(
+                                '[WARNING] Unable to retrieve remote file size - this'
+                                ' is usually due to the page being behind a different'
+                                ' click-bait/ad page. Error returned as : %s' % e
+                            )
+                            logger.warn(
+                                '[WARNING] Considering this particular download as'
+                                ' invalid and will ignore this result.'
+                            )
                             remote_filesize = 0
                             mylar.DDL_LOCK = False
-                            return ({"success":  False,
-                                     "filename": filename,
-                                     "path":     None})
+                            return {
+                                "success": False,
+                                "filename": filename,
+                                "path": None,
+                            }
 
                     else:
-                        logger.warn('[WARNING] Unable to retrieve remote file size - this is usually due to the page being behind a different click-bait/ad page. Error returned as : %s' % e)
-                        logger.warn('[WARNING] Considering this particular download as invalid and will ignore this result.')
+                        logger.warn(
+                            '[WARNING] Unable to retrieve remote file size - this is'
+                            ' usually due to the page being behind a different'
+                            ' click-bait/ad page. Error returned as : %s' % e
+                        )
+                        logger.warn(
+                            '[WARNING] Considering this particular download as invalid'
+                            ' and will ignore this result.'
+                        )
                         remote_filesize = 0
                         mylar.DDL_LOCK = False
-                        return ({"success":  False,
-                                 "filename": filename,
-                                 "path":     None})
+                        return {"success": False, "filename": filename, "path": None}
 
-                #write the filename to the db for tracking purposes...
-                myDB.upsert('ddl_info', {'filename': filename, 'remote_filesize': remote_filesize}, {'id': id})
+                # write the filename to the db for tracking purposes...
+                myDB.upsert(
+                    'ddl_info',
+                    {'filename': filename, 'remote_filesize': remote_filesize},
+                    {'id': id},
+                )
 
-                if mylar.CONFIG.DDL_LOCATION is not None and not os.path.isdir(mylar.CONFIG.DDL_LOCATION):
-                    checkdirectory = mylar.filechecker.validateAndCreateDirectory(mylar.CONFIG.DDL_LOCATION, True)
+                if mylar.CONFIG.DDL_LOCATION is not None and not os.path.isdir(
+                    mylar.CONFIG.DDL_LOCATION
+                ):
+                    checkdirectory = mylar.filechecker.validateAndCreateDirectory(
+                        mylar.CONFIG.DDL_LOCATION, True
+                    )
                     if not checkdirectory:
-                        logger.warn('[ABORTING] Error trying to validate/create DDL download directory: %s.' % mylar.CONFIG.DDL_LOCATION)
-                        return ({"success":  False,
-                                 "filename": filename,
-                                 "path":     None})
+                        logger.warn(
+                            '[ABORTING] Error trying to validate/create DDL download'
+                            ' directory: %s.' % mylar.CONFIG.DDL_LOCATION
+                        )
+                        return {"success": False, "filename": filename, "path": None}
 
                 path = os.path.join(mylar.CONFIG.DDL_LOCATION, filename)
 
-                #if t.headers.get('content-encoding') == 'gzip': #.get('Content-Encoding') == 'gzip':
+                # if t.headers.get('content-encoding') == 'gzip':
                 #    buf = StringIO(t.content)
                 #    f = gzip.GzipFile(fileobj=buf)
 
@@ -421,46 +620,54 @@ class GC(object):
         except Exception as e:
             logger.error('[ERROR] %s' % e)
             mylar.DDL_LOCK = False
-            return ({"success":  False,
-                     "filename": filename,
-                     "path":     None})
+            return {"success": False, "filename": filename, "path": None}
 
         else:
             mylar.DDL_LOCK = False
             if os.path.isfile(path):
                 if path.endswith('.zip'):
-                    new_path = os.path.join(mylar.CONFIG.DDL_LOCATION, re.sub('.zip', '', filename).strip())
-                    logger.info('Zip file detected. Unzipping into new modified path location: %s' % new_path)
+                    new_path = os.path.join(
+                        mylar.CONFIG.DDL_LOCATION, re.sub('.zip', '', filename).strip()
+                    )
+                    logger.info(
+                        'Zip file detected.'
+                        ' Unzipping into new modified path location: %s' % new_path
+                    )
                     try:
                         zip_f = zipfile.ZipFile(path, 'r')
                         zip_f.extractall(new_path)
                         zip_f.close()
                     except Exception as e:
-                        logger.warn('[ERROR: %s] Unable to extract zip file: %s' % (e, new_path))
-                        return ({"success":  False,
-                                 "filename": filename,
-                                 "path":     None})
+                        logger.warn(
+                            '[ERROR: %s] Unable to extract zip file: %s' % (e, new_path)
+                        )
+                        return {"success": False, "filename": filename, "path": None}
                     else:
                         try:
                             os.remove(path)
                         except Exception as e:
-                            logger.warn('[ERROR: %s] Unable to remove zip file from %s after extraction.' % (e, path))
+                            logger.warn(
+                                '[ERROR: %s] Unable to remove zip file from %s after'
+                                ' extraction.' % (e, path)
+                            )
                         filename = None
                 else:
                     new_path = path
-                return ({"success":  True,
-                         "filename": filename,
-                         "path":     new_path})
+                return {"success": True, "filename": filename, "path": new_path}
 
     def issue_list(self, pack):
-        #packlist = [x.strip() for x in pack.split(',)]
+        # packlist = [x.strip() for x in pack.split(',)]
         packlist = pack.replace('+', ' ').replace(',', ' ').split()
         print(packlist)
         plist = []
         pack_issues = []
         for pl in packlist:
             if '-' in pl:
-                plist.append(list(range(int(pl[:pl.find('-')]),int(pl[pl.find('-')+1:])+1)))
+                plist.append(
+                    list(
+                        range(int(pl[: pl.find('-')]), int(pl[pl.find('-') + 1 :]) + 1)
+                    )
+                )
             else:
                 if 'TPBs' not in pl:
                     plist.append(int(pl))
@@ -477,7 +684,8 @@ class GC(object):
         pack_issues.sort()
         print("pack_issues: %s" % pack_issues)
 
-#if __name__ == '__main__':
+
+# if __name__ == '__main__':
 #    ab = GC(sys.argv[1]) #'justice league aquaman') #sys.argv[0])
 #    #c = ab.search()
 #    b = ab.loadsite('test', sys.argv[2])

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -4125,7 +4125,7 @@ class WebInterface(object):
 
     ReadMassCopy.exposed = True
 
-    def logs(self):
+    def logs(self, **kwargs):
         return serve_template(templatename="logs.html", title="Log", lineList=mylar.LOGLIST)
     logs.exposed = True
 
@@ -6433,7 +6433,7 @@ class WebInterface(object):
     def download_0day(self, week):
         logger.info('Now attempting to search for 0-day pack for week: %s' % week)
         #week contains weekinfo['midweek'] = YYYY-mm-dd of Wednesday of the given week's pull
-        foundcom, prov = search.search_init('0-Day Comics Pack - %s.%s' % (week[:4],week[5:]), None, week[:4], None, None, week, week, None, allow_packs=True, oneoff=True)
+        foundcom, prov = search.search_init('%s.%s.%s Weekly Pack' % (week[:4],week[5:7],week[8:]), None, week[:4], None, None, week, week, None, allow_packs=True, oneoff=True)
 
     download_0day.exposed = True
 
@@ -6515,6 +6515,7 @@ class WebInterface(object):
                 )
                 return json.dumps({"status": "error"})
             else:
+                logger.info('successfully deleted entry: %s' % log_id)
                 return json.dumps({"status": "success"})
     deleteSpecificLog.exposed = True
 


### PR DESCRIPTION
- FIX: fix for DDL throwing CF challenge errors and killing the queue. This will not fix the errors (as that is due to the use of an external module), but it will not kill the queue now.
- FIX: searches doing an extra loop for non-loopable providers (ie. DDL, experimental)
- FIX: removed timeout after search for non-loopable providers
- FIX: fixed traceback GUI dialog so that it can delete specific entries
- FIX: ugly monkeypatch to exception GUI display so screen doesn't have to be refreshed
- IMP: black + flake8 done to getcomics.py