### PR TITLE
FIX:(#632) Add a try/except around image retrieval in case image is not yet present on CV

### DIFF
--- a/mylar/mb.py
+++ b/mylar/mb.py
@@ -305,12 +305,13 @@ def findComic(name, mode, issue, limityear=None, type=None):
                                 xml_lastissueid = result.getElementsByTagName('id')[cl].firstChild.wholeText
                             cl+=1
 
-                        if result.getElementsByTagName('super_url')[0].firstChild.wholeText:
+                        try:
                             xmlimage = result.getElementsByTagName('super_url')[0].firstChild.wholeText
-                        elif result.getElementsByTagName('small_url')[0].firstChild.wholeText:
-                            xmlimage = result.getElementsByTagName('small_url')[0].firstChild.wholeText
-                        else:
-                            xmlimage = "cache/blankcover.jpg"
+                        except Exception:
+                            try:
+                                xmlimage = result.getElementsByTagName('small_url')[0].firstChild.wholeText
+                            except Exception:
+                                xmlimage = "cache/blankcover.jpg"
 
                         if (result.getElementsByTagName('start_year')[0].firstChild) is not None:
                             xmlYr = result.getElementsByTagName('start_year')[0].firstChild.wholeText


### PR DESCRIPTION
In some cases, CV might not have available fields populated in the XML being returned from a search query due to being new series present in the listing, which causes search results for a query to finish generating (and thus no display to GUI). 

ATM this can happen for images, but this might have to be extended / refined if more fields end up being blank in order to avoid errors.