### PR TITLE
IMP: improved speed of ReCheck Files

### DIFF
--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -705,6 +705,13 @@ def dbcheck():
     conn.commit
     c.close
 
+    #create some indexes
+    c.execute('CREATE INDEX IF NOT EXISTS issues_id on issues(IssueID)')
+    c.execute('CREATE INDEX IF NOT EXISTS comics_id on comics(ComicID)')
+
+    #might enable these at a later date.
+    #c.execute('''PRAGMA synchronous = EXTRA''')
+    #c.execute('''PRAGMA journal_mode = WAL''')
 
     #add in the late players to the game....
     # -- Comics Table --


### PR DESCRIPTION
During a ReCheck Files of series that has a large issue base, the actual writing of issues to the db was very slow - especially when the issues were not present (ie. not Downloaded).

As an example, 
For a series of ~2230 issues, of which 2196 were not present.
before:
issue_status_writing took 0:00:18.884588

after:
issue_status_writing took 0:00:00.029606

This might need some further optimisation and/or testing, but from my limited testing it seems to be working far quicker than expected.
