### PR TITLE
FIX: fix for cbr files not rendering in webviewer on Windows systems

### DIFF
--- a/mylar/webviewer.py
+++ b/mylar/webviewer.py
@@ -153,7 +153,7 @@ class ComicScanner(object):
         logger.debug("Image List Requested")
         image_list = []
         image_src = os.path.join(mylar.CONFIG.CACHE_DIR, "webviewer", ish_id)
-        image_loc = os.path.join(mylar.CONFIG.HTTP_ROOT, 'cache', "webviewer", ish_id)
+        image_loc = mylar.CONFIG.HTTP_ROOT + '/'.join(['cache', "webviewer", ish_id])
         for root, dirs, files in os.walk(image_src):
             for f in files:
                 if f.endswith((".png", ".gif", ".bmp", ".dib", ".jpg", ".jpeg", ".jpe", ".jif", ".jfif", ".jfi", ".tiff", ".tif")):


### PR DESCRIPTION
note: not sure how this will resolve on reverse-proxies - it should be fine since even if the value in the config.ini doesn't have a trailing ```/``` we add one by default.