### PR TITLE
FIX: series.json creation would error when adding new series

### DIFF
--- a/mylar/series_metadata.py
+++ b/mylar/series_metadata.py
@@ -111,6 +111,7 @@ class metadata_Series(object):
                         else:
                             cdes_removed = comic['Description']
                             logger.warn('Series does not have a description. Not populating, but you might need to do a Refresh Series to fix this')
+                        cdes_formatted = comic['Description']
                 else:
                     if comic['DescriptionEdit'] is not None:
                         cdes_removed = re.sub(r'\n', ' ', comic['DescriptionEdit']).strip()


### PR DESCRIPTION
note that the series would still be added just fine - since the series.json creation happens at the end of the process.