### PR TITLE
FIX: annuals not properly showing as their release name in Wanted table, FIX: Upcoming table not updating

### DIFF
--- a/data/interfaces/default/upcoming.html
+++ b/data/interfaces/default/upcoming.html
@@ -107,7 +107,7 @@
                                           issueid = issue['IssueID']
 
                                       if any(d['IssueID'] == str(issue['IssueID']) for d in ann_list):
-                                          adjcomicname = issue['ComicName'] + ' Annual'
+                                          adjcomicname = issue['ReleaseComicName']
                                       else:
                                           adjcomicname = issue['ComicName']
                                       endif

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -2265,7 +2265,7 @@ class WebInterface(object):
                     return threading.Thread(target=weeklypull.pullit, args=[forcecheck]).start()
 
                 if int(upc['weeknumber']) == int(weeknumber) and int(upc['year']) == int(weekyear):
-                    if upc['Status'] == 'Wanted':
+                    if all([upc['Status'] == 'Wanted', upc['IssueID'] is None]):
                         upcoming_count +=1
                         upcoming.append({"ComicName":    upc['Comic'],
                                          "IssueNumber":  upc['Issue'],

--- a/mylar/weeklypull.py
+++ b/mylar/weeklypull.py
@@ -1041,23 +1041,17 @@ def new_pullcheck(weeknumber, pullyear, comic1off_name=None, comic1off_id=None, 
                         comicid = idmatch[0]['ComicID'].strip()
                         logger.fdebug('[WEEKLY-PULL-ID] Series Match to ID --- ' + comicname + ' [' + comicid + ']')
                     elif annualidmatch:
-                        try:
-                            if 'annual' in week['ComicName'].lower():
-                                comicname = annualidmatch[0]['AnnualIDs'][0]['ComicName'].strip()
-                            else:
-                                comicname = week['ComicName']
-                        except:
-                            comicname = week['ComicName']
+                        comicname = week['ComicName']
                         latestiss = annualidmatch[0]['latestIssue'].strip()
+                        comicid = annualidmatch[0]['AnnualIDs'][0]['ComicID'].strip()
                         if mylar.CONFIG.ANNUALS_ON:
                             comicid = None
                             for x in annualidmatch[0]['AnnualIDs']:
                                 if week['comicid'] == x['ComicID'] and week['annuallink'] is not None:
                                     comicid = x['ComicID'].strip()
+                                    comicname = x['ComicName']
                             if not comicid:
                                 pass
-                        else:
-                            comicid = annualidmatch[0]['AnnualIDs'][0]['ComicID'].strip()
                         if comicid:
                             logger.fdebug('[WEEKLY-PULL-ANNUAL] Series Match to ID --- ' + comicname + ' [' + comicid + ']')
                     else:
@@ -1643,13 +1637,13 @@ def future_check():
                             logger.fdebug('length match differential set for an allowance of 20%')
                             logger.fdebug('actual differential in length between result and series title: ' + str((length_match * 100)-100) + '%')
                             if ((length_match * 100)-100) > 20:
-                                logger.fdebug('there are too many extra words to consider this as match for the given title. Ignoring this result.') 
+                                logger.fdebug('there are too many extra words to consider this as match for the given title. Ignoring this result.')
                                 continue
                             new_match = pos_match['name'].lower()
                             split_series = ser['ComicName'].lower().split()
                             for cw in catch_words:
                                 for x in new_match.split():
-                                    #logger.fdebug('comparing x: ' + str(x) + ' to cw: ' + str(cw)) 
+                                    #logger.fdebug('comparing x: ' + str(x) + ' to cw: ' + str(cw))
                                     if x == cw:
                                         new_match = re.sub(x, '', new_match)
 
@@ -1676,12 +1670,12 @@ def future_check():
                                             word_match+=1
                                     except ValueError:
                                         break
-                                i+=1                                
+                                i+=1
                             logger.fdebug('word match score of : ' + str(word_match) + ' / ' + str(len(split_series)))
                             if word_match == len(split_series) or (word_match / len(split_series)) > 80:
                                  logger.fdebug('[' + pos_match['name'] + '] considered a match - word matching percentage is greater than 80%. Attempting to auto-add series into watchlist.')
                                  cid = pos_match['comicid']
-                                 matched = True                
+                                 matched = True
 
                 if matched:
                     #we should probably load all additional issues for the series on the futureupcoming list that are marked as Wanted and then


### PR DESCRIPTION
- FIX: force annuals to use release name instead of trying to modify the name (annuals will now correctly appear in Wanted table)
- FIX: fixed upcoming table so it updates accordingly when new issue data is present (issues with issue data will be removed from the Upcoming table and into the Wanted table. Upcoming table will only show issues with no issue data present yet).
- FIX: corrected some whitespace in weeklypull.py