### PR TITLE
FIX: fixed sorting of Have column on non-alpha index

### DIFF
--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -150,8 +150,11 @@ class WebInterface(object):
 
         #below sort is for multi-sort columns, maybe make them user configurable - not sure how to pass mutli-sort thru otherwise
         #filtered.sort(key= itemgetter(sortcolumn2, sortcolumn), reverse=sSortDir_0 == "desc")
-
-        filtered.sort(key=lambda x: (x[sortcolumn] is None, x[sortcolumn] == '', x[sortcolumn]), reverse=sSortDir_0 == "desc")
+        if sortcolumn == 'percent':
+            filtered.sort(key=lambda x: (x['totalissues'] is None, x['totalissues'] == '', x['totalissues']), reverse=sSortDir_0 == "asc")
+            filtered.sort(key=lambda x: (x['haveissues'] is None, x['haveissues'] == '', x['haveissues']), reverse=sSortDir_0 == "desc")
+        else:
+            filtered.sort(key=lambda x: (x[sortcolumn] is None, x[sortcolumn] == '', x[sortcolumn]), reverse=sSortDir_0 == "desc")
         rows = filtered[iDisplayStart:(iDisplayStart + iDisplayLength)]
         rows = [[row['ComicPublisher'], row['ComicName'], row['ComicYear'], row['LatestIssue'], row['LatestDate'], row['recentstatus'], row['Status'], row['percent'], row['haveissues'], row['totalissues'], row['ComicID'], row['displaytype'], row['ComicVolume']] for row in rows]
         return json.dumps({


### PR DESCRIPTION
This PR only affects the view for the non-alpha main page (alphaindex = False)

Previously sorting the Have column on the main index page would result in sorting by completion percentage, which would incorrectly sort.

This fixes it so that it now sorts by Total Issues descending, then by Have Issues ascending - which results in items in a more logical sequence (ie. so 0/400 comes before 0/1, both of which come before 1/34).