### PR TITLE
FIX: fix for CDH (SABnzbd) not finding nzo_id when querying sab history

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3237,7 +3237,9 @@ def nzb_monitor(queue):
             if item == 'exit':
                 logger.info('Cleaning up workers for shutdown')
                 break
+            tmp_apikey = item['queue'].pop('apikey')
             logger.info('Now loading from queue: %s' % item)
+            item['queue']['apikey'] = tmp_apikey
             if all([mylar.USE_SABNZBD is True, mylar.CONFIG.SAB_CLIENT_POST_PROCESSING is True]):
                 nz = sabnzbd.SABnzbd(item)
                 nzstat = nz.processor()


### PR DESCRIPTION
- FIX: fix for SABnzbd not returning enough results when searching history for matching nzo_id during CDH. Will either return last 200 results now (as opposed to 5-10), or will directly query against the specific nzo_id (sabnzbd 3.2.0Beta1+)
- FIX: removed indirect apikey references when logging relevant information related to sab.
- FIX: changed some INFO logging to DEBUG, and removed a few others (related to sabnzbd responses)