### PR TITLE
DDL GUI patches & DDL parsing adjustment for additional values for search matching

### DIFF
--- a/data/interfaces/default/queue_management.html
+++ b/data/interfaces/default/queue_management.html
@@ -222,7 +222,7 @@
                          if (aData[4] === "Completed") {
                             $('td', nRow).closest('tr').addClass("gradeA");
                          } else if (aData[4] === "Queued") {
-                            $('td', nRow).closest('tr').addClass("gradeL");
+                            $('td', nRow).closest('tr').addClass("gradeC");
                          } else if (aData[4] === "Incomplete" || aData[4] == "Failed") {
                             $('td', nRow).closest('tr').addClass("gradeX");
                          }

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -375,6 +375,7 @@ class GC(object):
                             [
                                 'run.php' in linkline['href'],
                                 'go.php' in linkline['href'],
+                                'comicfiles.ru' in linkline['href'],
                             ]
                         ):
                             volume = x.findNext(text=True)

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6592,22 +6592,25 @@ class WebInterface(object):
                                 'a_size':  None,
                                 'a_id':  None})
          else:
-             filelocation = os.path.join(mylar.CONFIG.DDL_LOCATION, active['filename'])
-             #logger.fdebug('checking file existance: %s' % filelocation)
-             if os.path.exists(filelocation) is True:
-                 filesize = os.stat(filelocation).st_size
-                 cmath = int(float(filesize*100)/int(int(active['remote_filesize'])*100) * 100)
-                 #logger.fdebug('ACTIVE DDL: %s  %s  [%s]' % (active['filename'], cmath, 'Downloading'))
-                 return json.dumps({'status':      'Downloading',
-                                    'percent':     "%s%s" % (cmath, '%'),
-                                    'a_series':    active['series'],
-                                    'a_year':      active['year'],
-                                    'a_filename':  active['filename'],
-                                    'a_size':      active['size'],
-                                    'a_id':        active['id']})
+             if active['filename'] is not None:
+                 filelocation = os.path.join(mylar.CONFIG.DDL_LOCATION, active['filename'])
+                 #logger.fdebug('checking file existance: %s' % filelocation)
+                 if os.path.exists(filelocation) is True:
+                     filesize = os.stat(filelocation).st_size
+                     cmath = int(float(filesize*100)/int(int(active['remote_filesize'])*100) * 100)
+                     #logger.fdebug('ACTIVE DDL: %s  %s  [%s]' % (active['filename'], cmath, 'Downloading'))
+                     return json.dumps({'status':      'Downloading',
+                                        'percent':     "%s%s" % (cmath, '%'),
+                                        'a_series':    active['series'],
+                                        'a_year':      active['year'],
+                                        'a_filename':  active['filename'],
+                                        'a_size':      active['size'],
+                                        'a_id':        active['id']})
+                 statline = '%s does not exist.</br> This probably needs to be restarted (use the option in the GUI)' % filelocation
              else:
-             #    myDB.upsert('ddl_info', {'status': 'Incomplete'}, {'id': active['id']})
-                 return json.dumps({'a_id': active['id'], 'status': 'File does not exist in %s.</br> This probably needs to be restarted (use the option in the GUI)' % filelocation, 'percent': 0})
+                 infoline = '%s (%s)' % (active['series'], active['year'])
+                 statline = 'No filename assigned for %s.</br> This was probably never started successfully - you should restart the download (use the option in the GUI)' % infoline
+             return json.dumps({'a_id': active['id'], 'status': statline, 'percent': 0})
 
     check_ActiveDDL.exposed = True
 


### PR DESCRIPTION
- FIX: corrected incorrect url check for DDL in order to get some additional values when parsing search results for matching values.
- FIX: if a DDL download failed during a download, or never initiated properly (probably due to CF popping up), filename would be invalid and it would not give available options in the GUI
- FIX: corrected Failed color status in DDL history view