### PR TITLE
Pullist improvements

### DIFF
--- a/data/interfaces/carbon/css/style.css
+++ b/data/interfaces/carbon/css/style.css
@@ -1156,11 +1156,6 @@ div#artistheader h2 a {
   text-align: left;
   vertical-align: middle;
 }
-#pull_table th#publishdate {
-  min-width: 50px;
-  text-align: left;
-  vertical-align: middle;
-}
 #pull_table th#publisher {
   min-width: 100px;
   text-align: center;
@@ -1186,11 +1181,6 @@ div#artistheader h2 a {
   text-align: center;
   vertical-align: middle;
 }
-#pull_table td#publishdate {
-  max-width: 50px;
-  text-align: left;
-  vertical-align: middle;
-}
 #pull_table td#publisher {
   min-width: 100px;
   text-align: left;
@@ -1203,12 +1193,12 @@ div#artistheader h2 a {
 }
 #pull_table td#comicnumber {
   max-width: 25px;
-  text-align: left;
+  text-align: right;
   vertical-align: middle;
 }
 #pull_table td#status {
   min-width: 30px;
-  text-align: left;
+  text-align: center;
   vertical-align: middle;
 }
 #pull_table td#options {

--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -1146,11 +1146,6 @@ div#artistheader h2 a {
   text-align: left;
   vertical-align: middle;
 }
-#pull_table th#publishdate {
-  min-width: 50px;
-  text-align: left;
-  vertical-align: middle;
-}
 #pull_table th#publisher {
   min-width: 100px;
   text-align: left;
@@ -1176,11 +1171,6 @@ div#artistheader h2 a {
   text-align: left;
   vertical-align: middle;
 }
-#pull_table td#publishdate {
-  max-width: 50px;
-  text-align: left;
-  vertical-align: middle;
-}
 #pull_table td#publisher {
   min-width: 100px;
   text-align: left;
@@ -1193,12 +1183,12 @@ div#artistheader h2 a {
 }
 #pull_table td#comicnumber {
   max-width: 25px;
-  text-align: left;
+  text-align: right;
   vertical-align: middle;
 }
 #pull_table td#status {
   min-width: 30px;
-  text-align: left;
+  text-align: center;
   vertical-align: middle;
 }
 #pull_table td#options {

--- a/data/interfaces/default/weeklypull.html
+++ b/data/interfaces/default/weeklypull.html
@@ -93,6 +93,8 @@
                                         grade = 'D'
                                 elif weekly['STATUS'] == 'Paused':
                                         grade = 'T'
+                                elif weekly['STATUS'] == 'Mismatched':
+                                        grade = 'U'
                                 if weekly['AUTOWANT'] == True:
                                         grade = 'H'
 


### PR DESCRIPTION
- IMP: Improved mismatch detection when polling from backend and comparing against Watchlist.
- IMP: Added a ```Mismatched``` status to the weekly pull to indicate when a title on the watchlist has incorrectly been auto-matched (based on comicid) and the backend data is incorrect (assigned a specific series the wrong comicid).
- IMP: Safety check implement that will now check the date of the given issue in the pull that it's matched up to, to ensure it's in the correct week, as well as that the booktypes correctly match up.
- IMP: digital issue should now be more accurately detected as being such instead of mistakenly matched to their printed counterparts when both digital and print editions of a particular series are available.