### PR TITLE
IMP: Update of series.json metadata to allow for 1.0.1 versioning, IMP: Added api calls for listing and updating seriesjson

### DIFF
--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -734,7 +734,7 @@ def dbcheck():
         except sqlite3.OperationalError:
             logger.warn('Unable to update readinglist table to new storyarc table format.')
 
-    c.execute('CREATE TABLE IF NOT EXISTS comics (ComicID TEXT UNIQUE, ComicName TEXT, ComicSortName TEXT, ComicYear TEXT, DateAdded TEXT, Status TEXT, IncludeExtras INTEGER, Have INTEGER, Total INTEGER, ComicImage TEXT, FirstImageSize INTEGER, ComicPublisher TEXT, PublisherImprint TEXT, ComicLocation TEXT, ComicPublished TEXT, NewPublish TEXT, LatestIssue TEXT, intLatestIssue INT, LatestDate TEXT, Description TEXT, DescriptionEdit TEXT, QUALalt_vers TEXT, QUALtype TEXT, QUALscanner TEXT, QUALquality TEXT, LastUpdated TEXT, AlternateSearch TEXT, UseFuzzy TEXT, ComicVersion TEXT, SortOrder INTEGER, DetailURL TEXT, ForceContinuing INTEGER, ComicName_Filesafe TEXT, AlternateFileName TEXT, ComicImageURL TEXT, ComicImageALTURL TEXT, DynamicComicName TEXT, AllowPacks TEXT, Type TEXT, Corrected_SeriesYear TEXT, Corrected_Type TEXT, TorrentID_32P TEXT, LatestIssueID TEXT, Collects CLOB, IgnoreType INTEGER, AgeRating TEXT, FilesUpdated TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS comics (ComicID TEXT UNIQUE, ComicName TEXT, ComicSortName TEXT, ComicYear TEXT, DateAdded TEXT, Status TEXT, IncludeExtras INTEGER, Have INTEGER, Total INTEGER, ComicImage TEXT, FirstImageSize INTEGER, ComicPublisher TEXT, PublisherImprint TEXT, ComicLocation TEXT, ComicPublished TEXT, NewPublish TEXT, LatestIssue TEXT, intLatestIssue INT, LatestDate TEXT, Description TEXT, DescriptionEdit TEXT, QUALalt_vers TEXT, QUALtype TEXT, QUALscanner TEXT, QUALquality TEXT, LastUpdated TEXT, AlternateSearch TEXT, UseFuzzy TEXT, ComicVersion TEXT, SortOrder INTEGER, DetailURL TEXT, ForceContinuing INTEGER, ComicName_Filesafe TEXT, AlternateFileName TEXT, ComicImageURL TEXT, ComicImageALTURL TEXT, DynamicComicName TEXT, AllowPacks TEXT, Type TEXT, Corrected_SeriesYear TEXT, Corrected_Type TEXT, TorrentID_32P TEXT, LatestIssueID TEXT, Collects CLOB, IgnoreType INTEGER, AgeRating TEXT, FilesUpdated TEXT, seriesjsonPresent INT)')
     c.execute('CREATE TABLE IF NOT EXISTS issues (IssueID TEXT, ComicName TEXT, IssueName TEXT, Issue_Number TEXT, DateAdded TEXT, Status TEXT, Type TEXT, ComicID TEXT, ArtworkURL Text, ReleaseDate TEXT, Location TEXT, IssueDate TEXT, DigitalDate TEXT, Int_IssueNumber INT, ComicSize TEXT, AltIssueNumber TEXT, IssueDate_Edit TEXT, ImageURL TEXT, ImageURL_ALT TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS snatched (IssueID TEXT, ComicName TEXT, Issue_Number TEXT, Size INTEGER, DateAdded TEXT, Status TEXT, FolderName TEXT, ComicID TEXT, Provider TEXT, Hash TEXT, crc TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS upcoming (ComicName TEXT, IssueNumber TEXT, ComicID TEXT, IssueID TEXT, IssueDate TEXT, Status TEXT, DisplayComicName TEXT)')
@@ -917,6 +917,11 @@ def dbcheck():
         c.execute('SELECT FilesUpdated from comics')
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE comics ADD COLUMN FilesUpdated TEXT')
+
+    try:
+        c.execute('SELECT seriesjsonPresent from comics')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE comics ADD COLUMN seriesjsonPresent INT')
 
     try:
         c.execute('SELECT DynamicComicName from comics')

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -70,6 +70,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'AUTOWANT_ALL': (bool, 'General', False),
     'COMIC_COVER_LOCAL': (bool, 'General', False),
     'SERIES_METADATA_LOCAL': (bool, 'General', False),
