### PR TITLE
IMP: small improvments involving ReCheck Files

### DIFF
--- a/mylar/db.py
+++ b/mylar/db.py
@@ -109,7 +109,7 @@ class DBConnection:
 
 
 
-    def action(self, query, args=None):
+    def action(self, query, args=None, executemany=False):
 
         with db_lock:
             if query == None:
@@ -121,11 +121,15 @@ class DBConnection:
             while attempt < 5:
                 try:
                     if args == None:
-                        #logger.fdebug("[ACTION] : " + query)
-                        sqlResult = self.connection.execute(query)
+                        if executemany is False:
+                            sqlResult = self.connection.execute(query)
+                        else:
+                            sqlResult = self.connection.executemany(query)
                     else:
-                        #logger.fdebug("[ACTION] : " + query + " with args " + str(args))
-                        sqlResult = self.connection.execute(query, args)
+                        if executemany is False:
+                            sqlResult = self.connection.execute(query, args)
+                        else:
+                            sqlResult = self.connection.executemany(query, args)
                     self.connection.commit()
                     break
                 except sqlite3.OperationalError as e:


### PR DESCRIPTION
Small improvements to the previous ReCheck PR:
- replaced iteration with executemany in regards to writing data to the db with relation to Status (ReCheck Files).
- instead of a separate connection to the mylar.db, will use existing connection via the db module. This should help prevent any database locking regarding this aspect.
- added the executemany option to the db module - which allows said execution over iteration, which should increase write times as well.
- both the above were done in regards to the ReCheck Files option only. Other aspects may/may not see improvements if used there.
