### PR TITLE
FIXES:  adding a series via the Search causing an error, incorrect value used for publication run, duplicates when using filter on main page 

### DIFF
--- a/data/interfaces/default/comicdetails.html
+++ b/data/interfaces/default/comicdetails.html
@@ -93,9 +93,18 @@
                                          css = '<div class=\"progress-container missing\">'
                           %>
                    <div style="display:table;position:relative;margin:auto;top:0px;"><span title="${comicConfig['percent']}"></span>${css}<div style="width:${comicConfig['percent']}%"><span class="progressbar-front-text">${comicConfig['haveissues']}/${comicConfig['totalissues']}</span></div></div></div>
+                   <%
+                        try:
+                            meta_series = False
+                            if mylar.CONFIG.SERIES_METADATA_LOCAL is True:
+                                if os.path.exists(os.path.join(comic['ComicLocation'], 'series.json')):
+                                    meta_series = True
+                        except:
+                            pass
+                   %>
                    %if mylar.CONFIG.SERIES_METADATA_LOCAL is True:
                        <div class="outerglow" style="z-index: 10; position: absolute; float: right; bottom: 10px; right: -50px;">
-                       %if os.path.exists(os.path.join(comic['ComicLocation'], 'series.json')):
+                       %if meta_series is True:
                            <span title="series.json found in comic directory" class="outerglow_shadow">series.json</span>
                            <span class="outerglow_text">series.json</span>
                        %endif

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -1452,7 +1452,7 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
             stmonth = helpers.fullmonth(firstdate[5:7])
 
         #if the store date exists and is newer than the pub date - use the store date for ended calcs.
-        if latest_stdate is not None:
+        if all([latest_stdate is not None, latest_stdate != '0000-00-00']):
             p_date = datetime.date(int(latestdate[:4]), int(latestdate[5:7]), 1)
             s_date = datetime.date(int(latest_stdate[:4]), int(latest_stdate[5:7]), 1)
             if s_date > p_date:

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -124,14 +124,16 @@ class WebInterface(object):
         else:
             for row in resultlist:
                 try:
-                    if any([sSearch.lower() in row['ComicPublisher'].lower(), sSearch.lower() in row['ComicName'].lower(), sSearch.lower() in row['ComicYear'], sSearch.lower() in row['LatestIssue'].lower(), sSearch.lower() in row['recentstatus'].lower()]):
+                    lat_iss = row['LatestIssue']
+                    if lat_iss is None:
+                        lat_iss = ''
+                    if any([sSearch.lower() in row['ComicPublisher'].lower(), sSearch.lower() in row['ComicName'].lower(), sSearch.lower() in row['ComicYear'], sSearch.lower() in lat_iss, sSearch.lower() in row['recentstatus'].lower()]):
                         filtered.append(row)
                     elif row['displaytype'] is not None and sSearch.lower() in row['displaytype'].lower():
                         filtered.append(row)
                 except Exception as e:
                     filtered = [row for row in resultlist if any([sSearch.lower() in row['ComicName'].lower(), sSearch.lower() in row['ComicYear'], sSearch.lower() in row['recentstatus']]) or (row['LatestIssue'] is not None and sSearch.lower() in row['LatestIssue'].lower())]
 
-            #filtered = [row for row in resultlist if any([sSearch.lower() in row['ComicPublisher'].lower(), sSearch.lower() in row['ComicName'].lower(), sSearch.lower() in row['ComicYear'], False if row['displaytype'] is None else (True if sSearch.lower() in row['displaytype'] else False), sSearch.lower() in row['LatestIssue'], sSearch.lower() in row['recentstatus']])]
         sortcolumn = 'ComicPublisher'
         if iSortCol_0 == '0':
             sortcolumn = 'ComicPublisher'


### PR DESCRIPTION
- FIX: fix for latest storedate being used for publication run, if the value is 0000-00-00
- FIX: when adding a series via the Search option, would throw back an error related to metadata location when trying to load the relevant series
- FIX: fix for low chance of duplicates appearing on main watchlist page when using the filter option