+    'SERIESJSON_FILE_PRIORITY': (bool, 'General', False),
     'COVER_FOLDER_LOCAL': (bool, 'General', False),
     'ADD_TO_CSV': (bool, 'General', True),
     'SKIPPED2WANTED': (bool, 'General', False),

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -32,7 +32,7 @@ import requests
 import threading
 
 import mylar
-from mylar import logger, filers, helpers, db, mb, cv, parseit, filechecker, search, updater, moveit, comicbookdb
+from mylar import logger, filers, helpers, db, mb, cv, parseit, filechecker, search, updater, moveit, comicbookdb, series_metadata
 
 
 def is_exists(comicid):
@@ -422,75 +422,6 @@ def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=No
     if issuedata is None:
         logger.warn('Unable to complete Refreshing / Adding issue data - this WILL create future problems if not addressed.')
         return {'status': 'incomplete'}
-    else:
-
-        #write out series.json here if enabled.
-        if mylar.CONFIG.SERIES_METADATA_LOCAL is True:
-            description_load = None
-            if os.path.exists(os.path.join(comlocation, 'series.json')):
-                try:
-                    with open(os.path.join(comlocation, 'series.json')) as j_file:
-                        metainfo = json.load(j_file)
-                        logger.info('metainfo_loaded: %s' % (metainfo,))
-                    description_load = metainfo['metadata'][0]['description']
-                except Exception as e:
-                    try:
-                        description_load = metainfo['metadata'][0]['description_formatted']
-                    except Exception as e:
-                        logger.info('No description found in metadata. Reloading from dB if available.[error: %s]' % e)
-
-            c_date = datetime.date(int(importantdates['LatestDate'][:4]), int(importantdates['LatestDate'][5:7]), 1)
-            n_date = datetime.date.today()
-            recentchk = (n_date - c_date).days
-            if importantdates['NewPublish'] is True:
-                seriesStatus = 'Continuing'
-            else:
-                #do this just incase and as an extra measure of accuracy hopefully.
-                if recentchk < 55:
-                    seriesStatus = 'Continuing'
-                else:
-                    seriesStatus = 'Ended'
-
-            clean_issue_list = None
-            if comic['Issue_List'] != 'None':
-                clean_issue_list = comic['Issue_List']
-
-            if description_load is not None:
-                cdes_removed = re.sub(r'\n', '', description_load).strip()
-                cdes_formatted = description_load
-            elif old_description is not None:
-                cdes_removed = re.sub(r'\n', ' ', old_description).strip()
-                cdes_formatted = old_description
-            else:
-                cdes_formatted = None # CV doesn't format their descriptions.
-
-            c_image = comic
-            metadata = {}
-            metadata['metadata'] = [(
-                                        {'type': 'comicSeries',
-                                         'publisher': comic['ComicPublisher'],
-                                         'imprint': comic['PublisherImprint'],
-                                         'name': comic['ComicName'],
-                                         'comicid': comicid,
-                                         'year': SeriesYear,
-                                         'description_text': cdes_removed,
-                                         'description_formatted': cdes_formatted,
-                                         'volume': comicVol,
-                                         'booktype': booktype,
-                                         'collects': clean_issue_list,
-                                         'ComicImage': comic.get('ComicImage', None),
-                                         'total_issues': comicIssues,
-                                         'publication_run': importantdates['ComicPublished'],
-                                         'status': seriesStatus}
-            )]
-
-            try:
-                with open(os.path.join(comlocation, 'series.json'), 'w', encoding='utf-8') as outfile:
-                    json.dump(metadata, outfile, indent=4, ensure_ascii=False)
-            except Exception as e:
-                logger.error('Unable to write series.json to %s. Error returned: %s' % (comlocation, e))
-            else:
-                logger.fdebug('Successfully written series.json file to %s' % comlocation)
 
     if any([calledfrom is None, calledfrom == 'maintenance']):
         issue_collection(issuedata, nostatus='False', serieslast_updated=serieslast_updated)
@@ -558,6 +489,11 @@ def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=No
     statbefore = myDB.selectone("SELECT Status FROM issues WHERE ComicID=? AND Int_IssueNumber=?", [comicid, helpers.issuedigits(latestiss)]).fetchone()
     logger.fdebug('issue: ' + latestiss + ' status before chk :' + str(statbefore['Status']))
     updater.forceRescan(comicid)
+
+    #series.json updater here (after all data written out)
+    sm = series_metadata.metadata_Series(comicid, bulk=False, api=False)
+    sm.update_metadata()
+
     statafter = myDB.selectone("SELECT Status FROM issues WHERE ComicID=? AND Int_IssueNumber=?", [comicid, helpers.issuedigits(latestiss)]).fetchone()
     logger.fdebug('issue: ' + latestiss + ' status after chk :' + str(statafter['Status']))
 

