### PR TITLE
add.it.all fixes

### DIFF
--- a/data/interfaces/carbon/css/style.css
+++ b/data/interfaces/carbon/css/style.css
@@ -2250,13 +2250,13 @@ table#annual_table td#aissuename { vertical-align: middle; text-align: center; m
   height: 30px;
   list-style-type: none;
   width: 100%;
-  z-index: 998;
+  z-index: 1;
 }
 #btn_container_center #btn_menu {
   float: center;
   margin-top: 5px;
   position: relative;
-  z-index: 99;
+  z-index: 1;
 }
 #btn_menu a {
   background-image: -moz-linear-gradient(#616161, #4e4e4e) !important;

--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -2194,13 +2194,13 @@ img.highqual {
   height: 30px;
   list-style-type: none;
   width: 100%;
-  z-index: 998;
+  z-index: 1;
 }
 #btn_container_center #btn_menu {
   float: center;
   margin-top: 5px;
   position: relative;
-  z-index: 99;
+  z-index: 1;
 }
 #btn_menu a {
   background-image: -moz-linear-gradient(#f4f4f4, #e7e7e7) !important;

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -7095,7 +7095,7 @@ class WebInterface(object):
         #            if not any(ext['comicid'] == wt['comicid'] for ext in mylar.ADD_LIST):
         #                watch.append({'comicid': wt['comicid'], 'series': wt['comic']})
 
-        pub_info = weeklypull.mass_publishers(publishers, weeknumber, year, mass_auto)
+        pub_info = weeklypull.mass_publishers(publishers, weeknumber, year)
 
         pub_count = pub_info['publisher_count']
         if pub_count == 0:

--- a/mylar/weeklypull.py
+++ b/mylar/weeklypull.py
@@ -1297,9 +1297,9 @@ def new_pullcheck(weeknumber, pullyear, comic1off_name=None, comic1off_id=None, 
 
     if mylar.CONFIG.AUTO_MASS_ADD is True:
        logger.info('[AUTO-MASS-ADD] Auto Mass-Add enabled and triggered for current week %s, %s..' % (weeknumber, pullyear))
-       mass_publishers(publishers=mylar.CONFIG.MASS_PUBLISHERS, weeknumber=weeknumber, year=pullyear, mass_auto=True)
+       mass_publishers(publishers=mylar.CONFIG.MASS_PUBLISHERS, weeknumber=weeknumber, year=pullyear)
 
-def mass_publishers(publishers, weeknumber, year, mass_auto=False):
+def mass_publishers(publishers, weeknumber, year):
 
     watchlibrary = helpers.listLibrary()
     watch = []
@@ -1309,8 +1309,14 @@ def mass_publishers(publishers, weeknumber, year, mass_auto=False):
     if type(publishers) == list and len(publishers) == 0:
         publishers = None
 
+    if type(publishers) == str:
+        publishers = json.loads(publishers)
+        if len(publishers) == 0:
+            publishers = None
+
     if publishers is None:
         watchlist = myDB.select('SELECT * FROM weekly WHERE weeknumber=? and year=?', [weeknumber, year])
+        mylar.CONFIG.MASS_PUBLISHERS = []
     else:
         cnt = 0
         pblist = 'AND (publisher="%s"' % publishers[cnt]
@@ -1321,9 +1327,10 @@ def mass_publishers(publishers, weeknumber, year, mass_auto=False):
              cnt += 1
         pblist += ')'
         mylar.CONFIG.MASS_PUBLISHERS = json.loads(json.dumps(pub_listing))
-        mylar.CONFIG.writeconfig(values={'mass_publishers': json.dumps(mylar.CONFIG.MASS_PUBLISHERS), 'auto_mass_add': mylar.CONFIG.AUTO_MASS_ADD})
         query_line = 'SELECT * FROM WEEKLY WHERE weeknumber=%s AND year=%s %s' % (weeknumber, year, pblist)
         watchlist = myDB.select(query_line)
+
+    mylar.CONFIG.writeconfig(values={'mass_publishers': json.dumps(mylar.CONFIG.MASS_PUBLISHERS), 'auto_mass_add': mylar.CONFIG.AUTO_MASS_ADD})
 
     if watchlist:
         for wt in watchlist:


### PR DESCRIPTION
- FIX: (add.it.all) mass_publishers config.ini value would grow exponentially under certain conditions
- FIX: (add.it.all) Submit button for add.it.all option would render on top of drop-down
- FIX: (add.it.all) Not setting any publishers and enabling auto-add would not save the value to config resulting in auto-add not being enabled