### PR TITLE
FIX: DDL RSS Feed would error out when a 503 is returned (CF is active)

### DIFF
--- a/mylar/rsscheck.py
+++ b/mylar/rsscheck.py
@@ -402,12 +402,11 @@ def ddl(forcerss=False):
     else:
         if r.status_code != 200:
             #typically 403 will not return results, but just catch anything other than a 200
-            if r.status_code == 403:
-                logger.warn('ERROR - status code:%s' % r.status_code)
-                return False
+            if r.status_code == 503:
+                logger.warn('[ERROR - Cloudflare is probably active] Status code returned: %s' % r.status_code)
             else:
-                logger.warn('[%s] Status code returned: %s' % (r.status_code))
-                return False
+                logger.warn('[ERROR] Status code returned: %s' % r.status_code)
+            return False
 
         feedme = feedparser.parse(r.content)
         results = []


### PR DESCRIPTION
If CF was active when the RSS fires off with DDL enabled, it would cause the RSS feed to traceback due to not getting back a valid response. 

This was in part due to an incorrect formatting reference in the logger, but will now also indicate that CF might be the possible cause of the 503 in the logs for reference.