--- a/mylar/series_metadata.py
+++ b/mylar/series_metadata.py
@@ -1,0 +1,197 @@
+#  This file is part of Mylar.
+#
+#  Mylar is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Mylar is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import os
+import re
+import datetime
+import threading
+
+import mylar
+from mylar import db, filechecker, helpers, logger, updater
+
+class metadata_Series(object):
+
+    def __init__(self, comicidlist, bulk=False, api=False, refreshSeries=False):
+        self.comiclist = comicidlist
+        if not type(comicidlist) is list:
+            self.comiclist = [comicidlist]
+
+        self.bulk = bulk
+        self.api = api
+        self.refreshSeries = refreshSeries
+
+    def update_metadata_thread(self):
+        threading.Thread(target=self.update_metadata).start()
+
+    def update_metadata(self):
+        for cid in self.comiclist:
+
+            if self.refreshSeries is True:
+                updater.dbupdate(cid, calledfrom='json_api')
+
+            myDB = db.DBConnection()
+            comic = myDB.selectone('SELECT * FROM comics WHERE ComicID=?', [cid]).fetchone()
+
+            if comic:
+
+                description_load = None
+                if not os.path.exists(comic['ComicLocation']) and mylar.CONFIG.CREATE_FOLDERS is True:
+                    try:
+                        checkdirectory = filechecker.validateAndCreateDirectory(comic['ComicLocation'], True)
+                    except Exception as e:
+                        logger.warn('[%s] Unable to create series directory @ %s. Aborting updating of series.json' % (e, comic['ComicLocation']))
+                        continue
+                    else:
+                        if checkdirectory is False:
+                            logger.warn('Unable to create series directory @ %s. Aborting updating of series.json' % (comic['ComicLocation']))
+                            continue
+
+                if os.path.exists(os.path.join(comic['ComicLocation'], 'series.json')):
+                    try:
+                        with open(os.path.join(comic['ComicLocation'], 'series.json')) as j_file:
+                            metainfo = json.load(j_file)
+                            logger.fdebug('metainfo_loaded: %s' % (metainfo,))
+                        try:
+                            # series.json version 1.0.1
+                            description_load = metainfo['metadata']['description_text']
+                        except Exception as e:
+                            try:
+                                # series.json version 1.0
+                                description_load = metainfo['metadata'][0]['description_text']
+                            except Exception as e:
+                                description_load = metainfo['metadata'][0]['description']
+                    except Exception as e:
+                        try:
+                            description_load = metainfo['metadata']['description_formatted']
+                        except Exception as e:
+                            try:
+                                description_load = metainfo['metadata'][0]['description_formatted']
+                            except Exception as e:
+                                logger.info('No description found in metadata. Reloading from dB if available.[error: %s]' % e)
+
+                c_date = datetime.date(int(comic['LatestDate'][:4]), int(comic['LatestDate'][5:7]), 1)
+                n_date = datetime.date.today()
+                recentchk = (n_date - c_date).days
+                if comic['NewPublish'] is True:
+                    seriesStatus = 'Continuing'
+                else:
+                    #do this just incase and as an extra measure of accuracy hopefully.
+                     if recentchk < 55:
+                         seriesStatus = 'Continuing'
+                     else:
+                         seriesStatus = 'Ended'
+
+                clean_issue_list = None
+                if comic['Collects'] != 'None':
+                    clean_issue_list = comic['Collects']
+
+                if mylar.CONFIG.SERIESJSON_FILE_PRIORITY is True:
+                    if description_load is not None:
+                        cdes_removed = re.sub(r'\n', '', description_load).strip()
+                        cdes_formatted = description_load
+                    elif comic['DescriptionEdit'] is not None:
+                        cdes_removed = re.sub(r'\n', ' ', comic['DescriptionEdit']).strip()
+                        cdes_formatted = comic['DescriptionEdit']
+                    else:
+                        if comic['Description'] is not None:
+                            cdes_removed = re.sub(r'\n', '', comic['Description']).strip()
+                        else:
+                            cdes_removed = comic['Description']
+                            logger.warn('Series does not have a description. Not populating, but you might need to do a Refresh Series to fix this')
+                else:
+                    if comic['DescriptionEdit'] is not None:
+                        cdes_removed = re.sub(r'\n', ' ', comic['DescriptionEdit']).strip()
+                        cdes_formatted = comic['DescriptionEdit']
+                    elif description_load is not None:
+                        cdes_removed = re.sub(r'\n', '', description_load).strip()
+                        cdes_formatted = description_load
+                    else:
+                        if comic['Description'] is not None:
+                            cdes_removed = re.sub(r'\n', '', comic['Description']).strip()
+                        else:
+                            cdes_removed = comic['Description']
+                            logger.warn('Series does not have a description. Not populating, but you might need to do a Refresh Series to fix this')
+                        cdes_formatted = comic['Description']
+
+                comicVol = comic['ComicVersion']
+                if all([mylar.CONFIG.SETDEFAULTVOLUME is True, comicVol is None]):
+                    comicVol = 1
+                if comicVol is not None:
+                    if comicVol.isdigit():
+                        comicVol = int(comicVol)
+                        logger.info('Updated version to :' + str(comicVol))
+                        if all([mylar.CONFIG.SETDEFAULTVOLUME is False, comicVol == 'v1']):
+                           comicVol = None
+                    else:
+                        comicVol = int(re.sub('[^0-9]', '', comicVol).strip())
+                else:
+                    if mylar.CONFIG.SETDEFAULTVOLUME is True:
+                        comicVol = 1
+
+                if any([comic['ComicYear'] is None, comic['ComicYear'] == '0000', comic['ComicYear'][-1:] == '-']):
+                    SeriesYear = int(issued['firstdate'][:4])
+                else:
+                    SeriesYear = int(comic['ComicYear'])
+
+                csyear = comic['Corrected_SeriesYear']
+
+                if any([SeriesYear > int(datetime.datetime.now().year) + 1, SeriesYear == 2099]) and csyear is not None:
+                    logger.info('Corrected year of ' + str(SeriesYear) + ' to corrected year for series that was manually entered previously of ' + str(csyear))
+                    SeriesYear = int(csyear)
+
+                if all([int(comic['Total']) == 1, SeriesYear < int(helpers.today()[:4]), comic['Type'] != 'One-Shot', comic['Type'] != 'TPB']):
+                    logger.info('Determined to be a one-shot issue. Forcing Edition to One-Shot')
+                    booktype = 'One-Shot'
+                else:
+                    booktype = comic['Type']
+
+                if comic['Corrected_Type'] and comic['Corrected_Type'] != booktype:
+                    booktype = comic['Corrected_Type']
+
+                c_image = comic
+                metadata = {}
+                metadata['version'] = '1.0.1'
+                metadata['metadata'] = (
+                                            {'type': 'comicSeries',
+                                             'publisher': comic['ComicPublisher'],
+                                             'imprint': comic['PublisherImprint'],
+                                             'name': comic['ComicName'],
+                                             'cid': int(cid),
+                                             'year': SeriesYear,
+                                             'description_text': cdes_removed,
+                                             'description_formatted': cdes_formatted,
+                                             'volume': comicVol,
+                                             'booktype': booktype,
+                                             'age_rating': comic['AgeRating'],
+                                             'collects': clean_issue_list,
+                                             'ComicImage': comic['ComicImageURL'],
+                                             'total_issues': comic['Total'],
+                                             'publication_run': comic['ComicPublished'],
+                                             'status': seriesStatus}
+                )
+
+                try:
+                    with open(os.path.join(comic['ComicLocation'], 'series.json'), 'w', encoding='utf-8') as outfile:
+                        json.dump(metadata, outfile, indent=4, ensure_ascii=False)
+                except Exception as e:
+                    logger.error('Unable to write series.json to %s. Error returned: %s' % (comic['ComicLocation'], e))
+                    continue
+                else:
+                    logger.fdebug('Successfully written series.json file to %s' % comic['ComicLocation'])
+                    myDB.upsert("comics", {"seriesjsonPresent": int(True)} ,{"ComicID": cid})
+
+        return
+

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -343,6 +343,11 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
                     logger.info('I have added ' + str(len(newiss)) + ' new issues for this series that were not present before.')
                     forceRescan(ComicID)
 
+                    #series.json updater here (after all data written out)
+                    if not calledfrom == 'json_api':
+                        sm = mylar.series_metadata.metadata_Series(ComicID, bulk=False, api=False)
+                        sm.update_metadata()
+
                 else:
                     chkstatus = mylar.importer.addComictoDB(ComicID, mismatch, annload=annload, csyear=csyear)
                     #if cchk:


### PR DESCRIPTION
- Allow for writing / reading of series.json v.1.0.1 metadata
- Added config.ini boolean option ```seriesjson_file_priority```:
   - ```True```: will prioritise series.json data for displaying & writing description data field.
   - ```False```: will priortise dB data for displaying & writing description data field.
   Fall-back method is the opposite of the selection if available.
- Broke out the seriesjson update module from webserve.py into it's own individual module (```series_metadata.py```)
- Added ```refreshSeriesjson``` and ```seriesjsonListing``` API endpoints ([docs here eventually](https://github.com/mylar3/mylar3/wiki/API-Documentation))