### PR TITLE
IMP: allow multiple_dest_dirs option to work with subdirectory strutures

### DIFF
--- a/data/interfaces/default/comicdetails.html
+++ b/data/interfaces/default/comicdetails.html
@@ -193,9 +193,14 @@
                                         arc_img = None
                                         arc_tip = None
                                         archive_path = None
-                                        if mylar.CONFIG.MULTIPLE_DEST_DIRS is not None and mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None':
+                                        if all([mylar.CONFIG.MULTIPLE_DEST_DIRS is not None, mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None']):
                                             try:
-                                                archive_path = os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comic['ComicLocation']))
+                                                if os.path.exists(os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comic['ComicLocation']))):
+                                                    secondary_folders = os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comic['ComicLocation']))
+                                                else:
+                                                    ff = mylar.filers.FileHandlers(ComicID=comic['ComicID'])
+                                                    secondary_folders = ff.secondary_folders(comic['ComicLocation'])
+                                                archive_path = secondary_folders
                                             except Exception:
                                                 archive_path = 'None'
 

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -813,11 +813,20 @@ class Api(object):
             comiclocation = comic.get('ComicLocation')
             f = os.path.join(comiclocation, issuelocation)
             if not os.path.isfile(f):
-                if mylar.CONFIG.MULTIPLE_DEST_DIRS is not None and mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None':
-                    pathdir = os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comiclocation))
-                    f = os.path.join(pathdir, issuelocation)
-                    self.file = f
-                    self.filename = issuelocation
+                try:
+                    if all([mylar.CONFIG.MULTIPLE_DEST_DIRS is not None, mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None']):
+                        if os.path.exists(os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comiclocation))):
+                            secondary_folders = os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comiclocation))
+                        else:
+                            ff = mylar.filers.FileHandlers(ComicID=issue['ComicID'])
+                            secondary_folders = ff.secondary_folders(comiclocation)
+
+                        f = os.path.join(secondary_folders, issuelocation)
+                        self.file = f
+                        self.filename = issuelocation
+
+                except Exception:
+                    pass
             else:
                 self.file = f
                 self.filename = issuelocation

--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -47,8 +47,8 @@ class FileHandlers(object):
             self.issue = None
             self.issueid = None
 
-    def folder_create(self, booktype=None, update_loc=None):
-        # dictionary needs to passed called comic with 
+    def folder_create(self, booktype=None, update_loc=None, secondary=None):
+        # dictionary needs to passed called comic with
         #  {'ComicPublisher', 'CorrectedType, 'Type', 'ComicYear', 'ComicName', 'ComicVersion'}
         # or pass in comicid value from __init__
 
@@ -209,7 +209,12 @@ class FileHandlers(object):
                     'path_convert': path_convert,
                     'comicid':      comicid}
         else:
-            ddir = pathlib.PurePath(mylar.CONFIG.DESTINATION_DIR)
+            if secondary is not None:
+                ppath = secondary
+            else:
+                ppath = mylar.CONFIG.DESTINATION_DIR
+
+            ddir = pathlib.PurePath(ppath)
             i = 0
             bb = []
             while i < len(ddir.parts):
@@ -237,6 +242,7 @@ class FileHandlers(object):
                 first = first.replace(' ', mylar.CONFIG.REPLACE_CHAR)
             logger.fdebug('first-2: %s' % first)
             comlocation = str(p_path.joinpath(first))
+            com_parentdir = str(p_path.joinpath(first).parent)
             logger.fdebug('comlocation: %s' % comlocation)
 
             #try:
@@ -262,7 +268,8 @@ class FileHandlers(object):
                 return
 
             return {'comlocation': comlocation,
-                    'subpath':     bb_tuple}
+                    'subpath':     bb_tuple,
+                    'com_parentdir': com_parentdir}
 
     def rename_file(self, ofilename, issue=None, annualize=None, arc=False, file_format=None): #comicname, issue, comicyear=None, issueid=None)
             comicid = self.comicid   # it's coming in unicoded...
@@ -677,3 +684,18 @@ class FileHandlers(object):
 
             return rename_this
 
+    def secondary_folders(self, comiclocation, secondary=None):
+        if not secondary:
+            secondary = mylar.CONFIG.MULTIPLE_DEST_DIRS
+
+        secondary_main = self.folder_create(secondary=secondary)
+        secondaryfolders = secondary_main['comlocation']
+
+        if not os.path.exists(secondaryfolders):
+            tmpbase = os.path.basename(comiclocation)
+            tmpath = os.path.join(secondary_main['com_parentdir'], tmpbase)
+
+            if os.path.exists(tmpath):
+                secondaryfolders = tmpath
+
+        return secondaryfolders

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -35,7 +35,6 @@ import gzip
 import os, errno
 import urllib
 from io import StringIO
-from pathlib import Path
 from apscheduler.triggers.interval import IntervalTrigger
 
 import mylar
@@ -2610,10 +2609,16 @@ def updatearc_locs(storyarcid, issues):
                 pathsrc = os.path.join(chk['ComicLocation'], chk['Location'])
                 if not os.path.exists(pathsrc):
                     try:
