### PR TITLE
FIX: attempted fix for annual directories being created incorrectly along with pull-related annuals

### DIFF
--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -373,11 +373,24 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
     #mylar.UPDATER_STATUS = 'Waiting'
     logger.fdebug('Update complete')
 
-def latest_update(ComicID, LatestIssue, LatestDate):
+def latest_update(ComicID, LatestIssue, LatestDate, ReleaseComicID=None):
     # here we add to comics.latest
     logger.fdebug(str(ComicID) + ' - updating latest_date to : ' + str(LatestDate))
     myDB = db.DBConnection()
-    latestCTRLValueDict = {"ComicID":      ComicID}
+    cid = ComicID
+    if mylar.CONFIG.ANNUALS_ON:
+        logger.fdebug('checking for releasecomicid %s reference in annuals table' % ReleaseComicID)
+        db_check = myDB.selectone("SELECT ComicID from Annuals WHERE ReleaseComicID=?", [ReleaseComicID]).fetchone()
+        if not db_check:
+            logger.fdebug('Annual has not been added yet to series')
+        else:
+            cid = db_check[0][0]
+            logger.fdebug('ReleaseComicID found of %s linking to series %s' % (ReleaseComicID, cid))
+            if cid != ComicID:
+                cid = ComicID
+            #might have to set the issue to something like 'Annual %s' % LatestIssue ?
+
+    latestCTRLValueDict = {"ComicID":      cid}
     newlatestDict = {"LatestIssue":      str(LatestIssue),
                      "intLatestIssue":   helpers.issuedigits(LatestIssue),
                      "LatestDate":       str(LatestDate)}
@@ -433,7 +446,7 @@ def upcoming_update(ComicID, ComicName, IssueNumber, IssueDate, forcecheck=None,
     if any(['annual' in ComicName.lower(), 'special' in ComicName.lower()]):
         if mylar.CONFIG.ANNUALS_ON:
             logger.info('checking: ' + str(ComicID) + ' -- issue#: ' + str(IssueNumber))
-            issuechk = myDB.selectone("SELECT * FROM annuals WHERE ComicID=? AND Issue_Number=?", [ComicID, IssueNumber]).fetchone()
+            issuechk = myDB.selectone("SELECT * FROM annuals WHERE ReleaseComicID=? AND Issue_Number=?", [ComicID, IssueNumber]).fetchone()
         else:
             logger.fdebug('Non-standard issue detected (annual/special/etc), but Annual Integration is not enabled. Ignoring result.')
             return
@@ -1862,17 +1875,21 @@ def watchlist_updater(calledfrom=None, sched=False):
     library = {}
 
     if mylar.CONFIG.ANNUALS_ON is True:
-        list = myDB.select("SELECT a.comicid, b.releasecomicid, a.status, a.LastUpdated, a.Total FROM Comics AS a LEFT JOIN annuals AS b on a.comicid=b.comicid group by a.comicid")
+        list = myDB.select("SELECT a.comicname, a.comicid, b.releasecomicid, a.status, a.LastUpdated, a.Total FROM Comics AS a LEFT JOIN annuals AS b on a.comicid=b.comicid group by a.comicid")
     else:
-        list = myDB.select("SELECT comicid, status, LastUpdated, Total FROM Comics group by comicid")
+        list = myDB.select("SELECT comicname, comicid, status, LastUpdated, Total FROM Comics group by comicid")
 
     # if a series failed to update for w/e reason, LastUpdated will be NULL and cause an error otherwise.
     # the prev_failed_updates dict will store all the 'failed' ID's that will be submitted in addition to any
     # other ID's that were updated recently by CV during the check.
     prev_failed_updates = []
-
+    popthecheck = []
     for row in list:
-        if not row['LastUpdated']:
+        if row['ComicName'] is None and mylar.CONFIG.ANNUALS_ON:
+            logger.fdebug('Popping the check for: %s' % row['ComicID'])
+            popthecheck.append(row['ComicID'])
+            continue
+        elif not row['LastUpdated'] and all(['ComicID' not in row['ComicName'], row['Status'] != 'Loading', row['ComicName'] is not None]):
             prev_failed_updates.append(int(row['ComicID']))
         else:
             tm = datetime.datetime.strptime(row['LastUpdated'], '%Y-%m-%d %H:%M:%S')
@@ -1881,12 +1898,23 @@ def watchlist_updater(calledfrom=None, sched=False):
                                             'lastupdated':    calendar.timegm(tm.utctimetuple()),
                                             'total':          row['Total']}
         try:
-            if row['ReleaseComicID'] is not None:
+            if row['ReleaseComicID'] is not None and all(['ComicID' not in row['ComicName'], row['Status'] != 'Loading', row['ComicName'] is not None]):
                 library[row['ReleaseComicID']] = {'comicid':     row['ComicID'],
                                                   'status':      row['Status']}
         except:
             pass
 
+    if len(popthecheck) > 0:
+        logger.fdebug('doing the popcheck')
+        # this is for annuals that have been mistakingly added during a previous phase - they have a ComicID on the comics table but nothing linked anywhere to it
+        # this will check to see if the releasecomicid is present on the annuals table (as it just got verified as being on the comics table) and if it is,
+        # will not flag it for a previous failed update action (ie. refresh). The None values in the Comics table will get cleared out on next restart.
+        for pc in popthecheck:
+            list = myDB.select("SELECT comicname, comicid, status FROM Annuals WHERE releasecomicid=? AND comicname is not NULL", [pc]).fetchone()
+            if not list:
+                continue
+            else:
+                prev_failed_updates.append(int(row['ComicID']))
     # this is based on comicid updates atm.
     to_check = []
     loaddate_stamp = None

--- a/mylar/weeklypull.py
+++ b/mylar/weeklypull.py
@@ -1144,7 +1144,10 @@ def new_pullcheck(weeknumber, pullyear, comic1off_name=None, comic1off_id=None, 
 
                     if all([statusupdate is not None, statusupdate['Status'] != 'incorrect_match']):
                         # here we add to comics.latest
-                        updater.latest_update(ComicID=comicid, LatestIssue=week['issue'], LatestDate=ComicDate)
+                        if mylar.CONFIG.ANNUALS_ON:
+                            updater.latest_update(ComicID=statusupdate['ComicID'], LatestIssue=week['issue'], LatestDate=ComicDate, ReleaseComicID=comicid)
+                        else:
+                            updater.latest_update(ComicID=comicid, LatestIssue=week['issue'], LatestDate=ComicDate)
 
                     # here we update status of weekly table...
                     mismatched = False


### PR DESCRIPTION
- When annual integration is enabled and the annual is present on the weekly pull (might also be during different scenarios), would incorrectly think that a previous refresh failed and attempt to recreate the entire annual series during the db update interval check (which is every 24hrs or on every restart).
- linking of annual to series (with annual integration enabled) would incorrectly show the comicid to the annual not the series that the annual is tied to which would result in a dead link.
