### PR TITLE
fixes for using [__ISSUEID__] in filename during manual post-processing

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -544,8 +544,7 @@ class PostProcessor(object):
                                                 "One-Off":         False,
                                                 "ForcedMatch":     True})
                             logger.info('manual_list: %s' % manual_list)
-                            break
-
+                            continue
                         else:
                             tmpsql = "SELECT * FROM comics WHERE DynamicComicName IN ({seq}) COLLATE NOCASE".format(seq=','.join('?' * len(loopchk)))
                             comicseries = myDB.select(tmpsql, tuple(loopchk))
@@ -2621,7 +2620,11 @@ class PostProcessor(object):
                     if yyb != -1:
                         rem_issueid = nfilename[xyb+3:yyb]
                         logger.fdebug('issueid: %s' % rem_issueid)
-                        nfilename = '%s %s'.strip() % (nfilename[:xyb], nfilename[yyb+3:])
+                        two_add = re.sub(r'\s+', '', nfilename[yyb+3:]).strip()
+                        if any([two_add == '', two_add == ' ']):
+                            nfilename = '%s' % nfilename[:xyb].strip()
+                        else:
+                            nfilename = '%s %s' % (nfilename[:xyb].strip(), two_add)
                         logger.fdebug('issueid information [%s] removed successfully: %s' % (rem_issueid, nfilename))
 
             self._log("New Filename: %s" % nfilename)


### PR DESCRIPTION
- FIX:(#608) When using the [__ISSUEID__] switch in a filename during a manual post-processing with multiple files, would stop after the 1st file was post-processed.
- FIX: When using the [__ISSUEID__] switch in a filename, the resulting filename in some cases would contain an extra space prior to the extension.