### PR TITLE
Importing comics with # in their filenames leads to errors in moveit.…

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -296,7 +296,7 @@ def rename_param(comicid, comicname, issue, ofilename, comicyear=None, issueid=N
 #            issue = iss
 
 #            print ("converted issue#: " + str(issue))
-            logger.fdebug('issueid:' + str(issueid))
+#            logger.fdebug('issueid:' + str(issueid))
 
             if issueid is None:
                 logger.fdebug('annualize is ' + str(annualize))

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5017,8 +5017,8 @@ class WebInterface(object):
             results = myDB.select("SELECT * FROM importresults WHERE (WatchMatch is Null OR WatchMatch LIKE 'C%') AND DynamicName=? AND Volume=?",[DynamicName,volume])
         files = []
         for result in results:
-            files.append({'comicfilename': result['ComicFilename'],
-                          'comiclocation': result['ComicLocation'],
+            files.append({'comicfilename': urllib.parse.quote(result['ComicFilename']),
+                          'comiclocation': urllib.parse.quote(result['ComicLocation']),
                           'issuenumber':   result['IssueNumber'],
                           'import_id':     result['impID']})
 


### PR DESCRIPTION
Importing comics with # in their filenames leads to errors in moveit.py and websever.py .
This is because the # is not properly encoded in the URL, using urllib.parse.quote() resolves this.

In tracing it, I found that in helpers.py line 299, a log entry is called for variable that is not guaranteed to be filled at that point. That line has been commented to prevent that for now.
