### PR TITLE
FIX:(#584) "Test SABnzbd" button throws a SyntaxError as not all of t…

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -2217,7 +2217,7 @@
                             var obj = JSON.parse(data);
                             var versionsab = obj['version'];
                             vsab = numberWithDecimals(versionsab);
-                            $('#sabstatus').val(obj['status']);
+                            $('#sabstatus').val(obj['message']);
                             $('#sabversion span').text('SABnzbd version: '+versionsab);
                             if ( vsab < "0.8.0" ){
                                 scdh = document.getElementById("sab_cdh");
@@ -2232,8 +2232,8 @@
                                 nocdh = document.getElementById("sab_nocdh");
                                 nocdh.style.display = "none";
                             }
-                            $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>"+obj['status']+"</div>");
-                            if ( data.indexOf("Successfully") > -1){
+                            $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>"+obj['message']+"</div>");
+                            if (obj['status']){
                                 imagechk.src = "";
                                 imagechk.src = "images/success.png";
                                 imagechk.style.visibility = "visible";

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5670,10 +5670,6 @@ class WebInterface(object):
             sabapikey = mylar.CONFIG.SAB_APIKEY
         logger.fdebug('Now attempting to test SABnzbd connection')
 
-        #if user/pass given, we can auto-fill the API ;)
-        if sabusername is None or sabpassword is None:
-            logger.error('No Username / Password provided for SABnzbd credentials. Unable to test API key')
-            return "Invalid Username/Password provided"
         logger.fdebug('testing connection to SABnzbd @ ' + sabhost)
         if sabhost.endswith('/'):
             sabhost = sabhost
@@ -5719,9 +5715,9 @@ class WebInterface(object):
                     r = requests.get(querysab, params=payload, verify=verify)
                 except Exception as e:
                     logger.warn('Error fetching data from %s: %s' % (sabhost, e))
-                    return 'Unable to retrieve data from SABnzbd'
+                    return json.dumps({"status": False, "message": "Unable to retrieve data from SABnzbd.", "version": str(version)})
             else:
-                return 'Unable to retrieve data from SABnzbd'
+                return json.dumps({"status": False, "message": "Unable to retrieve data from SABnzbd.", "version": str(version)})
 
 
         logger.fdebug('status code: ' + str(r.status_code))
@@ -5735,21 +5731,14 @@ class WebInterface(object):
         try:
             q_apikey = data['config']['misc']['api_key']
         except:
-            logger.error('Error detected attempting to retrieve SAB data using FULL APIKey')
-            if all([sabusername is not None, sabpassword is not None]):
-                try:
-                    sp = sabparse.sabnzbd(sabhost, sabusername, sabpassword)
-                    q_apikey = sp.sab_get()
-                except Exception as e:
-                    logger.warn('Error fetching data from %s: %s' % (sabhost, e))
-                if q_apikey is None:
-                    return "Invalid APIKey provided"
+            logger.error('Error detected attempting to retrieve SAB data using FULL API Key')
+            return json.dumps({"status": False, "message": "Invalid API Key provided.", "version": str(version)})
 
         mylar.CONFIG.SAB_APIKEY = q_apikey
-        logger.info('APIKey provided is the FULL APIKey which is the correct key. You still need to SAVE the config for the changes to be applied.')
+        logger.info('APIKey provided is the FULL API Key which is the correct key. You still need to SAVE the config for the changes to be applied.')
         logger.info('Connection to SABnzbd tested sucessfully')
         mylar.CONFIG.SAB_VERSION = version
-        return json.dumps({"status": "Successfully verified APIkey.", "version": str(version)})
+        return json.dumps({"status": True, "message": "Successfully verified API Key.", "version": str(version)})
 
     SABtest.exposed = True
 
@@ -5848,7 +5837,7 @@ class WebInterface(object):
     def findsabAPI(self, sabhost=None, sabusername=None, sabpassword=None):
         sp = sabparse.sabnzbd(sabhost, sabusername, sabpassword)
         sabapi = sp.sab_get()
-        logger.info('SAB APIKey found as : ' + str(sabapi) + '. You still have to save the config to retain this setting.')
+        logger.info('SAB API Key found as : ' + str(sabapi) + '. You still have to save the config to retain this setting.')
         mylar.CONFIG.SAB_APIKEY = sabapi
         return sabapi
 


### PR DESCRIPTION
…he SABtest() responses are JSON encoded. Also simplified a bit by removing the "Get API" call as there is an explicit link to do that.