### PR TITLE
FIX: fix for CV erroring out when the db_updater was requesting a range that contained bad data on CV

### DIFF
--- a/mylar/config.py
+++ b/mylar/config.py
@@ -88,6 +88,8 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'BACKUP_ON_START': (bool, 'General', False),
     'BACKFILL_LENGTH': (int, 'General', 8),  # weeks
     'BACKFILL_TIMESPAN': (int, 'General', 10),   # minutes
+    'PROBLEM_DATES': (str, 'General', []),
+    'PROBLEM_DATES_SECONDS': (int, 'General', 60),
 
     'RSS_CHECKINTERVAL': (int, 'Scheduler', 20),
     'SEARCH_INTERVAL': (int, 'Scheduler', 360),
@@ -1063,6 +1065,18 @@ class Config(object):
                 except Exception as e:
                     logger.warn('[MASS_PUBLISHERS] Unable to convert publishers [%s]. Error returned: %s' % (self.MASS_PUBLISHERS, e))
         logger.info('[MASS_PUBLISHERS] Auto-add for weekly publishers set to: %s' % (self.MASS_PUBLISHERS,))
+
+        if len(self.PROBLEM_DATES) > 0 and self.PROBLEM_DATES != '[]':
+            if type(self.PROBLEM_DATES) != list:
+                try:
+                    self.PROBLEM_DATES = json.loads(self.PROBLEM_DATES)
+                except Exception as e:
+                    logger.warn('unable to load problem dates')
+        else:
+            setattr(self, 'PROBLEM_DATES', ['2021-07-14 04:00:34'])
+            config.set('General', 'problem_dates', json.dumps(self.PROBLEM_DATES))
+
+        logger.info('[PROBLEM_DATES] Problem dates loaded: %s' % (self.PROBLEM_DATES,))
 
         #comictagger - force to use included version if option is enabled.
         import comictaggerlib.ctversion as ctversion


### PR DESCRIPTION
When the db_updater runs, it takes a date range - the last time the updater was successfully ran and the current date. It uses that as the start-end range when requesting issue data from CV. 

As of  yesterday, CV did something to one specific issue that was posted/updated at a specific time which would cause an error - both in the API and on the CV website itself. If Mylar was requesting a set of data within that range, CV would return an xml error response and no updates would occur. This would deadlock as Mylar would try later to retrieve the same data range, but fail again due to that one specific issue.

This PR does a few things:
- creates 2 new config entries: ```problem_dates``` and ```problem_dates_seconds```.
- ```problem_dates``` is a list variable which holds any bad issue datetimes in the format of ``YYYY-MM-DD %HH:%:MM:%SS``.
- ```problem_dates_seconds``` is an integer value in seconds which will tell Mylar how far away to go from that date when setting the range
- the updater loop has changed from a single iteration to a for..loop in case of multiple problem_dates
- it takes the normal start date to check to see if the value is after the problem_date
- if it is, it checks the normal end date to see if the value is before the current date
- if both are true, it resets the values so that it uses:
    - (normal start date -to- (```problem_date``` - ```problem_dates_seconds```)
    - (```problem_date``` + ```problem_date_seconds```)  -to- current date)

_Note that the end-user won't even notice any of this - this PR description is more for current/future devs and making sure something is documented in regards to what all of this is_