### PR TITLE
IMP: Added listProviders, addProvider, delProvider and changeProvider API endpoints

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -961,9 +961,8 @@
                                                         <label>Torznab Host</label>
                                                         <input type="text" name="torznab_host${torznab_number}" id="torznab_host${torznab_number}" value="${torznab[1]}" size="30">
                                                     </div>
-                                                    <div class="row">
-                                                        <label>Verify SSL</label>
-                                                        <input type="checkbox" name="torznab_verify${torznab_number}" id="torznab_verify${torznab_number}" value="${torznab[2]}">
+                                                    <div class="row checkbox">
+                                                        <input type="checkbox" name="torznab_verify${torznab_number}" id="torznab_verify${torznab_number}" value="1" ${torznab_verify} /><label>Verify SSL</label>
                                                     </div>
                                                     <div class="row">
                                                         <label>Torznab API</label>

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -20,6 +20,7 @@ import json
 import cherrypy
 import random
 import os
+import re
 import urllib.request, urllib.error, urllib.parse
 from . import cache
 import imghdr
@@ -34,6 +35,7 @@ cmd_list = ['getIndex', 'getComic', 'getUpcoming', 'getWanted', 'getHistory',
             'getVersion', 'checkGithub','shutdown', 'restart', 'update',
             'getComicInfo', 'getIssueInfo', 'getArt', 'downloadIssue',
             'refreshSeriesjson', 'seriesjsonListing',
+            'listProviders', 'changeProvider', 'addProvider', 'delProvider',
             'downloadNZB', 'getReadList', 'getStoryArc', 'addStoryArc']
 
 class Api(object):
@@ -890,6 +892,405 @@ class Api(object):
         wi = webserve.WebInterface()
         logger.info("arclist: %s - arcid: %s - storyarcname: %s - storyarcissues: %s" % (arclist, self.id, storyarcname, issuecount))
         wi.addStoryArc_thread(arcid=self.id, storyarcname=storyarcname, storyarcissues=issuecount, arclist=arclist, **kwargs)
