### PR TITLE
IMP: When the weekly pull job runs, it will now recreate the pull for previous week as well

### DIFF
--- a/mylar/locg.py
+++ b/mylar/locg.py
@@ -132,7 +132,7 @@ def locg(pulldate=None,weeknumber=None,year=None):
                                 'FORMAT':      x['format']}
                 myDB.upsert("weekly", newValueDict, controlValueDict)
 
-            logger.info('[PULL-LIST] Successfully populated pull-list into Mylar for the week of: ' + str(weeknumber))
+            logger.info('[PULL-LIST] Successfully populated pull-list into Mylar for week %s of %s' % (weeknumber, year))
             #set the last poll date/time here so that we don't start overwriting stuff too much...
             mylar.CONFIG.PULL_REFRESH = todaydate.strftime('%Y-%m-%d %H:%M:%S')
             mylar.CONFIG.writeconfig(values={'pull_refresh': mylar.CONFIG.PULL_REFRESH})


### PR DESCRIPTION
Due to CV not updating items until the following week in some cases, and because the weekly pull changes to the new week on Sundays, some issues on the Wanted list from the previous week would not get updated until the given series was either manually refreshed or a new issue came out in subsequent weeks.

This PR tries to ensure that the stragglers (ie. updates on CV that happen after the pull changes over), are updated and displayed correctly on the given week's pull. This will update the current week, as well as the previous week's pull-list with any relevant issue information changes.