### PR TITLE
IMP: Changed the entire method Mylar uses to maintain series being up-to-date

### DIFF
--- a/mylar/config.py
+++ b/mylar/config.py
@@ -82,6 +82,8 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'SECURE_DIR': (str, 'General', None),
     'ENCRYPT_PASSWORDS': (bool, 'General', False),
     'BACKUP_ON_START': (bool, 'General', False),
+    'BACKFILL_LENGTH': (int, 'General', 8),  # weeks
+    'BACKFILL_TIMESPAN': (int, 'General', 10),   # minutes
 
     'RSS_CHECKINTERVAL': (int, 'Scheduler', 20),
     'SEARCH_INTERVAL': (int, 'Scheduler', 360),

--- a/mylar/mb.py
+++ b/mylar/mb.py
@@ -533,7 +533,7 @@ def storyarcinfo(xmlid):
             fi+=1
         logger.fdebug('firstid: ' + str(firstid))
         if firstid is not None:
-            firstdom = cv.pulldetails(comicid=None, type='firstissue', issueid=firstid)
+            firstdom = cv.pulldetails(comicid=None, rtype='firstissue', issueid=firstid)
             logger.fdebug('success')
             arcyear = cv.Getissue(firstid,firstdom,'firstissue')
     except:

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -635,7 +635,7 @@ class WebInterface(object):
                             f.write(chunk)
                             f.flush()
 
-        arc_results = mylar.cv.getComic(comicid=None, type='issue', arcid=arcid, arclist=arclist)
+        arc_results = mylar.cv.getComic(comicid=None, rtype='issue', arcid=arcid, arclist=arclist)
         logger.fdebug('%s Arcresults: %s' % (module, arc_results))
         logger.fdebug('%s Arclist: %s' % (module, arclist))
         if len(arc_results) > 0:
@@ -731,7 +731,7 @@ class WebInterface(object):
                                   "Int_IssueNumber":    int_issnum,
                                   "Manual":             manual_mod})
                 n+=1
-            comicid_results = mylar.cv.getComic(comicid=None, type='comicyears', comicidlist=cidlist)
+            comicid_results = mylar.cv.getComic(comicid=None, rtype='comicyears', comicidlist=cidlist)
             logger.fdebug('%s Initiating issue updating - just the info' % module)
 
             for AD in issuedata:
@@ -6913,3 +6913,9 @@ class WebInterface(object):
         #data = wv.read_comic(ish_id)
         return data
     read_comic.exposed = True
+
+    def dbupdater_watchlist(self):
+        updater.watchlist_updater()
+    dbupdater_watchlist.exposed = True
+
+


### PR DESCRIPTION
Currently in order to keep watchlisted series up-to-date, Mylar goes from oldest last update time to newest - so the oldest titles will always get refreshed first. This has several problems with it - namely that it has to poll CV every 5 minutes so the backlog doesn't get huge, it's constantly updating old series that might not need/have an update, it's just inefficient.

The new method introduced in this PR:
- will poll CV for issues that have been updated in the last 8 weeks initially on first startup (this is configurable, ```DB_BACKFILL``` can be set to a higher numeric if required). However larger datasets will require more time to back-fill.
- if the results comes back as more than 1500 entries for the 8 week period, it will only query for the last 1500 items based on the update_date within CV. 
- the remainder of everything above 1500 will be set to be checked in sequence every 10 minutes at 1500 items / set until the backlog is completed.  (so if 15,000 items are returned as having had updates during that 8 week period, the last 1500 / 15000 will be checked, then the next 1500/13500, then the next 1500/12000, etc).
- Mylar will only update series that have had issues updated that pertain to their specific comicid.
- Once initially caught up, the scheduler will fire off every 24 hrs thereafter to check if there is anything new and only run a full update on the series that are shown as having new data posted during that time frame.
- Since Mylar knows the last run date of this job, if you leave Mylar off for a few days and turn it back on, Mylar will fire off the updater from the point of the last run (so 3 days ago in this example) and update accordingly.

Between the updater running in this method, and the pull-list method of updating only relevant issues during a 4 hr check, coverage should be much better as far as maintaining relevant information.