+        return
+
+    def _listProviders(self, **kwargs):
+        try:
+            newznabs = []
+            for nz in mylar.CONFIG.EXTRA_NEWZNABS:
+                uid = nz[4]
+                if '#' in nz[4]:
+                    cats = re.sub('#', ',', nz[4][nz[4].find('#')+1:].strip()).strip()
+                    uid = nz[4][:nz[4].find('#')].strip()
+                else:
+                    cats = None
+                newznabs.append({'name': nz[0],
+                                 'host': nz[1],
+                                 'apikey': nz[3],
+                                 'categories': cats,
+                                 'uid': uid,
+                                 'enabled': bool(int(nz[5]))})
+            torznabs= []
+            for nz in mylar.CONFIG.EXTRA_TORZNABS:
+                cats = nz[4]
+                if '#' in nz[4]:
+                    cats = re.sub('#', ',', nz[4]).strip()
+                torznabs.append({'name': nz[0],
+                                 'host': nz[1],
+                                 'apikey': nz[3],
+                                 'categories': nz[4],
+                                 'enabled': bool(int(nz[5]))})
+
+            providers = {'newznabs': newznabs, 'torznabs': torznabs}
+        except Exception as e:
+            self.data = self._failureResponse(e)
+        else:
+            self.data = self._successResponse(providers)
+        return
+
+    def _addProvider(self, **kwargs):
+        if 'providertype' not in kwargs:
+            self.data = self._failureResponse('No provider type provided')
+            logger.fdebug('[API][addProvider] %s' % (self.data,))
+            return
+        else:
+            providertype = kwargs['providertype']
+            if all([providertype != 'newznab', providertype != 'torznab']):
+                self.data = self._failureResponse('providertype indicated %s is not a valid option. Options are `newznab` or `torznab`.' % providertype)
+                logger.fdebug('[API][addProvider] %s' % (self.data,))
+                return
+
+        if any(['host' not in kwargs, 'name' not in kwargs, 'prov_apikey' not in kwargs, 'enabled' not in kwargs]):
+            if providertype == 'newznab':
+                self.data = self._failureResponse('Missing arguement. Required arguements are: `name`, `host`, `prov_apikey`, `enabled`. `categories` & `uid` is optional but `uid` is required for RSS.')
+            elif providertype == 'torznab':
+                self.data = self._failureResponse('Missing arguement. Required arguements are: `name`, `host`, `prov_apikey`, `categories`, `enabled.`')
+                logger.fdebug('[API][addProvider] %s' % (self.data,))
+            return
+
+        if providertype == 'newznab':
+            if 'name' in kwargs:
+                newznab_name = kwargs['name']
+                if any([newznab_name is None, newznab_name.strip() == '']):
+                    self.data = self._failureResponse('name given for provider cannot be None or blank')
+                    logger.fdebug('[API][addProvider] %s' % (self.data,))
+                    return
+                for x in mylar.CONFIG.EXTRA_NEWZNABS:
+                    if x[0].lower() == newznab_name.lower():
+                        self.data = self._failureResponse('%s already exists as a provider.' % newznab_name)
+                        logger.fdebug('[API][addProvider] %s' % (self.data,))
+                        return
+
+            if 'host' in kwargs:
+                newznab_host = kwargs['host']
+                if not newznab_host.startswith('http'):
+                    self.data = self._failureResponse('protocol is required for % host entry' % providertype)
+                    logger.fdebug('[API][addProvider] %s' % (self.data,))
+                    return
+                if newznab_host.startswith('https'):
+                    newznab_verify = '1'
+                else:
+                    newznab_verify = '0'
+            if 'prov_apikey' in kwargs:
+                newznab_apikey = kwargs['prov_apikey']
+
+            newznab_enabled = '0' # set the default to disabled.
+            if 'enabled' in kwargs:
+                newznab_enabled = '1'
+            if 'uid' in kwargs:
+                newznab_uid = kwargs['uid']
+            else:
+                newznab_uid = None
+
+            if 'categories' in kwargs:
+                newznab_categories = kwargs['categories']
+                if newznab_uid is not None:
+                    newznab_uid += '%s%s'.strip() % ('#', re.sub(',', '#', newznab_categories))
+                else:
+                    newznab_uid = '%s%s'.strip() % ('#', re.sub(',', '#', newznab_categories))
+
+            mylar.CONFIG.EXTRA_NEWZNABS.append((newznab_name, newznab_host, newznab_verify, newznab_apikey, newznab_uid, newznab_enabled))
+            p_name = newznab_name
+
+        elif providertype == 'torznab':
+            if 'name' in kwargs:
+                torznab_name = kwargs['name']
+                if any([torznab_name is None, torznab_name.strip() == '']):
+                    self.data = self._failureResponse('name given for provider cannot be None or blank')
+                    logger.fdebug('[API][addProvider] %s' % (self.data,))
+                    return
+                for x in mylar.CONFIG.EXTRA_TORZNABS:
+                    if x[0].lower() == torznab_name.lower():
+                        self.data = self._failureResponse('%s already exists as a provider.' % torznab_name)
+                        logger.fdebug('[API][addProvider] %s' % (self.data,))
+                        return
+
+            if 'host' in kwargs:
+                torznab_host = kwargs['host']
+                if not torznab_host.startswith('http'):
+                    self.data = self._failureResponse('protocol is required for % host entry' % providertype)
+                    logger.fdebug('[API][addProvider] %s' % (self.data,))
+                    return
+                if torznab_host.startswith('https'):
+                    torznab_verify = '1'
+                else:
+                    torznab_verify = '0'
+            if 'prov_apikey' in kwargs:
+                torznab_apikey = kwargs['prov_apikey']
+            torznab_enabled = '0'
+            if 'enabled' in kwargs:
+                torznab_enabled = '1'
+            if 'categories' in kwargs:
+                torznab_categories = kwargs['categories']
+                if ',' in torznab_categories:
+                    tc = torznab_categories.split(',')
+                    torznab_categories = '#'.join(tc).strip()
+
+            mylar.CONFIG.EXTRA_TORZNABS.append((torznab_name, torznab_host, torznab_verify, torznab_apikey, torznab_categories, torznab_enabled))
+            p_name = torznab_name
+
+        try:
+            mylar.CONFIG.writeconfig()
+        except Exception as e:
+            logger.error('[API][ADD_PROVIDER][%s] error returned : %s' % (providertype, e))
+            self.data = self._failureResponse('Unable to add %s provider %s to the provider list. Check the logs.' % (providertype, p_name))
+        else:
+            self.data = self._successResponse('Successfully added %s provider %s to the provider list' % (providertype, p_name))
+        return
+
+    def _delProvider(self, **kwargs):
+        providername = None
+        if 'name' in kwargs:
+            providername = kwargs['name'].strip()
+
+        if any([providername is None, providername == '']):
+            self.data = self._failureResponse('name given for provider cannot be None or blank')
+            logger.fdebug('[API][delProvider] %s' % (self.data,))
+            return
+
+        providertype = None
+        if 'providertype' in kwargs:
+            providertype = kwargs['providertype'].strip()
+        else:
+            self.data = self._failureResponse('No provider type provided')
+            logger.fdebug('[API][addProvider] %s' % (self.data,))
+            return
+
+        if any([providertype is None, providertype == '']) or all([providertype != 'torznab', providertype != 'newznab']):
+            if any([providertype is None, providertype == '']):
+                self.data = self._failureResponse('`providertype` cannot be None or blank (either `torznab` or `newznab`)')
+            elif all([providertype != 'torznab', providertype != 'newznab']):
+                self.data = self._failureResponse('`providertype` provided not recognized. Must be either `torznab` or `newznab`)')
+            logger.fdebug('[API][delProvider] %s' % (self.data,))
+            return
+
+        del_match = False
+        newznabs = []
+        if providertype == 'newznab':
+            for nz in mylar.CONFIG.EXTRA_NEWZNABS:
+                if providername.lower() == nz[0]:
+                    del_match = True
+                    continue
+                else:
+                    newznabs.append(nz)
+
+            if del_match is True:
+                mylar.CONFIG.EXTRA_NEWZNABS = ((newznabs))
+        else:
+            torznabs= []
+            for nz in mylar.CONFIG.EXTRA_TORZNABS:
+                if providername.lower() == nz[0]:
+                    del_match = True
+                    continue
+                else:
+                    torznabs.append(nz)
+            if del_match is True:
+                mylar.CONFIG.EXTRA_TORZNABS = ((torznabs))
+
+        if del_match is False:
+            self.data = self._failureResponse('Cannot remove %s as a provider, as it does not exist as a %s provider' % (providername, providertype))
+            logger.fdebug('[API][delProvider] %s' % self.data)
+            return
+        else:
+            try:
+                mylar.CONFIG.writeconfig()
+            except Exception as e:
+                logger.error('[API][ADD_PROVIDER][%s] error returned : %s' % (providertype, e))
+                self.data = self._failureResponse('Unable to save config of deleted %s provider %s. Check the logs.' % (providertype, providername))
+            else:
+                self.data = self._successResponse('Successfully removed %s provider %s' % (providertype, providername))
+                logger.fdebug('[API][delProvider] %s' % self.data)
+        return
+
+    def _changeProvider(self, **kwargs):
+        providername = None
+        changename = None
+        if 'altername' in kwargs:
+            changename = kwargs.pop('altername').strip()
+            if any([changename is None, changename == '']):
+                self.data = self._failureResponse('altered name given for provider cannot be None or blank')
+                logger.fdebug('[API][changeProvider] %s' % (self.data,))
+                return
+
+        if 'name' not in kwargs:
+            self.data = self._failureResponse('provider name (`name`) not given')
+            logger.fdebug('[API][changeProvider] %s' % (self.data,))
+            return
+        else:
+            providername = kwargs['name'].strip()
+            if all([providername is None, providername == '']):
+                self.data = self._failureResponse('name given for provider cannot be None or blank')
+                logger.fdebug('[API][changeProvider] %s' % (self.data,))
+                return
+
+        providertype = None
+        if 'providertype' not in kwargs:
+            self.data = self._failureResponse('No provider type provided')
+            logger.fdebug('[API][changeProvider] %s' % (self.data,))
+            return
+        else:
+            providertype = kwargs['providertype'].strip()
+            if all([providertype != 'newznab', providertype != 'torznab']):
+                self.data = self._failureResponse('providertype indicated %s is not a valid option. Options are `newznab` or `torznab`.' % providertype)
+                logger.fdebug('[API][changerovider] %s' % (self.data,))
+                return
+
+        # find the values to change.
+        if 'host' in kwargs:
+            providerhost = kwargs['host']
+            if providerhost.startswith('http'):
+                if providerhost.startswith('https'):
+                    prov_verify = '1'
+                else:
+                    prov_verify = '0'
+            else:
+                self.data = self._failureResponse('protocol is required for % host entry' % providertype)
+                logger.fdebug('[API][changeProvider] %s' % (self.data,))
+                return
+        else:
+            providerhost = None
+            prov_verify = None
+
+        if 'prov_apikey' in kwargs:
+            prov_apikey = kwargs['prov_apikey']
+        else:
+            prov_apikey = None
+
+        if 'enabled' in kwargs:
+            tmp_enable = kwargs['enabled']
+            prov_enabled = '1'
+            if tmp_enable == 'true':
+                prov_enabled = '1'
+            elif any([tmp_enable == 'false', tmp_enable is None, tmp_enable == '']):
+                prov_enabled = '0'
+            else:
+                self.data = self._failureResponse('`enabled` value must be `true`, `false` or not declared')
+                logger.fdebug('[API][changeProvider] %s' % (self.data,))
+                return
+
+        elif 'disabled' in kwargs:
+            tmp_enable = kwargs['disabled']
+            prov_enabled = '0'
+            if tmp_enable == 'true':
+                prov_enabled = '0'
+            elif any([tmp_enable == 'false', tmp_enable is None, tmp_enable == '']):
+                prov_enabled = '1'
+            else:
+                self.data = self._failureResponse('`disabled` value must be `true`, `false` or not declared')
+                logger.fdebug('[API][changeProvider] %s' % (self.data,))
+                return
+        else:
+            prov_enabled = None
+
+        torznab_categories = None
+        if 'categories' in kwargs and providertype == 'torznab':
+            torznab_categories = kwargs['categories']
+            if ',' in torznab_categories:
+                tc = torznab_categories.split(',')
+                torznab_categories = '#'.join(tc).strip()
+
+        if 'uid' in kwargs and providertype == 'newznab':
+            newznab_uid = kwargs['uid']
+        else:
+            newznab_uid = None
+
+        newznab_categories = None
+        if 'categories' in kwargs and providertype == 'newznab':
+            newznab_categories = kwargs['categories']
+            if newznab_uid is not None:
+                newznab_uid += '%s%s'.strip() % ('#', re.sub(',', '#', newznab_categories))
+            else:
+                newznab_uid = '%s%s'.strip() % ('#', re.sub(',', '#', newznab_categories))
+
+        newznabs = []
+        change_match = []
+        if providertype == 'newznab':
+            for nz in mylar.CONFIG.EXTRA_NEWZNABS:
+                if providername.lower() == nz[0].lower():
+                    if changename is not None:
+                        if providername.lower() != changename.lower():
+                            providername = changename
+                            change_match.append('name')
+                    p_host = nz[1]
+                    if providerhost is not None:
+                        if p_host.lower() != providerhost.lower():
+                            p_host = providerhost
+                            change_match.append('host')
+                    p_verify = nz[2]
+                    if prov_verify is not None:
+                        if p_verify != prov_verify:
+                            p_verify = prov_verify
+                            change_match.append('verify')
+                    p_apikey = nz[3]
+                    if prov_apikey is not None:
+                        if p_apikey != prov_apikey:
+                            p_apikey = prov_apikey
+                            change_match.append('apikey')
+                    p_uid = nz[4]
+                    if newznab_uid is not None:
+                        if p_uid != newznab_uid:
+                            p_uid = newznab_uid
+                            change_match.append('uid')
+                    p_enabled = nz[5]
+                    if p_enabled != prov_enabled and prov_enabled is not None:
+                        p_enabled = prov_enabled
+                        change_match.append('enabled')
+                    newznabs.append((providername, p_host, p_verify, p_apikey, p_uid, p_enabled))
+                else:
+                    newznabs.append(nz)
+
+            if len(change_match) > 0:
+                mylar.CONFIG.EXTRA_NEWZNABS = ((newznabs))
+        else:
+            torznabs= []
+            for nt in mylar.CONFIG.EXTRA_TORZNABS:
+                if providername.lower() == nt[0].lower():
+                    if changename is not None:
+                        if providername.lower() != changename.lower():
+                            providername = changename
+                            change_match.append('name')
+                    p_host = nt[1]
+                    if providerhost is not None:
+                        if p_host.lower() != providerhost.lower():
+                            p_host = providerhost
+                            change_match.append('host')
+                    p_verify = nt[2]
+                    if p_verify != prov_verify and prov_verify is not None:
+                        p_verify = prov_verify
+                        change_match.append('verify')
+                    p_apikey = nt[3]
+                    if prov_apikey is not None:
+                        if p_apikey != prov_apikey:
+                            p_apikey = prov_apikey
+                            change_match.append('apikey')
+                    p_categories = nt[4]
+                    if torznab_categories is not None:
+                        if p_categories != torznab_categories:
+                            p_categories = torznab_categories
+                            change_match.append('categories')
+                    p_enabled = nt[5]
+                    if p_enabled != prov_enabled and prov_enabled is not None:
+                        p_enabled = prov_enabled
+                        change_match.append('enabled')
+                    torznabs.append((providername, p_host, p_verify, p_apikey, p_categories, p_enabled))
+                else:
+                    torznabs.append(nt)
+
+            if len(change_match) > 0:
+                mylar.CONFIG.EXTRA_TORZNABS = ((torznabs))
+
+        if len(change_match) == 0:
+            self.data = self._failureResponse('Nothing to change for %s provider %s. It does not exist as a %s provider or nothing to change' % (providertype, providername, providertype))
+            logger.fdebug('[API][changeProvider] %s' % self.data)
+            return
+        else:
+            try:
+                mylar.CONFIG.writeconfig()
+            except Exception as e:
+                logger.error('[API][ADD_PROVIDER][%s] error returned : %s' % (providertype, e))
+            else:
+                self.data = self._successResponse('Successfully changed %s for %s provider %s ' % (change_match, providertype, providername))
+                logger.fdebug('[API][changeProvider] %s' % self.data)
         return
 
 class REST(object):

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -790,6 +790,7 @@ class Config(object):
         config.set('Torznab', 'extra_torznabs', ', '.join(tmp_torz))
 
         # this needs to revert from , to # so that it is stored properly (multiple categories)