-                        if all([mylar.CONFIG.MULTIPLE_DEST_DIRS is not None, mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None', os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(chk['ComicLocation'])) != chk['ComicLocation'], os.path.exists(os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(chk['ComicLocation'])))]):
-                            pathsrc = os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(chk['ComicLocation']), chk['Location'])
+                        if all([mylar.CONFIG.MULTIPLE_DEST_DIRS is not None, mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None']):
+                            if os.path.exists(os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(chk['ComicLocation']))):
+                                secondary_folders = os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(chk['ComicLocation']))
+                            else:
+                                ff = mylar.filers.FileHandlers(ComicID=chk['ComicID'])
+                                secondary_folders = ff.secondary_folders(chk['ComicLocation'])
+
+                            pathsrc = os.path.join(secondary_folders, chk['Location'])
                         else:
-                            logger.fdebug(module + ' file does not exist in location: ' + pathdir + '. Cannot valid location - some options will not be available for this item.')
+                            logger.fdebug(module + ' file does not exist in location: ' + pathsrc + '. Cannot validate location - some options will not be available for this item.')
                             continue
                     except:
                         continue

--- a/mylar/readinglist.py
+++ b/mylar/readinglist.py
@@ -59,10 +59,15 @@ class Readinglist(object):
             logger.info(self.module + ' Issue not located on your current watchlist. I should probably check story-arcs but I do not have that capability just yet.')
         else:
             locpath = None
-            if mylar.CONFIG.MULTIPLE_DEST_DIRS is not None and mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None' and os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comicinfo['ComicLocation'])) != comicinfo['ComicLocation']:
-                pathdir = os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comicinfo['ComicLocation']))
-                if os.path.exists(os.path.join(pathdir, readlist['Location'])):
-                    locpath = os.path.join(pathdir, readlist['Location'])
+            if all([mylar.CONFIG.MULTIPLE_DEST_DIRS is not None, mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None']):
+                if os.path.exists(os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comicinfo['ComicLocation']))):
+                    secondary_folders = os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comicinfo['ComicLocation']))
+                else:
+                    ff = mylar.filers.FileHandlers(ComicID=readlist['ComicID'])
+                    secondary_folders = ff.secondary_folders(comicinfo['ComicLocation'])
+
+                if os.path.exists(os.path.join(secondary_folders, readlist['Location'])):
+                    locpath = os.path.join(secondary_folders, readlist['Location'])
                 else:
                     if os.path.exists(os.path.join(comicinfo['ComicLocation'], readlist['Location'])):
                         locpath = os.path.join(comicinfo['ComicLocation'], readlist['Location'])

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -1025,19 +1025,24 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
         #logger.fdebug(module + 'comiccnt is:' + str(comiccnt))
         fca.append(tmpval)
         try:
-            if all([mylar.CONFIG.MULTIPLE_DEST_DIRS is not None, mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None', os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(rescan['ComicLocation'])) != rescan['ComicLocation'], os.path.exists(os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(rescan['ComicLocation'])))]):
+            if all([mylar.CONFIG.MULTIPLE_DEST_DIRS is not None, mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None']):
+                if os.path.exists(os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(rescan['ComicLocation']))):
+                    secondary_folders = os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(rescan['ComicLocation']))
+                else:
+                    ff = mylar.filers.FileHandlers(ComicID=ComicID)
+                    secondary_folders = ff.secondary_folders(rescan['ComicLocation'])
+
                 logger.fdebug(module + 'multiple_dest_dirs:' + mylar.CONFIG.MULTIPLE_DEST_DIRS)
                 logger.fdebug(module + 'dir: ' + rescan['ComicLocation'])
                 logger.fdebug(module + 'os.path.basename: ' + os.path.basename(rescan['ComicLocation']))
-                pathdir = os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(rescan['ComicLocation']))
-                logger.info(module + ' Now checking files for ' + rescan['ComicName'] + ' (' + str(rescan['ComicYear']) + ') in :' + pathdir)
-                mvals = filechecker.FileChecker(dir=pathdir, watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=altnames)
+                logger.info(module + ' Now checking files for ' + rescan['ComicName'] + ' (' + str(rescan['ComicYear']) + ') in :' + secondary_folders)
+                mvals = filechecker.FileChecker(dir=secondary_folders, watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=altnames)
                 tmpv = mvals.listFiles()
-                #tmpv = filechecker.listFiles(dir=pathdir, watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=altnames)
+                #tmpv = filechecker.listFiles(dir=secondary_dir, watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=altnames)
                 logger.fdebug(module + 'tmpv filecount: ' + str(tmpv['comiccount']))
                 comiccnt += int(tmpv['comiccount'])
                 fca.append(tmpv)
-        except:
+        except Exception:
             pass
     else:
 #        files_arc = filechecker.listFiles(dir=archive, watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=rescan['AlternateSearch'])


### PR DESCRIPTION
if the ``multiple_dest_dirs`` option was being used, and the ``destination_location`` was within a subdirectory off of the main directory (ie. it was in a ``$publisher/series`` type of format) the multiple_dest_dirs option would fail to pick it up properly

This PR addresses that problem, in addition to building it out so that it will now accept for series locations under the multiple_dest_dirs folder:
- series folders as titled exactly under the destination location
- series folders if matching to the current folder format (even if the destination location folders are titled differently)