### PR TITLE
Experimental search query changes

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -1267,6 +1267,10 @@ def NZB_SEARCH(
                 bb = findcomicfeed.Startit(
                     findcomic, isssearch, comyear, ComicVersion, IssDateFix, booktype
                 )
+                if bb == 'disable':
+                    helpers.disable_provider('experimental', 'unresponsive / down')
+                    foundc['status'] = False
+                    done = True
                 # since the regexs in findcomicfeed do the 3 loops,
                 # lets force the exit after
                 cmloopit == 1


### PR DESCRIPTION
-IMP: (FIXES #664, #670, #689) changes experimental search so it doesn't query multiple times for the same issue, instead does it all in one query
- IMP: allows for possible disabling if query returns are invalid