### PR TITLE
FIX: 2021 annuals would not be post-processed, searched or matched against

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -485,6 +485,7 @@ class PostProcessor(object):
                         as_sinfo = as_d.dynamic_replace(fl['alt_series']) #helpers.conversion(fl['alt_series']))
                         mod_altseriesname = as_sinfo['mod_seriesname']
                         if all([mylar.CONFIG.ANNUALS_ON, 'annual' in mod_altseriesname.lower()]) or all([mylar.CONFIG.ANNUALS_ON, 'special' in mod_altseriesname.lower()]):
+                            mod_altseriesname = re.sub('2021annual', '', mod_altseriesname, flags=re.I).strip()
                             mod_altseriesname = re.sub('annual', '', mod_altseriesname, flags=re.I).strip()
                             mod_altseriesname = re.sub('special', '', mod_altseriesname, flags=re.I).strip()
                         if not any(re.sub('[\|\s]', '', mod_altseriesname).lower() == x for x in loopchk):
@@ -500,6 +501,7 @@ class PostProcessor(object):
                                     loopchk.append(re.sub('[\|\s]', '', cname.lower()))
 
                     if all([mylar.CONFIG.ANNUALS_ON, 'annual' in mod_seriesname.lower()]) or all([mylar.CONFIG.ANNUALS_ON, 'special' in mod_seriesname.lower()]):
+                        mod_seriesname = re.sub('2021annual', '', mod_seriesname, flags=re.I).strip()
                         mod_seriesname = re.sub('annual', '', mod_seriesname, flags=re.I).strip()
                         mod_seriesname = re.sub('special', '', mod_seriesname, flags=re.I).strip()
 
@@ -605,6 +607,13 @@ class PostProcessor(object):
                         #force it to use the Publication Date of the latest issue instead of the Latest Date (which could be anything)
                         ld_check = myDB.selectone('SELECT ReleaseDate, Issue_Number, Int_IssueNumber from issues WHERE ComicID=? order by ReleaseDate DESC', [wv['ComicID']]).fetchone()
                         if ld_check:
+                            if mylar.CONFIG.ANNUALS_ON:
+                                ld_check_ann = myDB.selectone('SELECT ReleaseDate, Issue_Number, Int_IssueNumber from annuals WHERE ComicID=? order by ReleaseDate DESC', [wv['ComicID']]).fetchone()
+                                if ld_check_ann:
+                                    if all([ld_check_ann[0] != '0000-00-00', ld_check_ann[0] is not None]):
+                                        if int(re.sub('-', '', ld_check_ann[0]).strip()) > int(re.sub('-', '', ld_check[0]).strip()):
+                                            logger.fdebug('Annual date newer than latest issue date - re-assigning latestdate as an annual')
+                                            ld_check = ld_check_ann
                             #tmplatestdate = latestdate[0]
                             if ld_check[0][:4] != wv['LatestDate'][:4]:
                                 if ld_check[0][:4] > wv['LatestDate'][:4]:
@@ -735,6 +744,7 @@ class PostProcessor(object):
                                     fcdigit = helpers.issuedigits(re.sub('biannual', '', str(biannchk)).strip())
                                 else:
                                     if 'annual' in temploc.lower():
+                                        fcdigit = helpers.issuedigits(re.sub('2021 annual', '', str(temploc.lower())).strip())
                                         fcdigit = helpers.issuedigits(re.sub('annual', '', str(temploc.lower())).strip())
                                     else:
                                         fcdigit = helpers.issuedigits(re.sub('special', '', str(temploc.lower())).strip())
@@ -880,6 +890,7 @@ class PostProcessor(object):
                                         as_dinfo = as_d.dynamic_replace(watchmatch['series_name'])
                                         tmpseriesname = as_dinfo['mod_seriesname']
                                         if all([mylar.CONFIG.ANNUALS_ON, 'annual' in tmpseriesname.lower()]) or all([mylar.CONFIG.ANNUALS_ON, 'special' in tmpseriesname.lower()]):
