### PR TITLE
FIX: Do not re-add previously deleted annuals from a series when annuals are enabled.

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -512,7 +512,7 @@ class PostProcessor(object):
                             logger.info('issueid detected in filename: %s' % fl['issueid'])
                             csi = myDB.selectone('SELECT i.ComicID, i.IssueID, i.Issue_Number, c.ComicName FROM comics as c JOIN issues as i ON c.ComicID = i.ComicID WHERE i.IssueID=?', [fl['issueid']]).fetchone()
                             if csi is None:
-                                csi = myDB.selectone('SELECT i.ComicID as comicid, i.IssueID, i.Issue_Number, a.ReleaseComicName, c.ComicName FROM comics as c JOIN annuals as a ON c.ComicID = a.ComicID WHERE a.IssueID=?', [fl['issueid']]).fetchone()
+                                csi = myDB.selectone('SELECT i.ComicID as comicid, i.IssueID, i.Issue_Number, a.ReleaseComicName, c.ComicName FROM comics as c JOIN annuals as a ON c.ComicID = a.ComicID WHERE a.IssueID=? AND NOT a.Deleted', [fl['issueid']]).fetchone()
                                 if csi is not None:
                                     annchk = 'yes'
                                 else:
@@ -688,7 +688,7 @@ class PostProcessor(object):
                                         fcdigit = helpers.issuedigits(re.sub('special', '', str(temploc.lower())).strip())
                                     logger.fdebug('%s Annual/Special detected [%s]. ComicID assigned as %s' % (module, fcdigit, cs['ComicID']))
                                 annchk = "yes"
-                                issuechk = myDB.select("SELECT * from annuals WHERE ComicID=? AND Int_IssueNumber=?", [cs['ComicID'], fcdigit])
+                                issuechk = myDB.select("SELECT * from annuals WHERE ComicID=? AND Int_IssueNumber=? AND NOT Deleted", [cs['ComicID'], fcdigit])
                             else:
                                 annchk = "no"
                                 if temploc is not None:
@@ -724,7 +724,7 @@ class PostProcessor(object):
                                     continue
 
                                 if annchk == 'yes':
-                                    issuechk = myDB.select("SELECT * from annuals WHERE ComicID=? AND Int_IssueNumber=?", [cs['ComicID'], fcdigit])
+                                    issuechk = myDB.select("SELECT * from annuals WHERE ComicID=? AND Int_IssueNumber=? AND NOT Deleted", [cs['ComicID'], fcdigit])
                                 else:
                                     issuechk = myDB.select("SELECT * from issues WHERE ComicID=? AND Int_IssueNumber=?", [cs['ComicID'], fcdigit])
                                 if not issuechk:
@@ -1606,7 +1606,7 @@ class PostProcessor(object):
                     self.oneoff = nzbiss['OneOff']
                     tmpiss = myDB.selectone('SELECT * FROM issues WHERE IssueID=?', [issueid]).fetchone()
                     if tmpiss is None:
-                        tmpiss = myDB.selectone('SELECT * FROM annuals WHERE IssueID=?', [issueid]).fetchone()
+                        tmpiss = myDB.selectone('SELECT * FROM annuals WHERE IssueID=? AND NOT Deleted', [issueid]).fetchone()
                     comicid = None
                     comicname = None
                     issuenumber = None
@@ -1796,7 +1796,7 @@ class PostProcessor(object):
             issuenzb = myDB.selectone("SELECT * from issues WHERE IssueID=? AND ComicName NOT NULL", [issueid]).fetchone()
             if issuenzb is None:
                 logger.info('%s Could not detect as a standard issue - checking against annuals.' % module)
-                issuenzb = myDB.selectone("SELECT * from annuals WHERE IssueID=? AND ComicName NOT NULL", [issueid]).fetchone()
+                issuenzb = myDB.selectone("SELECT * from annuals WHERE IssueID=? AND ComicName NOT NULL AND NOT Deleted", [issueid]).fetchone()
                 if issuenzb is None:
                     logger.info('%s issuenzb not found.' % module)
                     #if it's non-numeric, it contains a 'G' at the beginning indicating it's a multi-volume
@@ -1809,7 +1809,7 @@ class PostProcessor(object):
                                 issuearcid = onechk['IssueArcID']
                                 issuenzb = myDB.selectone('SELECT * FROM issues WHERE IssueID=? AND ComicName NOT NULL', [onechk['IssueID']]).fetchone()
                                 if issuenzb is None:
-                                    issuenzb = myDB.selectone("SELECT * from annuals WHERE IssueID=? AND ComicName NOT NULL", [onechk['IssueID']]).fetchone()
+                                    issuenzb = myDB.selectone("SELECT * from annuals WHERE IssueID=? AND ComicName NOT NULL AND NOT Deleted", [onechk['IssueID']]).fetchone()
                             if issuenzb is not None:
                                 issueid = issuenzb['IssueID']
                                 logger.fdebug('Reverse lookup discovered watchlisted series [issueid: %s] - adjusting so we can PP both properly.' % issueid)
@@ -2191,7 +2191,7 @@ class PostProcessor(object):
                 else:
                     logger.fdebug('%s Was downloaded from %s. Enabling torrent manual post-processing completion notification.' % (module, snatchnzb['Provider']))
             if issuenzb is None:
