### PR TITLE
FIX: "RSS Feeds" Job Stuck Running

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -2996,6 +2996,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
 
             if rsscheck:
                 logger.info('Completed RSS Search scan')
+                mylar.SEARCHLOCK = False
             else:
                 logger.info('Completed Queueing API Search scan')
         else:


### PR DESCRIPTION
My "RSS Feeds" Job, as seen on Manage -> Activity / Jobs (Schedulers), always appears to be Running after the initial / successful run of the job after startup.  Looking at the code, the "[RSS-FEEDS] Watchlist Check for new Releases" (mylar.search.searchforissue(rsscheck='yes')) call in rsscheckit.py does not reset mylar.SEARCHLOCK which causes the subsequent job to do nothing but sleep.