+                                            tmpseriesname = re.sub('2021annual', '', tmpseriesname, flags=re.I).strip()
                                             tmpseriesname = re.sub('annual', '', tmpseriesname, flags=re.I).strip()
                                             tmpseriesname = re.sub('special', '', tmpseriesname, flags=re.I).strip()
                                         dynamic_seriesname = re.sub('[\|\s]','', tmpseriesname.lower()).strip()
@@ -891,6 +902,7 @@ class PostProcessor(object):
                                                 week_comic = test[0]
                                                 week_dynamicname = test[1]
                                                 if all([mylar.CONFIG.ANNUALS_ON, 'annual' in week_dynamicname.lower()]) or all([mylar.CONFIG.ANNUALS_ON, 'special' in week_dynamicname.lower()]):
+                                                    week_dynamicname = re.sub('2021annual', '', week_dynamicname, flags=re.I).strip()
                                                     week_dynamicname = re.sub('annual', '', week_dynamicname, flags=re.I).strip()
                                                     week_dynamicname = re.sub('special', '', week_dynamicname, flags=re.I).strip()
                                                 week_issue = test[2]
@@ -1173,6 +1185,7 @@ class PostProcessor(object):
                                                 fcdigit = helpers.issuedigits(re.sub('biannual', '', str(biannchk)).strip())
                                             else:
                                                 if 'annual' in temploc.lower():
+                                                    fcdigit = helpers.issuedigits(re.sub('2021 annual', '', str(temploc.lower())).strip())
                                                     fcdigit = helpers.issuedigits(re.sub('annual', '', str(temploc.lower())).strip())
                                                 else:
                                                     fcdigit = helpers.issuedigits(re.sub('special', '', str(temploc.lower())).strip())
@@ -1485,6 +1498,7 @@ class PostProcessor(object):
                                                 logger.fdebug('%s Bi-Annual detected.' % module)
                                                 fcdigit = helpers.issuedigits(re.sub('biannual', '', str(biannchk)).strip())
                                             else:
+                                                fcdigit = helpers.issuedigits(re.sub('2021 annual', '', str(temploc.lower())).strip())
                                                 fcdigit = helpers.issuedigits(re.sub('annual', '', str(temploc.lower())).strip())
                                                 logger.fdebug('%s Annual detected [%s]. ComicID assigned as %s' % (module, fcdigit, ofv['ComicID']))
                                             annchk = "yes"

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -1343,10 +1343,14 @@ class FileChecker(object):
                 justthedigits = 'Annual'
                 if series_info['issue_number'] is not None:
                     justthedigits += ' %s' % series_info['issue_number']
+                nspace_seriesname = re.sub('2021annual', '', nspace_seriesname.lower()).strip()
                 nspace_seriesname = re.sub('annual', '', nspace_seriesname.lower()).strip()
+                nspace_seriesname_decoded = re.sub('2021annual', '', nspace_seriesname_decoded.lower()).strip()
                 nspace_seriesname_decoded = re.sub('annual', '', nspace_seriesname_decoded.lower()).strip()
             if alt_series is not None and 'annual' in alt_series.lower():
+                nspace_altseriesname = re.sub('2021annual', '', nspace_altseriesname.lower()).strip()
                 nspace_altseriesname = re.sub('annual', '', nspace_altseriesname.lower()).strip()
+                nspace_altseriesname_decoded = re.sub('2021annual', '', nspace_altseriesname_decoded.lower()).strip()
                 nspace_altseriesname_decoded = re.sub('annual', '', nspace_altseriesname_decoded.lower()).strip()
         if mylar.CONFIG.ANNUALS_ON and 'special' not in nspace_watchcomic.lower():
             if 'special' in series_name.lower():
@@ -1401,6 +1405,7 @@ class FileChecker(object):
                         elif 'annual' in nspace_seriesname.lower():
                             if mylar.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
                                 logger.fdebug('[FILECHECKER] Annual detected - proceeding cautiously.')
