### PR TITLE
FIX: fix for previous PR which broke post-processing issues that matched to multiple volumes but not currently published

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -573,6 +573,7 @@ class PostProcessor(object):
                         wv_comicname = wv['ComicName']
                         wv_dynamicname = wv['DynamicComicName']
                         wv_comicpublisher = wv['ComicPublisher']
+                        wv_comicpublished = wv['ComicPublished']
                         wv_alternatesearch = wv['AlternateSearch']
                         wv_comicid = wv['ComicID']
                         if wv['Corrected_Type'] is None:
@@ -661,6 +662,7 @@ class PostProcessor(object):
                         watchvals.append({"ComicName":       wv_comicname,
                                           "DynamicName":     wv_dynamicname,
                                           "ComicPublisher":  wv_comicpublisher,
+                                          "ComicPublished":  wv_comicpublished,
                                           "AlternateSearch": wv_alternatesearch,
                                           "ComicID":         wv_comicid,
                                           "LastUpdated":     wv['LastUpdated'],
@@ -859,7 +861,7 @@ class PostProcessor(object):
                                     watch_values = cs['WatchValues']
                                     second_check = False
                                     if watch_values['LatestIssueInt'] >= fcdigit:
-                                        logger.info('possible match - issue in dB (%s) is greater than issue in file (%s)' % (watch_values['LatestIssueInt'], fcdigit))
+                                        logger.fdebug('possible match - issue in dB (%s) is greater than issue in file (%s)' % (watch_values['LatestIssueInt'], fcdigit))
 
                                         #dynamic-name generation here.
                                         as_d = filechecker.FileChecker(watchcomic=watchmatch['series_name'])
@@ -881,7 +883,11 @@ class PostProcessor(object):
                                                 else:
                                                     logger.fdebug('%s %s in filename don\'t match up to what\'s in the dB %s %s [%s]' % (watchmatch['series_name'], watchmatch['justthedigits'], week_comic, week_issue, cs['ComicID']))
                                             else:
-                                                second_check = False
+                                                if any(['Present' not in cs['ComicPublished'], helpers.now()[:4] not in cs['ComicPublished']]):
+                                                    logger.fdebug('%s %s is not part of an ongoing publication. Bypassing this check and letting the dates verify below' % (watchmatch['series_name'],watchmatch['justthedigits']))
+                                                    second_check = True
+                                                else:
+                                                    second_check = False
                                         else:
                                             pass
                                             #logger.info('name in dB (%s) does not match name in file (%s)' % (cs['ComicName'], watchmatch['series_name']))

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -309,6 +309,9 @@ def initialize(config_file):
         if CONFIG.LOCMOVE:
             helpers.updateComicLocation()
 
+        # make sure the intLatestIssue field is populated with values...
+        helpers.latestissue_update()
+
         #Ordering comics here
         if mylar.MAINTENANCE is False:
             logger.info('Remapping the sorting to allow for new additions.')
@@ -449,6 +452,7 @@ def start():
 
             if CONFIG.ENABLE_DDL is True:
                 queue_schedule('ddl_queue', 'start')
+
             helpers.latestdate_fix()
 
             if CONFIG.ALT_PULL == 2:
@@ -730,7 +734,7 @@ def dbcheck():
         except sqlite3.OperationalError:
             logger.warn('Unable to update readinglist table to new storyarc table format.')
 
-    c.execute('CREATE TABLE IF NOT EXISTS comics (ComicID TEXT UNIQUE, ComicName TEXT, ComicSortName TEXT, ComicYear TEXT, DateAdded TEXT, Status TEXT, IncludeExtras INTEGER, Have INTEGER, Total INTEGER, ComicImage TEXT, FirstImageSize INTEGER, ComicPublisher TEXT, PublisherImprint TEXT, ComicLocation TEXT, ComicPublished TEXT, NewPublish TEXT, LatestIssue TEXT, LatestDate TEXT, Description TEXT, DescriptionEdit TEXT, QUALalt_vers TEXT, QUALtype TEXT, QUALscanner TEXT, QUALquality TEXT, LastUpdated TEXT, AlternateSearch TEXT, UseFuzzy TEXT, ComicVersion TEXT, SortOrder INTEGER, DetailURL TEXT, ForceContinuing INTEGER, ComicName_Filesafe TEXT, AlternateFileName TEXT, ComicImageURL TEXT, ComicImageALTURL TEXT, DynamicComicName TEXT, AllowPacks TEXT, Type TEXT, Corrected_SeriesYear TEXT, Corrected_Type TEXT, TorrentID_32P TEXT, LatestIssueID TEXT, Collects CLOB, IgnoreType INTEGER, AgeRating TEXT, FilesUpdated TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS comics (ComicID TEXT UNIQUE, ComicName TEXT, ComicSortName TEXT, ComicYear TEXT, DateAdded TEXT, Status TEXT, IncludeExtras INTEGER, Have INTEGER, Total INTEGER, ComicImage TEXT, FirstImageSize INTEGER, ComicPublisher TEXT, PublisherImprint TEXT, ComicLocation TEXT, ComicPublished TEXT, NewPublish TEXT, LatestIssue TEXT, intLatestIssue INT, LatestDate TEXT, Description TEXT, DescriptionEdit TEXT, QUALalt_vers TEXT, QUALtype TEXT, QUALscanner TEXT, QUALquality TEXT, LastUpdated TEXT, AlternateSearch TEXT, UseFuzzy TEXT, ComicVersion TEXT, SortOrder INTEGER, DetailURL TEXT, ForceContinuing INTEGER, ComicName_Filesafe TEXT, AlternateFileName TEXT, ComicImageURL TEXT, ComicImageALTURL TEXT, DynamicComicName TEXT, AllowPacks TEXT, Type TEXT, Corrected_SeriesYear TEXT, Corrected_Type TEXT, TorrentID_32P TEXT, LatestIssueID TEXT, Collects CLOB, IgnoreType INTEGER, AgeRating TEXT, FilesUpdated TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS issues (IssueID TEXT, ComicName TEXT, IssueName TEXT, Issue_Number TEXT, DateAdded TEXT, Status TEXT, Type TEXT, ComicID TEXT, ArtworkURL Text, ReleaseDate TEXT, Location TEXT, IssueDate TEXT, DigitalDate TEXT, Int_IssueNumber INT, ComicSize TEXT, AltIssueNumber TEXT, IssueDate_Edit TEXT, ImageURL TEXT, ImageURL_ALT TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS snatched (IssueID TEXT, ComicName TEXT, Issue_Number TEXT, Size INTEGER, DateAdded TEXT, Status TEXT, FolderName TEXT, ComicID TEXT, Provider TEXT, Hash TEXT, crc TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS upcoming (ComicName TEXT, IssueNumber TEXT, ComicID TEXT, IssueID TEXT, IssueDate TEXT, Status TEXT, DisplayComicName TEXT)')
@@ -818,6 +822,11 @@ def dbcheck():
         c.execute('SELECT ForceContinuing from comics')
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE comics ADD COLUMN ForceContinuing INTEGER')
+
+    try:
+        c.execute('SELECT intLatestIssue from comics')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE comics ADD COLUMN intLatestIssue INTEGER')
 
     try:
         c.execute('SELECT ComicName_Filesafe from comics')

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3073,6 +3073,27 @@ def latestdate_update():
         logger.info('updating latest date for : ' + a['ComicID'] + ' to ' + a['LatestDate'] + ' #' + a['LatestIssue'])
         myDB.upsert("comics", newVal, ctrlVal)
 
+def latestissue_update():
+    myDB = db.DBConnection()
+    cck = myDB.select('SELECT ComicID, LatestIssue FROM comics WHERE intLatestIssue is NULL')
+
+    if cck:
+        c_list = []
+        for ck in cck:
+            c_list.append({'ComicID': ck['ComicID'],
+                           'intLatestIssue': issuedigits(ck['LatestIssue'])})
+
+        logger.info('[LATEST_ISSUE_TO_INT] Updating the latestIssue field for %s series' % (len(c_list)))
+
+        for ct in c_list:
+            try:
+                newVal = {'intLatestIssue': ct['intLatestIssue']}
+                ctrlVal = {'ComicID': ct['ComicID']}
+                myDB.upsert("comics", newVal, ctrlVal)
+            except Exception as e:
+                logger.fdebug('exception encountered: %s' % e)
+                continue
+
 def ddl_downloader(queue):
     myDB = db.DBConnection()
     while True:

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -1574,6 +1574,7 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
                     "ComicPublished":  publishfigure,
                     "NewPublish":      newpublish,
                     "LatestIssue":     latestiss,
+                    "intLatestIssue":  helpers.issuedigits(latestiss),
                     "LatestIssueID":   latestissueid,
                     "LatestDate":      latestdate,
                     "LastUpdated":     helpers.now()

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -374,7 +374,8 @@ def latest_update(ComicID, LatestIssue, LatestDate):
     myDB = db.DBConnection()
     latestCTRLValueDict = {"ComicID":      ComicID}
     newlatestDict = {"LatestIssue":      str(LatestIssue),
-                    "LatestDate":       str(LatestDate)}
+                     "intLatestIssue":   helpers.issuedigits(LatestIssue),
+                     "LatestDate":       str(LatestDate)}
     myDB.upsert("comics", newlatestDict, latestCTRLValueDict)
 
 def upcoming_update(ComicID, ComicName, IssueNumber, IssueDate, forcecheck=None, futurepull=None, altissuenumber=None, weekinfo=None):


### PR DESCRIPTION
- added ```intLatestIssue``` to the comics table.
- created a function to add values to ```intLatestIssue``` on startup so it should never be null.
- added to importer and weeklypull check so that the ```intLatestIssue``` will be populated when added / updated via the pull.