### PR TITLE
DDL: Use alternate search patterns as needed, and auto-correct query based on specific characters 

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -922,7 +922,10 @@ def NZB_SEARCH(
                 lineq = findcomic
             else:
                 lineq = '%s %s' % (findcomic, isssearch)
-            b = getcomics.GC(query=lineq)
+            fline = {'comicname': findcomic,
+                     'issue':     isssearch,
+                     'year':      comyear}
+            b = getcomics.GC(query=fline)
             bb = b.search()
         elif RSS == "yes":
             if nzbprov == 'DDL':


### PR DESCRIPTION
- IMP: Use alternate search patterns with DDL until some valid matches are found. Used #382 as the main basis for the change (thnx @Micket).
- IMP: auto-correct DDL search query if series contains either ':' or '/'.