### PR TITLE
FIX: (#846) memory leak, FIX: removal of invalid ComicID's on startup, FIX: Updater invalid field patch

### DIFF
--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -1429,7 +1429,7 @@ def dbcheck():
 #        c.execute('ALTER TABLE importresults ADD COLUMN MetaData TEXT')
 
     #let's delete errant comics that are stranded (ie. Comicname = Comic ID: )
-    c.execute("DELETE from comics WHERE ComicName='None' OR ComicName LIKE 'Comic ID%' OR ComicName is NULL")
+    c.execute("DELETE from comics WHERE ComicName='None' OR ComicName LIKE 'Comic ID%' OR ComicName is NULL OR ComicName like '%Fetch%failed%'")
     c.execute("DELETE from issues WHERE ComicName='None' OR ComicName LIKE 'Comic ID%' OR ComicName is NULL")
     c.execute("DELETE from issues WHERE ComicID is NULL")
     c.execute("DELETE from annuals WHERE ComicName='None' OR ComicName is NULL or Issue_Number is NULL")

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -1905,7 +1905,7 @@ def watchlist_updater(calledfrom=None, sched=False):
         return
 
 
-    logger.fdebug('update_list: %s' % (update_list,))
+    #logger.fdebug('update_list: %s' % (update_list,))
 
     if update_list['count'] == 0:
         logger.info('[BACKFILL-UPDATE] Nothing new has been posted to any series in your watchlist')
@@ -1951,11 +1951,16 @@ def watchlist_updater(calledfrom=None, sched=False):
         elif not row['LastUpdated'] and all(['ComicID' not in row['ComicName'], row['Status'] != 'Loading', row['ComicName'] is not None]):
             prev_failed_updates.append(int(row['ComicID']))
         else:
-            tm = datetime.datetime.strptime(row['LastUpdated'], '%Y-%m-%d %H:%M:%S')
-            library[int(row['ComicID'])] = {'comicid':        row['ComicID'],
-                                            'status':         row['Status'],
-                                            'lastupdated':    calendar.timegm(tm.utctimetuple()),
-                                            'total':          row['Total']}
+            try:
+                tm = datetime.datetime.strptime(row['LastUpdated'], '%Y-%m-%d %H:%M:%S')
+            except Exception:
+                # if the lastupdated date is NULL, but the other values filled in partially - this will make sure to get the ID so it can be refeshed properly
+                prev_failed_updates.append(int(row['ComicID']))
+            else:
+                library[int(row['ComicID'])] = {'comicid':        row['ComicID'],
+                                                'status':         row['Status'],
+                                                'lastupdated':    calendar.timegm(tm.utctimetuple()),
+                                                'total':          row['Total']}
         try:
             if row['ReleaseComicID'] is not None and all(['ComicID' not in row['ComicName'], row['Status'] != 'Loading', row['ComicName'] is not None]):
                 library[row['ReleaseComicID']] = {'comicid':     row['ComicID'],


### PR DESCRIPTION
- FIX: (#846) memory leak on Manage Issues page
- FIX: on startup, make sure to remove problem IDs from comics table
- FIX: Updater would fail if ``LastUpdated`` field was not present