### PR TITLE
FIX:(#770) Annuals, when annual integration is enabled, would not be linked up properly when viewing a related story arc

### DIFF
--- a/data/interfaces/default/storyarc_detail.html
+++ b/data/interfaces/default/storyarc_detail.html
@@ -1,6 +1,7 @@
 <%inherit file="base.html"/>
 <%!
         import os
+        import re
         import mylar
 	from mylar.helpers import checked, listLibrary
 %>
@@ -167,16 +168,22 @@
                 else:
                         volume = ''
 
+                if 'annual' in item['ComicName'].lower():
+                        cname = re.sub('Annual', '', item['ComicName'], flags=re.I).strip()
+                        displayname = '%s %s %s (%s)' % (cname, volume, 'Annual', item['SeriesYear'])
+                else:
+                        displayname = '%s %s (%s)' % (item['ComicName'], volume, item['SeriesYear'])
+
+
         %>
 
          <tr id="${item['ReadingOrder']}" class="grade${grade}">
                 <td class="edit" title="Change the order (click to edit)" id="${storyarcid}.${item['IssueArcID']}">${item['ReadingOrder']}</td>
                 <td id="comicname" title="${item['IssueName']}">
                 %if haveit == "No":
-                     ${item['ComicName']} ${volume} (${item['SeriesYear']})
+                    ${displayname)
                 %else:
-                    <a href="comicDetails?ComicID=${haveit}">${item['ComicName']} ${volume} (${item['SeriesYear']})</a>
-
+                    <a href="comicDetails?ComicID=${haveit}">${displayname)</a>
                 %endif
                 </td>
 

--- a/data/interfaces/default/storyarc_detail.poster.html
+++ b/data/interfaces/default/storyarc_detail.poster.html
@@ -1,6 +1,7 @@
 <%inherit file="base.html"/>
 <%!
         import os
+        import re
         import mylar
 	from mylar.helpers import checked, listLibrary
 %>
@@ -161,15 +162,26 @@
                 else:
                         volume = ''
 
+                if all([item['Volume'] is not None, item['Volume'] != 'None']):
+                        volume = 'V' + item['Volume']
+                else:
+                        volume = ''
+
+                if 'annual' in item['ComicName'].lower():
+                        cname = re.sub('Annual', '', item['ComicName'], flags=re.I).strip()
+                        displayname = '%s %s %s (%s)' % (cname, volume, 'Annual', item['SeriesYear'])
+                else:
+                        displayname = '%s %s (%s)' % (item['ComicName'], volume, item['SeriesYear'])
+
         %>
 
          <tr id="${item['ReadingOrder']}" class="grade${grade}">
                 <td class="edit" title="Change the order (click to edit)" id="${storyarcid}.${item['IssueArcID']}">${item['ReadingOrder']}</td>
                 <td id="comicname" title="${item['IssueName']}">
                 %if haveit == "No":
-                     ${item['ComicName']} ${volume} (${item['SeriesYear']})
+                     ${displayname}
                 %else:
-                    <a href="comicDetails?ComicID=${haveit}">${item['ComicName']} ${volume} (${item['SeriesYear']})</a>
+                    <a href="comicDetails?ComicID=${haveit}">${displayname}</a>
 
                 %endif
                 </td>

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -473,6 +473,11 @@ class FileChecker(object):
                     logger.fdebug('checking date : %s' % dtcheck)
                     checkdate_response = self.checkthedate(dtcheck)
                     if checkdate_response:
+                        if dtcheck.endswith('-') and int(dtcheck[:-1]) == int(checkdate_response):
+                            volume_found['volume'] = dtcheck[:-1]
+                            volume_found['position'] = split_file.index(sf,current_pos)
+                            logger.fdebug('volume detected as : %s' % dtcheck)
+                            continue
                         logger.fdebug('date: %s' % checkdate_response)
                         datecheck.append({'date':         dtcheck,
                                           'position':     split_file.index(sf),
@@ -1657,7 +1662,7 @@ class FileChecker(object):
     #    Jan 1990
     #    January1990'''
 
-        fmts = ('%Y','%b %d, %Y','%B %d, %Y','%B %d %Y','%m/%d/%Y','%m/%d/%y','(%m/%d/%Y)','%b %Y','%B%Y','%b %d,%Y','%m-%Y','%B %Y','%Y-%m-%d','%Y-%m','%Y%m','%Y-%m-00')
+        fmts = ('%Y','%Y-', '%b %d, %Y','%B %d, %Y','%B %d %Y','%m/%d/%Y','%m/%d/%y','(%m/%d/%Y)','%b %Y','%B%Y','%b %d,%Y','%m-%Y','%B %Y','%Y-%m-%d','%Y-%m','%Y%m','%Y-%m-00')
         mnths = ('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec')
         parsed=[]
 


### PR DESCRIPTION
- FIX: Added ability of filechecker to properly detect filenames containing a volume in the format of (YYYY-)
- added in some additional volume handling of annuals being detected incorrectly btwn CV deck and CV description.
- Changed formatting of annuals on story arc detail page so that they are named as ```Series Volume Annual (Year)``` so the naming is more consistent with series titles (which are ```Series Volume (Year)```.

*note that on a story arc detail page, the annual will not be properly highlighted as belonging to a particular series (when annual integration is enabled), however the status will still be properly shown (it's a display issue).