### PR TITLE
FIX: fix for SABnzbd directory option not being properly determined

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -374,20 +374,23 @@ class PostProcessor(object):
                     else:
                         # if the SAB Directory option is enabled, let's use that folder name and append the jobname.
                         if all([mylar.CONFIG.SAB_TO_MYLAR, mylar.CONFIG.SAB_DIRECTORY is not None, mylar.CONFIG.SAB_DIRECTORY != 'None']):
-                            tmpchk = os.path.join(mylar.CONFIG.SAB_DIRECTORY, self.nzb_name) # .encode(mylar.SYS_ENCODING)
-                            if os.path.exists(tmpchk):
-                                self.nzb_folder = tmpchk
-                                logger.fdebug('%s SABnzbd Download folder option enabled. Directory set to : %s' % (module, self.nzb_folder))
+                            if os.path.exists(os.path.join(self.nzb_folder, self.nzb_name)):
+                                logger.fdebug('%s SABnzbd Download folder option enabled. Using directory of : %s' % (module, self.nzb_folder))
                             else:
-                                tmpchk2 = os.path.join(mylar.CONFIG.SAB_DIRECTORY, os.path.basename(self.nzb_folder))
-                                if os.path.exists(tmpchk2):
-                                    self.nzb_folder = tmpchk2
+                                tmpchk = os.path.join(mylar.CONFIG.SAB_DIRECTORY, self.nzb_name) # .encode(mylar.SYS_ENCODING)
+                                if os.path.exists(tmpchk):
+                                    self.nzb_folder = tmpchk
                                     logger.fdebug('%s SABnzbd Download folder option enabled. Directory set to : %s' % (module, self.nzb_folder))
                                 else:
-                                    logger.warn('Unable to locate directory within %s location. I have unsucessfully attempted to locate the following paths: %s & %s' % (mylar.CONFIG.SAB_DIRECTORY, tmpchk, tmpchk2))
-                                    self.valreturn.append({"self.log": self.log,
-                                                           "mode": 'stop'})
-                                    return self.queue.put(self.valreturn)
+                                    tmpchk2 = os.path.join(mylar.CONFIG.SAB_DIRECTORY, os.path.basename(self.nzb_folder))
+                                    if os.path.exists(tmpchk2):
+                                        self.nzb_folder = tmpchk2
+                                        logger.fdebug('%s SABnzbd Download folder option enabled. Directory set to : %s' % (module, self.nzb_folder))
+                                    else:
+                                        logger.warn('Unable to locate directory within %s location. I have unsucessfully attempted to locate the following paths: %s & %s' % (mylar.CONFIG.SAB_DIRECTORY, tmpchk, tmpchk2))
+                                        self.valreturn.append({"self.log": self.log,
+                                                               "mode": 'stop'})
+                                        return self.queue.put(self.valreturn)
 
                 if mylar.USE_NZBGET==1:
                     if self.nzb_name != 'Manual Run':

--- a/mylar/sabnzbd.py
+++ b/mylar/sabnzbd.py
@@ -188,6 +188,38 @@ class SABnzbd(object):
                                  'apicall':  True,
                                  'ddl':      False}
                         break
+
+                    elif all([mylar.CONFIG.SAB_TO_MYLAR, mylar.CONFIG.SAB_DIRECTORY is not None, mylar.CONFIG.SAB_DIRECTORY != 'None']):
+                        tmpfile = ntpath.basename(hq['storage'])
+                        tmp_path = os.path.abspath(os.path.join(hq['storage'], os.pardir))
+                        tmp_path_b = tmp_path.split(os.path.sep)[:-1]
+                        sub_dir = tmp_path.split(os.path.sep)[-1]
+                        rep_tmp_path_b = re.sub(os.path.sep.join(tmp_path_b), mylar.CONFIG.SAB_DIRECTORY, tmp_path).strip()
+
+                        try:
+                            if os.path.exists(os.path.join( rep_tmp_path_b, os.path.sep.join(sub_dir), tmpfile )):
+                                new_path = os.path.join( rep_tmp_path_b, os.path.sep.join(sub_dir), tmpfile )
+                            elif os.path.exists(os.path.join( rep_tmp_path_b, tmpfile )):
+                                new_path = os.path.join( rep_tmp_path_b, tmpfile )
+                            else:
+                                logger.error('[SAB-DIRECTORY ENABLED] No file found where it should be @ %s - sabnzbd passed this: %s' % (rep_tmp_path_b, hq['storage']))
+                                return {'status': 'file not found', 'failed': False}
+
+                        except Exception as e:
+                            logger.warn('[ERROR] %s' % e)
+                            return {'status': 'file not found', 'failed': False}
+
+                        logger.fdebug('location found @ %s' % new_path)
+                        found = {'status':   True,
+                                 'name':     ntpath.basename(new_path),
+                                 'location': os.path.abspath(os.path.join(new_path, os.pardir)),
+                                 'failed':   False,
+                                 'issueid':  nzbinfo['issueid'],
+                                 'comicid':  nzbinfo['comicid'],
+                                 'apicall':  True,
+                                 'ddl':      False}
+                        break
+
                     else:
                         logger.error('no file found where it should be @ %s - is there another script that moves things after completion ?' % hq['storage'])
                         return {'status': 'file not found', 'failed': False}


### PR DESCRIPTION
When using CDH and the SABnzbd directory option, searching the active queue if the directory option was not in the same path would result in files not being found error message. This also occured during post-processing as the directory option was not taking certain factors into account (same idea as the history check basically).