### PR TITLE
FIX: Depreciate the annual field as an available option for Folder Format

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -1271,7 +1271,7 @@
                                      <label>Folder Format</label>
                                      <input type="text" name="folder_format" value="${config['folder_format']}" size="43">
                                      <%
-                                          folder_options = "$Series = SeriesName\n$Year = SeriesYear\n$Annual = Annual (word)\n$VolumeY = V{SeriesYear}\n$VolumeN = V{Volume#}\n$Type = BookType (TPB/GN)"
+                                          folder_options = "$Series = SeriesName\n$Year = SeriesYear\n$VolumeY = V{SeriesYear}\n$VolumeN = V{Volume#}\n$Type = BookType (TPB/GN)"
                                      %>
                                      <a href="#" title="${folder_options}"><img src="images/info32.png" height="16" alt="" /></a>
                                      <small>Use: $Publisher, $Series, $Year<br />

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -1128,6 +1128,16 @@ class Config(object):
             elif self.ENABLE_DDL is False:
                 mylar.queue_schedule('ddl_queue', 'stop')
 
+        if self.FOLDER_FORMAT is None:
+            setattr(self, 'FOLDER_FORMAT', '$Series ($Year)')
+
+        if '$Annual' in self.FOLDER_FORMAT:
+            logger.fdebug('$Annual has been depreciated as a folder format option. Auto-removing from your folder format scheme.')
+            ann_removed = re.sub(r'\$annual', '', self.FOLDER_FORMAT, flags=re.I).strip()
+            ann_remove = re.sub(r'\s+', ' ', ann_removed).strip()
+            setattr(self, 'FOLDER_FORMAT', ann_remove)
+            config.set('General', 'folder_format', ann_remove)
+
         if not self.DDL_LOCATION:
             self.DDL_LOCATION = self.CACHE_DIR
             if self.ENABLE_DDL is True:

--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -132,7 +132,6 @@ class FileHandlers(object):
                   '$publisher':     publisher.lower(),
                   '$VolumeY':       'V' + self.comic['ComicYear'],
                   '$VolumeN':       comicVol.upper(),
-                  '$Annual':        'Annual',
                   '$Type':          booktype
                   }
 

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -850,7 +850,6 @@ def updateComicLocation():
                           '$publisher':     publisher.lower(),
                           '$VolumeY':       'V' + str(year),
                           '$VolumeN':       comversion,
-                          '$Annual':        'Annual',
                           '$Type':          booktype
                           }
 


### PR DESCRIPTION
- depreciate the ```$Annual``` variable as an option for use with Folder Format.
- will remove any existing occurrence of ```$Annual``` within the Folder Format scheme.