### PR TITLE
FIX:(#804) post-processing failing to detect issues previously on the pull-list, but in an Ended status, FIX: Fixed incorrect publication run calculation

### DIFF
--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -1471,7 +1471,7 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
         n_date = datetime.date.today()
         recentchk = (n_date - c_date).days
 
-        if recentchk <= 55:
+        if recentchk <= helpers.checkthepub(comicid):
             lastpubdate = 'Present'
         else:
             if ltmonth == '?':


### PR DESCRIPTION
- FIX:(#804) post-processing would not detect issues that had previously existed on the pull-list, but were in an Ended status,
- FIX: The ```Present``` value in a series publication run calculation (to determine if a series is continuing or ended) was hard_coded to 55 days past last publication date - changed to allow based on publisher groupings.