### PR TITLE
Add a config option for backups during startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,13 @@ FROM python:${BASE_VERSION}
 
 # set version label
 ARG MYLAR_COMMIT=v0.3.0
+ARG ORG=mylar3
 LABEL version ${BASE_VERSION}_${MYLAR_COMMIT}
 
 RUN \
 echo "**** install system packages ****" && \
  apk add --no-cache \
- git=2.24.1-r0 \
+ git=2.24.3-r0 \
  # cfscrape dependecies
  nodejs=12.15.0-r1 \
  # unrar-cffi & Pillow dependencies
@@ -24,7 +25,7 @@ echo "**** install system packages ****" && \
 # docker host over /app/mylar.
 RUN echo "**** install app ****" && \
  git config --global advice.detachedHead false && \
- git clone https://github.com/mylar3/mylar3.git --depth 1 --branch ${MYLAR_COMMIT} --single-branch /app/mylar
+ git clone https://github.com/${ORG}/mylar3.git --depth 1 --branch ${MYLAR_COMMIT} --single-branch /app/mylar
 
 RUN echo "**** install requirements ****" && \
  pip3 install --no-cache-dir -U -r /app/mylar/requirements.txt && \

--- a/Mylar.py
+++ b/Mylar.py
@@ -214,6 +214,9 @@ def main():
 
     # backup the db and configs before they load.
     if args.backup:
+        mylar.config.BACKUP_ON_START = True
+
+    if mylar.config.BACKUP_ON_START:
         print('[AUTO-BACKUP] Backing up .db and config.ini files for safety.')
         backupdir = os.path.join(mylar.DATA_DIR, 'backup')
 

--- a/Mylar.py
+++ b/Mylar.py
@@ -213,7 +213,7 @@ def main():
             raise SystemExit('Cannot write to the data directory: ' + mylar.DATA_DIR + '. Exiting...')
 
     # backup the db and configs before they load.
-    if args.backup or mylar.config.BACKUP_ON_START:
+    if args.backup or mylar.CONFIG.BACKUP_ON_START:
         print('[AUTO-BACKUP] Backing up .db and config.ini files for safety.')
         backupdir = os.path.join(mylar.DATA_DIR, 'backup')
 

--- a/Mylar.py
+++ b/Mylar.py
@@ -213,10 +213,7 @@ def main():
             raise SystemExit('Cannot write to the data directory: ' + mylar.DATA_DIR + '. Exiting...')
 
     # backup the db and configs before they load.
-    if args.backup:
-        mylar.config.BACKUP_ON_START = True
-
-    if mylar.config.BACKUP_ON_START:
+    if args.backup or mylar.config.BACKUP_ON_START:
         print('[AUTO-BACKUP] Backing up .db and config.ini files for safety.')
         backupdir = os.path.join(mylar.DATA_DIR, 'backup')
 

--- a/Mylar.py
+++ b/Mylar.py
@@ -237,7 +237,7 @@ def main():
                 back_1 = os.path.join(backupdir, 'config.ini.1')
 
             try:
-                print('[AUTO-BACKUP] Now Backing up mylar.db file')
+                print('[AUTO-BACKUP] Now Backing up ' + back + ' file')
                 if os.path.isfile(back_1):
                     print('[AUTO-BACKUP] ' + back_1 + ' exists. Deleting and keeping new.')
                     os.remove(back_1)

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -210,6 +210,10 @@
                                  </div>
 
                                  <div class="row checkbox">
+                                    <input type="checkbox" name="backup_on_start" value="1" ${config['backup_on_start']} /> <label>Backup Database on Startup</label>
+                                 </div>
+
+                                 <div class="row checkbox">
                                     <input type="checkbox" name="syno_fix" value="1" ${config['syno_fix']} /> <label>Synology Fix</label>
                                     <br/><small>*Use this if experiencing parsing problems*</small>
                                  </div>

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -81,6 +81,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'CLEANUP_CACHE': (bool, 'General', False),
     'SECURE_DIR': (str, 'General', None),
     'ENCRYPT_PASSWORDS': (bool, 'General', False),
+    'BACKUP_ON_START': (bool, 'General', False),
 
     'RSS_CHECKINTERVAL': (int, 'Scheduler', 20),
     'SEARCH_INTERVAL': (int, 'Scheduler', 360),

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5308,7 +5308,7 @@ class WebInterface(object):
                     "dlstats": dlprovstats,
                     "dltotals": freq_tot,
                     "alphaindex": mylar.CONFIG.ALPHAINDEX,
-                    "backup_on_start": mylar.CONFIG.BACKUP_ON_START
+                    "backup_on_start": helpers.checked(mylar.CONFIG.BACKUP_ON_START)
                }
         return serve_template(templatename="config.html", title="Settings", config=config, comicinfo=comicinfo)
     config.exposed = True

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5307,7 +5307,8 @@ class WebInterface(object):
                     "opds_pagesize": mylar.CONFIG.OPDS_PAGESIZE,
                     "dlstats": dlprovstats,
                     "dltotals": freq_tot,
-                    "alphaindex": mylar.CONFIG.ALPHAINDEX
+                    "alphaindex": mylar.CONFIG.ALPHAINDEX,
+                    "backup_on_start": mylar.CONFIG.BACKUP_ON_START
                }
         return serve_template(templatename="config.html", title="Settings", config=config, comicinfo=comicinfo)
     config.exposed = True

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5573,7 +5573,7 @@ class WebInterface(object):
 
 
     def configUpdate(self, **kwargs):
-        checked_configs = ['enable_https', 'launch_browser', 'syno_fix', 'auto_update', 'annuals_on', 'api_enabled', 'nzb_startup_search',
+        checked_configs = ['enable_https', 'launch_browser', 'backup_on_start', 'syno_fix', 'auto_update', 'annuals_on', 'api_enabled', 'nzb_startup_search',
                            'enforce_perms', 'sab_to_mylar', 'torrent_local', 'torrent_seedbox', 'rtorrent_ssl', 'rtorrent_verify', 'rtorrent_startonload',
                            'enable_torrents', 'enable_rss', 'nzbsu', 'nzbsu_verify',
                            'dognzb', 'dognzb_verify', 'experimental', 'enable_torrent_search', 'enable_32p', 'enable_torznab',


### PR DESCRIPTION
This should add the ability to run backups at startup through a config option instead of just a command line option. This will allow people like myself to use the LinuxServer.io image and maintain DB backups. This can be accomplished by restarting the container on a schedule, which is not ideal but is doable.

I'm getting errors when using the Dockerfile, so I have not been able to test this change.
```
ERROR: unsatisfiable constraints:
  git-2.24.3-r0:
    breaks: world[git=2.24.1-r0]
```