+        setattr(self, 'EXTRA_NEWZNABS', self.get_extra_newznabs())
         setattr(self, 'EXTRA_TORZNABS', self.get_extra_torznabs())
 
         ###this should be moved elsewhere...
@@ -1220,7 +1221,19 @@ class Config(object):
         return KEYS_32P
 
     def get_extra_newznabs(self):
-        extra_newznabs = list(zip(*[iter(self.EXTRA_NEWZNABS.split(', '))]*6))
+        extra_newznabs = self.EXTRA_NEWZNABS
+        if type(extra_newznabs) != list:
+            extra_newznabs = list(zip(*[iter(extra_newznabs.split(', '))]*6))
+        x_newzcat = []
+        for x in extra_newznabs:
+            x_cat = x[4]
+            if '#' in x_cat:
+                x_t = x[4].split('#')
+                x_cat = ','.join(x_t)
+                if x_cat[0] == ',':
+                    x_cat = re.sub(',', '#', x_cat, 1)
+            x_newzcat.append((x[0],x[1],x[2],x[3],x_cat,x[5]))
+        extra_newznabs = x_newzcat
         return extra_newznabs
 
     def get_extra_torznabs(self):

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -771,7 +771,7 @@ def NZB_SEARCH(
         verify = bool(newznab_host[2])
         if '#' in newznab_host[4].rstrip():
             catstart = newznab_host[4].find('#')
-            category_newznab = newznab_host[4][catstart + 1 :]
+            category_newznab = re.sub('#', ',', newznab_host[4][catstart + 1 :]).strip()
             logger.fdebug('Non-default Newznab category set to : %s' % category_newznab)
         else:
             category_newznab = '7030'

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5763,6 +5763,8 @@ class WebInterface(object):
                     newznab_verify = 0
                 newznab_apikey = kwargs['newznab_apikey' + newznab_number]
                 newznab_uid = kwargs['newznab_uid' + newznab_number]
+                if ',' in newznab_uid:
+                    newznab_uid = re.sub(',', '#', newznab_uid).strip()
                 try:
                     newznab_enabled = str(kwargs['newznab_enabled' + newznab_number])
                 except KeyError:

--- a/mylar/webstart.py
+++ b/mylar/webstart.py
@@ -96,7 +96,7 @@ def initialize(options):
         },
         '/favicon.ico': {
             'tools.staticfile.on': True,
-            'tools.staticfile.filename': os.path.join(os.path.abspath(os.curdir), 'images' + os.sep + 'favicon.ico')
+            'tools.staticfile.filename': os.path.join(mylar.PROG_DIR, 'data', 'images','favicon.ico')
         },
         '/cache': {
             'tools.staticdir.on': True,


### PR DESCRIPTION
- added ```listProviders```, ```addProvider```, ```delProvider``` and ```changeProvider``` API endpoints (see https://github.com/mylar3/mylar3/wiki/API-Documentation).
- fixed newznab ```verify ssl``` field in the GUI.
- fixed API calls so they wouldn't generate cherry tracebacks whenever an API endpoint was used.
- multiple categories are now allowed for newznab entries.