### PR TITLE
IMP: monitor series directory changes via FilesUpdated field.

### DIFF
--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -730,7 +730,7 @@ def dbcheck():
         except sqlite3.OperationalError:
             logger.warn('Unable to update readinglist table to new storyarc table format.')
 
-    c.execute('CREATE TABLE IF NOT EXISTS comics (ComicID TEXT UNIQUE, ComicName TEXT, ComicSortName TEXT, ComicYear TEXT, DateAdded TEXT, Status TEXT, IncludeExtras INTEGER, Have INTEGER, Total INTEGER, ComicImage TEXT, FirstImageSize INTEGER, ComicPublisher TEXT, PublisherImprint TEXT, ComicLocation TEXT, ComicPublished TEXT, NewPublish TEXT, LatestIssue TEXT, LatestDate TEXT, Description TEXT, DescriptionEdit TEXT, QUALalt_vers TEXT, QUALtype TEXT, QUALscanner TEXT, QUALquality TEXT, LastUpdated TEXT, AlternateSearch TEXT, UseFuzzy TEXT, ComicVersion TEXT, SortOrder INTEGER, DetailURL TEXT, ForceContinuing INTEGER, ComicName_Filesafe TEXT, AlternateFileName TEXT, ComicImageURL TEXT, ComicImageALTURL TEXT, DynamicComicName TEXT, AllowPacks TEXT, Type TEXT, Corrected_SeriesYear TEXT, Corrected_Type TEXT, TorrentID_32P TEXT, LatestIssueID TEXT, Collects CLOB, IgnoreType INTEGER, AgeRating TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS comics (ComicID TEXT UNIQUE, ComicName TEXT, ComicSortName TEXT, ComicYear TEXT, DateAdded TEXT, Status TEXT, IncludeExtras INTEGER, Have INTEGER, Total INTEGER, ComicImage TEXT, FirstImageSize INTEGER, ComicPublisher TEXT, PublisherImprint TEXT, ComicLocation TEXT, ComicPublished TEXT, NewPublish TEXT, LatestIssue TEXT, LatestDate TEXT, Description TEXT, DescriptionEdit TEXT, QUALalt_vers TEXT, QUALtype TEXT, QUALscanner TEXT, QUALquality TEXT, LastUpdated TEXT, AlternateSearch TEXT, UseFuzzy TEXT, ComicVersion TEXT, SortOrder INTEGER, DetailURL TEXT, ForceContinuing INTEGER, ComicName_Filesafe TEXT, AlternateFileName TEXT, ComicImageURL TEXT, ComicImageALTURL TEXT, DynamicComicName TEXT, AllowPacks TEXT, Type TEXT, Corrected_SeriesYear TEXT, Corrected_Type TEXT, TorrentID_32P TEXT, LatestIssueID TEXT, Collects CLOB, IgnoreType INTEGER, AgeRating TEXT, FilesUpdated TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS issues (IssueID TEXT, ComicName TEXT, IssueName TEXT, Issue_Number TEXT, DateAdded TEXT, Status TEXT, Type TEXT, ComicID TEXT, ArtworkURL Text, ReleaseDate TEXT, Location TEXT, IssueDate TEXT, DigitalDate TEXT, Int_IssueNumber INT, ComicSize TEXT, AltIssueNumber TEXT, IssueDate_Edit TEXT, ImageURL TEXT, ImageURL_ALT TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS snatched (IssueID TEXT, ComicName TEXT, Issue_Number TEXT, Size INTEGER, DateAdded TEXT, Status TEXT, FolderName TEXT, ComicID TEXT, Provider TEXT, Hash TEXT, crc TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS upcoming (ComicName TEXT, IssueNumber TEXT, ComicID TEXT, IssueID TEXT, IssueDate TEXT, Status TEXT, DisplayComicName TEXT)')
@@ -903,6 +903,11 @@ def dbcheck():
         c.execute('SELECT DescriptionEdit from comics')
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE comics ADD COLUMN DescriptionEdit TEXT')
+
+    try:
+        c.execute('SELECT FilesUpdated from comics')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE comics ADD COLUMN FilesUpdated TEXT')
 
     try:
         c.execute('SELECT DynamicComicName from comics')

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -1724,7 +1724,8 @@ def totals(ComicID, havefiles=None, totalfiles=None, module=None, issueid=None, 
     #store just the total of issues, since annuals gets tracked seperately.
     controlValueStat = {"ComicID":     ComicID}
     newValueStat = {"Have":            havefiles,
-                    "Total":           totalfiles}
+                    "Total":           totalfiles,
+                    "FilesUpdated":    helpers.now()}
 
     myDB.upsert("comics", newValueStat, controlValueStat)
     if file is not None:

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -180,6 +180,45 @@ class WebInterface(object):
         if comic is None:
             raise cherrypy.HTTPRedirect("home")
 
+        if ComicID is not None:
+            comic_ext = ('.cbr','.cbz','.cb7')
+            filesupdated = 0
+            if comic['FilesUpdated']:
+                filesupdated = time.mktime(datetime.datetime.strptime(comic['FilesUpdated'], '%Y-%m-%d %H:%M:%S').timetuple())
+
+            run_them_down = False
+
+            for dirname, subs, files in os.walk(comic['ComicLocation']):
+                if run_them_down is True:
+                    break
+
+                if dirname == dir:
+                    direc = None
+                else:
+                    direc = dirname
+
+                for fname in files:
+                    filename = fname
+                    if os.path.splitext(filename)[1].lower().endswith(comic_ext):
+                        if direc is None:
+                            try:
+                                ctime = os.path.getmtime(dirname)
+                            except Exception as e:
+                                continue
+                        else:
+                            try:
+                                ctime = os.path.getmtime(dirname)
+                            except Exception as e:
+                                continue
+
+                        if ctime > filesupdated:
+                           run_them_down = True
+                           break
+
+            if run_them_down is True:
+                updater.forceRescan(ComicID)
+                comic = myDB.selectone('SELECT * FROM comics WHERE ComicID=?', [ComicID]).fetchone()
+
         totalissues = comic['Total']
         haveissues = comic['Have']
         if not haveissues:


### PR DESCRIPTION
This is the first part to this.

This will keep track of the last time the files were checked within a directory for each series via the ```FilesUpdated``` dB field.

It will basically run a ```ReCheck Files``` during a series detail page load only if any files have been modified/created/deleted within the given series directory. It will only trigger if anything has changed - if nothing has changed it will not do a ReCheck.

The 2nd(ary) part is to have it automatically monitor the folders themselves (outside of the GUI), and update the check accordingly, but be dependent on running only if something has changed.