### PR TITLE
FIX: weekly pull would not properly recreate the current week via the autoscheduler method.

### DIFF
--- a/mylar/locg.py
+++ b/mylar/locg.py
@@ -96,9 +96,10 @@ def locg(pulldate=None,weeknumber=None,year=None):
             myDB.action("CREATE TABLE IF NOT EXISTS weekly (SHIPDATE, PUBLISHER text, ISSUE text, COMIC VARCHAR(150), EXTRA text, STATUS text, ComicID text, IssueID text, CV_Last_Update text, DynamicName text, weeknumber text, year text, volume text, seriesyear text, annuallink text, format text, rowid INTEGER PRIMARY KEY)")
 
             #clear out the upcoming table here so they show the new values properly.
-            if pulldate == '00000000':
-                logger.info('Re-creating pullist to ensure everything\'s fresh.')
-                myDB.action('DELETE FROM weekly WHERE weeknumber=? AND year=?',[int(weeknumber), int(year)])
+            #if pulldate == '00000000':
+            # 2021-07-03 -> we should always clear out the table to ensure we don't have old data mixed with fresh.
+            logger.info('Re-creating pullist to ensure everything\'s fresh.')
+            myDB.action('DELETE FROM weekly WHERE weeknumber=? AND year=?',[int(weeknumber), int(year)])
 
             for x in pull:
                 comicid = None


### PR DESCRIPTION
When not manually recreating the pull-list (ie. the auto-scheduler method), it would only refresh the exsiting table with new data - which could create extra / repeated entries depending on issue changes to the pull-list.

This will just ensure that the existing weekly table for the given week, gets wiped out prior to putting the new data in so that it's never considered 'stale'.