+                            nspace_seriesname = re.sub('2021annual', '', nspace_seriesname).strip()
                             nspace_seriesname = re.sub('annual', '', nspace_seriesname).strip()
                             enable_annual = False
                         elif 'special' in nspace_seriesname.lower():

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -115,10 +115,13 @@ def search_init(
     if mode == 'want_ann':
         logger.info('Annual/Special issue search detected. Appending to issue #')
         # anything for mode other than None indicates an annual.
-        if all(['annual' not in ComicName.lower(), 'special' not in ComicName.lower()]):
-            ComicName = '%s Annual' % ComicName
+        #if all(['annual' not in ComicName.lower(), 'special' not in ComicName.lower()]):
+        #    ComicName = '%s Annual' % ComicName
+        if '2021 annual' in ComicName.lower():
+            AlternateSearch= '%s Annual' % re.sub('2021 annual', '', ComicName, flags=re.I).strip()
+            logger.info('Setting alternate search to %s because people are gonna people.' % AlternateSearch)
 
-        if all(
+        elif all(
             [
                 AlternateSearch is not None,
                 AlternateSearch != "None",
@@ -2715,6 +2718,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                                 'IssueArcID': None,
                                 'mode': 'want',
                                 'DateAdded': iss['DateAdded'],
+                                'ComicName': iss['ComicName'],
                             }
                         )
                 elif stloop == 2:
@@ -2746,6 +2750,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                                     'IssueArcID': iss['IssueArcID'],
                                     'mode': 'story_arc',
                                     'DateAdded': iss['DateAdded'],
+                                    'ComicName': iss['ComicName'],
                                 }
                             )
                             cnt += 1
@@ -2777,6 +2782,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                                 'IssueArcID': None,
                                 'mode': 'want_ann',
                                 'DateAdded': iss['DateAdded'],
+                                'ComicName': iss['ReleaseComicName'],
                             }
                         )
                 stloop -= 1
@@ -2853,10 +2859,14 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
 
                     foundNZB = "none"
                     AllowPacks = False
+                    if result['mode'] == 'want_ann' or 'annual' in result['ComicName']:
+                        comicname = result['ComicName']
+                    else:
+                        comicname = comic['ComicName']
                     if all(
                         [result['mode'] == 'story_arc', storyarc_watchlist is False]
                     ):
-                        Comicname_filesafe = helpers.filesafe(comic['ComicName'])
+                        Comicname_filesafe = helpers.filesafe(comicname)
                         SeriesYear = comic['SeriesYear']
                         Publisher = comic['Publisher']
                         AlternateSearch = None
@@ -2915,7 +2925,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                                 '%s #%s did not have a DateAdded recorded, setting it'
                                 ' : %s'
                                 % (
-                                    comic['ComicName'],
+                                    comicname,
                                     result['Issue_Number'],
                                     DateAdded,
                                 )
@@ -2936,7 +2946,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                         )
                         mylar.SEARCH_QUEUE.put(
                             {
-                                'comicname': comic['ComicName'],
+                                'comicname': comicname,
                                 'seriesyear': SeriesYear,
                                 'issuenumber': result['Issue_Number'],
                                 'issueid': result['IssueID'],
@@ -2948,7 +2958,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
 
                     mode = result['mode']
                     foundNZB, prov = search_init(
-                        comic['ComicName'],
+                        comicname,
                         result['Issue_Number'],
                         str(ComicYear),
                         SeriesYear,
@@ -3000,7 +3010,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                         'err': str(err),
                         'err_text': err_text,
                         'traceback': tracebackline,
-                        'comicname': comic['ComicName'],
+                        'comicname': comicname,
                         'issuenumber': result['Issue_Number'],
                         'seriesyear': SeriesYear,
                         'issueid': result['IssueID'],
@@ -3096,7 +3106,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                         'SELECT * FROM comics where ComicID=?', [ComicID]
                     ).fetchone()
                     if mode == 'want_ann':
-                        ComicName = result['ComicName']
+                        ComicName = result['ReleaseComicName']
                         Comicname_filesafe = None
                         AlternateSearch = None
                     else:


### PR DESCRIPTION
- FIX: ``2021 Annual`` would not post-process, search, or match during file rechecks
- IMP: auto-add normalised annual naming as an AlternateSearch when searching for a ``2021 Annual``