### PR TITLE
some docker patches to make things simpler

### DIFF
--- a/Mylar.py
+++ b/Mylar.py
@@ -348,12 +348,12 @@ def main():
         'opds_pagesize': mylar.CONFIG.OPDS_PAGESIZE,
     }
 
-    # Try to start the server.
-    webstart.initialize(web_config)
-
     #check for version here after web server initialized so it doesn't try to repeatidly hit github
     #for version info if it's already running
     versioncheck.versionload()
+
+    # Try to start the server.
+    webstart.initialize(web_config)
 
     if mylar.CONFIG.LAUNCH_BROWSER and not args.nolaunch:
         mylar.launch_browser(mylar.CONFIG.HTTP_HOST, http_port, mylar.CONFIG.HTTP_ROOT)

--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -97,8 +97,10 @@
 				<a href="shutdown"><span class="ui-button-icon-primary ui-icon ui-icon-power"></span>Shutdown</a> |
 				<a href="restart"><span class="ui-button-icon-primary ui-icon ui-icon-power"></span>Restart</a> |
 				<a href="auth/logout"><span class="ui-button-icon-primary ui-icon ui-icon-power"></span>Logout</a></br>
-				<a href="#" onclick="doAjaxCall('checkGithub',$(this))" data-success="Checking for update successful" data-error="Error checking for update"><span class="ui-icon ui-icon-refresh"></span>Check for new version</a>
-				</small>
+                                %if mylar.INSTALL_TYPE != 'docker':
+                                    <a href="#" onclick="doAjaxCall('checkGithub',$(this))" data-success="Checking for update successful" data-error="Error checking for update"><span class="ui-icon ui-icon-refresh"></span>Check for new version</a>
+                                %endif
+			 	</small>
 			</div>
                         <div id="donate">
                             %if mylar.DONATEBUTTON:

--- a/mylar/versioncheck.py
+++ b/mylar/versioncheck.py
@@ -165,7 +165,14 @@ def getVersion():
 
     else:
 
-        mylar.INSTALL_TYPE = 'source'
+        d_path = '/proc/self/cgroup'
+        if os.path.exists('/.dockerenv') or os.path.isfile(d_path) and any('docker' in line for line in open(d_path)):
+            logger.info('[DOCKER-AWARE] Docker installation detected.')
+            mylar.INSTALL_TYPE = 'docker'
+        else:
+            logger.info('Not a Docker installation.')
+            mylar.INSTALL_TYPE = 'source'
+
         #current_version = None
         branch = None
 
@@ -284,12 +291,10 @@ def checkGithub(current_version=None):
 
 def update():
 
-
     if mylar.INSTALL_TYPE == 'win':
 
         logger.info('Windows .exe updating not supported yet.')
         pass
-
 
     elif mylar.INSTALL_TYPE == 'git':
 
@@ -307,6 +312,9 @@ def update():
             elif line.endswith('Aborting.'):
                 logger.error('Unable to update from git: ' +line)
                 logger.info('Output: ' + str(output))
+
+    elif mylar.INSTALL_TYPE == 'docker':
+        logger.info('Docker updates via it\'s own mechanics. Updating docker via Mylar GUI not supported at this time.')
 
     else:
 
@@ -384,7 +392,7 @@ def versionload():
 
     logger.info('Version information: %s [%s]' % (mylar.CONFIG.GIT_BRANCH, mylar.CURRENT_VERSION))
 
-    if mylar.CONFIG.CHECK_GITHUB_ON_STARTUP:
+    if mylar.CONFIG.CHECK_GITHUB_ON_STARTUP and mylar.INSTALL_TYPE != 'docker':
         try:
             mylar.LATEST_VERSION = checkGithub() #(CURRENT_VERSION)
         except:


### PR DESCRIPTION
- IMP: will now indicate if docker is being used in the GUI
- IMP: disable built-in updater and update-checks if docker is being run
- IMP: run versioncheck prior to starting the webinterface to avoid error message if trying to view webpage after initial startup too quickly  (wasn't finished starting up fully).