-                issuenzb = myDB.selectone("SELECT * from annuals WHERE issueid=? and comicid=?", [issueid, comicid]).fetchone()
+                issuenzb = myDB.selectone("SELECT * from annuals WHERE issueid=? and comicid=? AND NOT Deleted", [issueid, comicid]).fetchone()
                 annchk = "yes"
             if annchk == "no":
                 logger.info('%s %s Starting Post-Processing for %s issue: %s' % (module, stat, issuenzb['ComicName'], issuenzb['Issue_Number']))

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -738,7 +738,7 @@ def dbcheck():
     c.execute('CREATE TABLE IF NOT EXISTS weekly (SHIPDATE TEXT, PUBLISHER TEXT, ISSUE TEXT, COMIC VARCHAR(150), EXTRA TEXT, STATUS TEXT, ComicID TEXT, IssueID TEXT, CV_Last_Update TEXT, DynamicName TEXT, weeknumber TEXT, year TEXT, volume TEXT, seriesyear TEXT, annuallink TEXT, format TEXT, rowid INTEGER PRIMARY KEY)')
     c.execute('CREATE TABLE IF NOT EXISTS importresults (impID TEXT, ComicName TEXT, ComicYear TEXT, Status TEXT, ImportDate TEXT, ComicFilename TEXT, ComicLocation TEXT, WatchMatch TEXT, DisplayName TEXT, SRID TEXT, ComicID TEXT, IssueID TEXT, Volume TEXT, IssueNumber TEXT, DynamicName TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS readlist (IssueID TEXT, ComicName TEXT, Issue_Number TEXT, Status TEXT, DateAdded TEXT, Location TEXT, inCacheDir TEXT, SeriesYear TEXT, ComicID TEXT, StatusChange TEXT)')
-    c.execute('CREATE TABLE IF NOT EXISTS annuals (IssueID TEXT, Issue_Number TEXT, IssueName TEXT, IssueDate TEXT, Status TEXT, ComicID TEXT, GCDComicID TEXT, Location TEXT, ComicSize TEXT, Int_IssueNumber INT, ComicName TEXT, ReleaseDate TEXT, DigitalDate TEXT, ReleaseComicID TEXT, ReleaseComicName TEXT, IssueDate_Edit TEXT, DateAdded TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS annuals (IssueID TEXT, Issue_Number TEXT, IssueName TEXT, IssueDate TEXT, Status TEXT, ComicID TEXT, GCDComicID TEXT, Location TEXT, ComicSize TEXT, Int_IssueNumber INT, ComicName TEXT, ReleaseDate TEXT, DigitalDate TEXT, ReleaseComicID TEXT, ReleaseComicName TEXT, IssueDate_Edit TEXT, DateAdded TEXT, Deleted INT DEFAULT 0)')
     c.execute('CREATE TABLE IF NOT EXISTS rssdb (Title TEXT UNIQUE, Link TEXT, Pubdate TEXT, Site TEXT, Size TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS futureupcoming (ComicName TEXT, IssueNumber TEXT, ComicID TEXT, IssueID TEXT, IssueDate TEXT, Publisher TEXT, Status TEXT, DisplayComicName TEXT, weeknumber TEXT, year TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS failed (ID TEXT, Status TEXT, ComicID TEXT, IssueID TEXT, Provider TEXT, ComicName TEXT, Issue_Number TEXT, NZBName TEXT, DateFailed TEXT)')
@@ -1191,6 +1191,11 @@ def dbcheck():
         c.execute('SELECT DigitalDate from annuals')
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE annuals ADD COLUMN DigitalDate TEXT')
+
+    try:
+        c.execute('SELECT Deleted from annuals')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE annuals ADD COLUMN Deleted INT DEFAULT 0')
 
     ## -- Snatched Table --
 

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -2754,11 +2754,11 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                     ):
                         issues_3 = myDB.select(
                             'SELECT * from annuals WHERE Status="Wanted" OR'
-                            ' Status="Failed"'
+                            ' Status="Failed AND NOT Deleted"'
                         )
                     else:
                         issues_3 = myDB.select(
-                            'SELECT * from annuals WHERE Status="Wanted"'
+                            'SELECT * from annuals WHERE Status="Wanted AND NOT Deleted"'
                         )
                     for iss in issues_3:
                         results.append(
@@ -3027,7 +3027,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                 oneoff = False
                 if result is None:
                     result = myDB.selectone(
-                        'SELECT * FROM annuals where IssueID=?', [issueid]
+                        'SELECT * FROM annuals where IssueID=? AND NOT Deleted', [issueid]
                     ).fetchone()
                     mode = 'want_ann'
                     if result is None:
@@ -3257,7 +3257,7 @@ def searchIssueIDList(issuelist):
             ).fetchone()
             if issue is None:
                 issue = myDB.selectone(
-                    'SELECT * from annuals WHERE IssueID=?', [issueid]
+                    'SELECT * from annuals WHERE IssueID=? AND NOT Deleted', [issueid]
                 ).fetchone()
                 if issue is None:
                     logger.warn(


### PR DESCRIPTION
- FIX: When deleting Annuals from a series (annual tracking is on), will now remember deleted items so refreshing the series does not re-add them repeatedly
- FIX: Due to the inclusion of the Deleted field in the annuals table, have to change select statements involving annuals so as to not look at Deleted items