### PR TITLE
FIX: annuals not properly linking to series on weekly pull, FIX: post…

### DIFF
--- a/data/interfaces/default/comicdetails.html
+++ b/data/interfaces/default/comicdetails.html
@@ -488,9 +488,11 @@
                                 <td id="issuenumber">${issue['Issue_Number']}</td>
 
                                 <%
+                                    titledisplay = False
                                     if issue['IssueName'] is not None:
                                         if len(issue['IssueName']) > 70:
-                                            issuename = "%s..." % issue['IssueName'][:70]
+                                            issuename = "%s..." % issue['IssueName'][:67]
+                                            titledisplay = True
                                         else:
                                             issuename = issue['IssueName']
                                         try:
@@ -500,7 +502,11 @@
                                     else:
                                         issuename = None
                                 %>
-                                <td id="issuename">${issuename}</td>
+                                %if titledisplay:
+                                    <td id="issuename" title="${issue['IssueName']}">${issuename}</td>
+                                %else:
+                                    <td id="issuename">${issuename}</td>
+                                %endif
                                 <%
                                     issdate = issue['IssueDate']
                                     dateline = "Publication Date (click to edit)"
@@ -639,7 +645,7 @@
                         <tr>
                                 <th id="select" align="left"><input type="checkbox" onClick="toggle(this)" name="annuals" class="checkbox" /></th>
                                 <th id="aint_issuenumber">Int_IssNumber</th>
-                                <th id="aissuenumber">Number</th>
+                                <th id="aissuenumber">#</th>
                                 <th id="aissuename">Name</th>
                                 <th id="areldate">Date</th>
                                 <th id="astatus">Status</th>

--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -878,6 +878,9 @@ class PostProcessor(object):
                                                 logger.fdebug('test matched to ComicID: %s' % (cs['ComicID']))
                                                 week_comic = test[0]
                                                 week_dynamicname = test[1]
+                                                if all([mylar.CONFIG.ANNUALS_ON, 'annual' in week_dynamicname.lower()]) or all([mylar.CONFIG.ANNUALS_ON, 'special' in week_dynamicname.lower()]):
+                                                    week_dynamicname = re.sub('annual', '', week_dynamicname, flags=re.I).strip()
+                                                    week_dynamicname = re.sub('special', '', week_dynamicname, flags=re.I).strip()
                                                 week_issue = test[2]
                                                 week_intissue = helpers.issuedigits(week_issue)
                                                 logger.fdebug('week_dynamicname: %s / dynamic_seriesname: %s' % (week_dynamicname,dynamic_seriesname))

--- a/mylar/weeklypull.py
+++ b/mylar/weeklypull.py
@@ -1048,7 +1048,12 @@ def new_pullcheck(weeknumber, pullyear, comic1off_name=None, comic1off_id=None, 
                             comicname = week['ComicName']
                         latestiss = annualidmatch[0]['latestIssue'].strip()
                         if mylar.CONFIG.ANNUALS_ON:
-                            comicid = annualidmatch[0]['ComicID'].strip()
+                            comicid = None
+                            for x in annualidmatch[0]['AnnualIDs']:
+                                if week['comicid'] == x['ComicID'] and week['annuallink'] is not None:
+                                    comicid = x['ComicID'].strip()
+                            if not comicid:
+                                pass
                         else:
                             comicid = annualidmatch[0]['AnnualIDs'][0]['ComicID'].strip()
                         logger.fdebug('[WEEKLY-PULL-ANNUAL] Series Match to ID --- ' + comicname + ' [' + comicid + ']')


### PR DESCRIPTION
- FIX: (annual integration) annuals not properly linking to series on weekly pull
- FIX: (annual integration) post-processing annuals present on weekly pull
- IMP: Issue Title on series detail page changed to hover value if > 70 in length (as it cuts off at > 70)
- FIX: Changed column heading on series detail page for annuals to just '#'