### PR TITLE
series.json fixes that broke when editing a series description

### DIFF
--- a/data/interfaces/default/comicdetails.html
+++ b/data/interfaces/default/comicdetails.html
@@ -810,7 +810,7 @@
                     return(value);
                 }
             });
-            $('.description_edit').editable('.description_edit', {
+            $('.description_edit').editable('description_edit', {
                 loadurl: 'get_description',
                 type: 'textarea',
                 submit: '<button class="button btn btn-success" type="submit">Ok</button>',

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -7027,7 +7027,7 @@ class WebInterface(object):
                 except Exception as e:
                     logger.info('No description found in metadata. Reloading from dB if available.[error: %s]' % e)
 
-        if descripton_load is not None:
+        if description_load is not None:
             return description_load
         elif desc:
             if desc['DescriptionEdit']:
@@ -7070,7 +7070,6 @@ class WebInterface(object):
             clean_issue_list = None
             if comic['Collects'] != 'None':
                 clean_issue_list = comic['Collects']
-
 
             if description_load is not None:
                 cdes_removed = re.sub(r'\n', '', description_load).strip()


### PR DESCRIPTION
- FIX: when editing description for a series, would fail to initially load up existing description for editing (would be a blank canvas)
- FIX: Clicking on OK after editing would not update description