### PR TITLE
IMP: check booktype before attempting to snatch DDL links, IMP: Ignore weekly packs in DDL results

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -2216,6 +2216,7 @@ def NZB_SEARCH(
                             "tmpprov": tmpprov,
                             "kind": kind,
                             "SARC": SARC,
+                            "booktype": booktype,
                             "IssueArcID": IssueArcID,
                             "newznab": newznab_host,
                             "torznab": torznab_host,
@@ -2390,6 +2391,7 @@ def NZB_SEARCH(
                                     "size": comsize_m,
                                     "tmpprov": tmpprov,
                                     "kind": kind,
+                                    "booktype": booktype,
                                     "SARC": SARC,
                                     "IssueArcID": IssueArcID,
                                     "newznab": newznab_host,
@@ -3837,7 +3839,7 @@ def searcher(
             tmp_issueid = IssueID
         ggc = getcomics.GC(issueid=tmp_issueid, comicid=ComicID)
         ggc.loadsite(nzbid, link)
-        ddl_it = ggc.parse_downloadresults(nzbid, link)
+        ddl_it = ggc.parse_downloadresults(nzbid, link, comicinfo)
         if ddl_it['success'] is True:
             logger.info(
                 'Successfully snatched %s from DDL site. It is currently being queued'


### PR DESCRIPTION
- Check booktype before attempting to snatch non-booktype related issues with DDL (ie. issue vs TPB). This can occur when items are part of a pack and they add TPB to the listing, in some cases the issues are on non-resolvable links so Mylar attempts to snatch the TPB links since they're active, but they weren't being searched for.

- Ignore weekly pack matches for DDL single issue searches. Since Mylar can't process 0-day packs as of yet from DDL, there's no point in retaining it as a search result.