### PR TITLE
IMP:(#777) Allow for multiple categories within torznab configuration

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -752,6 +752,9 @@ def NZB_SEARCH(
         category_torznab = torznab_host[4]
         if any([category_torznab is None, category_torznab == 'None']):
             category_torznab = '8020'
+        if '#' in category_torznab:
+            t_cats = category_torznab.split('#')
+            category_torznab = ','.join(t_cats)
         logger.fdebug('Using Torznab host of : %s' % name_torznab)
     elif nzbprov == 'newznab':
         # updated to include Newznab Name now

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5766,6 +5766,9 @@ class WebInterface(object):
                     torznab_verify = 0
                 torznab_api = kwargs['torznab_apikey' + torznab_number]
                 torznab_category = kwargs['torznab_category' + torznab_number]
+                if ',' in torznab_category:
+                    torznab_category = re.sub(',', '#', torznab_category).strip()
+
                 try:
                     torznab_enabled = str(kwargs['torznab_enabled' + torznab_number])
                 except KeyError:


### PR DESCRIPTION
in GUI:
- use ```,``` to separate torznab categories

in config.ini
- use ```#``` to separate torznab categories

The PR does the above and converts between the two as required so all the user will see is the categories separated by ```,``` within the GUI - but it is stored with ```#``` as the category separators. 