### PR TITLE
IMP: Imprint as an Folder Format field, IMP: GN/HC added to available booktypes, FIX: stale date check was invalid

### DIFF
--- a/data/interfaces/default/comicdetails.html
+++ b/data/interfaces/default/comicdetails.html
@@ -123,7 +123,7 @@
                                 </div>
                                 <div>
                                    <label><big>Publisher: </big><norm>${comic['ComicPublisher']}</norm></label>
-                                   %if comic['PublisherImprint']:
+                                   %if all([comic['PublisherImprint'] is not None, comic['PublisherImprint'] != 'None']):
                                        </br><label><big>Imprint: </big><norm>${comic['PublisherImprint']}</norm></label>
                                    %endif
 	            		</div>
@@ -138,9 +138,18 @@
                                               comictype = comic['Corrected_Type']
                                           else:
                                               comictype = comic['Type']
+
+                                      if comictype == 'HC':
+                                          display_type = 'Hardcover'
+                                      elif comictype == 'GN':
+                                          display_type = 'Graphic Novel'
+                                      elif comictype == 'TPB':
+                                          display_type = 'Trade PaperBack'
+                                      else:
+                                          display_type = comictype
                                 %>
                                 <div>
-                                    <label><big>Edition: </big><norm>${comictype}</norm>
+                                    <label><big>Edition: </big><norm>${display_type}</norm>
                                     <% 
                                         if comicConfig['issue_list'] is not None:
                                             cnt = 0
@@ -329,7 +338,7 @@
                                                 <label>Force-Type (original:${comic['Type']})</label>
                                                 <select name="force_type">
                                                 <%
-                                                    ftt_list = ['Select', 'TPB', 'Digital', 'One-Shot', 'Print']
+                                                    ftt_list = ['Select', 'TPB', 'HC', 'GN', 'Digital', 'One-Shot', 'Print']
                                                 %>
                                                 %for ftt in ftt_list:
                                                         <%
@@ -356,7 +365,7 @@
                                                 <a href="#" title="Will forcibly mark this series as selected in those instances where it assumes it's a ${comic['Type']}-based series"><img src="images/info32.png" height="16" alt="" /></a>
                                 </div>
                                 <div class="row checkbox right clearfix">
-                                   %if comic['Type'] != 'TPB':
+                                   %if all([comic['Type'] != 'TPB', comic['Type'] != 'HC', comic['Type'] != 'GN']):
                                        <label>Accept all booktype search matches</label>
                                        <input type="checkbox" style="vertical-align: bottom; margin: 3px; margin-top: -3px;" name="ignore_type" value="1" ${comicConfig['ignore_type']} />
                                        <a href="#" title="Will not restrict search matches to just being a matching Edition type (ie. One-Shots/Digitals will match against normal Issues."><img src="images/info32.png" height="16" alt="" /></a>
@@ -392,6 +401,11 @@
                                        <input type="text" name="alt_filename" value="${comic['AlternateFileName']}" size="90">
                                        <a href="#" title="Alternate File Naming"><img src="images/info32.png" height="16" alt="" /></a>
                                        <small>Alternate file-naming to be used when post-processing / renaming files instead of the actual title.</small>
+                                   </div>
+
+                                   <div class="row">
+                                       <label>Publication Imprint</label>
+                                       <input type="text" name="publisher_imprint" value="${comic['PublisherImprint']}" size="90">
                                    </div>
 
                                    <div class="row">

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -1325,7 +1325,7 @@
                                      <label>Folder Format</label>
                                      <input type="text" name="folder_format" value="${config['folder_format']}" size="43">
                                      <%
-                                          folder_options = "$Series = SeriesName\n$Year = SeriesYear\n$VolumeY = V{SeriesYear}\n$VolumeN = V{Volume#}\n$Type = BookType (TPB/GN)"
+                                          folder_options = "$Series = SeriesName\n$Year = SeriesYear\n$VolumeY = V{SeriesYear}\n$VolumeN = V{Volume#}\n$Publisher = Publisher\n$Imprint = Publisher Imprint\n$Type = BookType (TPB/GN/HC/One-Shot/Digital)"
                                      %>
                                      <a href="#" title="${folder_options}"><img src="images/info32.png" height="16" alt="" /></a>
                                      <small>Use: $Publisher, $Series, $Year<br />
@@ -1339,7 +1339,7 @@
                                     <label> File Format</label>
                                     <input type="text" name="file_format" value="${config['file_format']}" size="43">
                                     <%
-                                         file_options = "$Series = SeriesName\n$Year = IssueYear\n$Annual = Annual (word)\n$Issue = IssueNumber\n$VolumeY = V{SeriesYear}\n$VolumeN = V{Volume#}\n$month = publication month number\n$monthname = publication month name\n$Type = BookType (TPB)"
+                                         file_options = "$Series = SeriesName\n$Year = IssueYear\n$Annual = Annual (word)\n$Issue = IssueNumber\n$VolumeY = V{SeriesYear}\n$VolumeN = V{Volume#}\n$month = publication month number\n$monthname = publication month name\n$Type = BookType (TPB/GN/HC/One-Shot/Digital)"
                                     %>
                                     <a href="#" title="${file_options}"><img src="images/info32.png" height="16" alt="" /></a>
                                     <small>Use:  $Series, $Year, $Issue<br />

--- a/data/interfaces/default/searchresults.html
+++ b/data/interfaces/default/searchresults.html
@@ -38,7 +38,7 @@
                 <tr>
                 <td style="float:left;margin-right:10px;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;;background:#61924f;"></span> Print</td></tr>
                 <tr>
-                <td style="float:left;margin-right:10px;"><span class="gradeZ" style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;"></span> Digital/TPB/GN</td></tr>
+                <td style="float:left;margin-right:10px;"><span class="gradeZ" style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;"></span> Digital/TPB/GN/HC</td></tr>
             </table>
         </div>
 
@@ -72,6 +72,9 @@
                                                 grade = 'Z'
                                             elif result['type'] == 'TPB':
                                                 rtype = '[TPB]'
+                                                grade = 'Z'
+                                            elif result['type'] == 'GN':
+                                                rtype = '[GN]'
                                                 grade = 'Z'
                                             elif result['type'] == 'HC':
                                                 rtype = '[HC]'

--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -710,7 +710,7 @@ class PostProcessor(object):
                             continue
                         else:
                             try:
-                                if all([cs['WatchValues']['Type'] == 'TPB', cs['WatchValues']['Total'] > 1]) or all([cs['WatchValues']['Type'] == 'One-Shot', cs['WatchValues']['Total'] == 1]):
+                                if (any([cs['WatchValues']['Type'] == 'TPB', cs['WatchValues']['Type'] == 'HC', cs['WatchValues']['Type'] == 'GN']) and cs['WatchValues']['Total'] > 1) or all([cs['WatchValues']['Type'] == 'One-Shot', cs['WatchValues']['Total'] == 1]):
                                     if watchmatch['series_volume'] is not None:
                                         just_the_digits = re.sub('[^0-9]', '', watchmatch['series_volume']).strip()
                                     else:
@@ -727,13 +727,13 @@ class PostProcessor(object):
                                 temploc = re.sub('[\#\']', '', temploc)
                                 #logger.fdebug('temploc: %s' % temploc)
                             else:
-                                if any([cs['WatchValues']['Type'] == 'TPB', cs['WatchValues']['Type'] == 'One-Shot']):
+                                if any([cs['WatchValues']['Type'] == 'TPB', cs['WatchValues']['Type'] == 'GN', cs['WatchValues']['Type'] == 'HC', cs['WatchValues']['Type'] == 'One-Shot']):
                                    temploc = '1'
                                 else:
                                    temploc = None
                             datematch = "False"
 
-                            if temploc is None and all([cs['WatchValues']['Type'] != 'TPB', cs['WatchValues']['Type'] != 'One-Shot']):
+                            if temploc is None and all([cs['WatchValues']['Type'] != 'TPB', cs['WatchValues']['Type'] != 'GN', cs['WatchValues']['Type'] != 'HC', cs['WatchValues']['Type'] != 'One-Shot']):
                                 logger.info('this should have an issue number to match to this particular series: %s' % cs['ComicID'])
                                 continue
 
@@ -901,7 +901,7 @@ class PostProcessor(object):
                                                 alts = x['AS_Alt']
                                         alt_listing = [True if x.lower() == dynamic_seriesname else False for x in alts]
 
-                                        if any([cs['DynamicName'] == dynamic_seriesname, alt_listing]) and all([cs['WatchValues']['Type'] != 'TPB', cs['WatchValues']['Type'] != 'One-Shot']):
+                                        if any([cs['DynamicName'] == dynamic_seriesname, alt_listing]) and all([cs['WatchValues']['Type'] != 'TPB', cs['WatchValues']['Type'] != 'GN', cs['WatchValues']['Type'] != 'HC', cs['WatchValues']['Type'] != 'One-Shot']):
                                             logger.fdebug('name match exact : %s - %s' % (cs['DynamicName'], dynamic_seriesname))
                                             test = myDB.selectone('SELECT Comic, DynamicName, Issue, weeknumber, year FROM weekly WHERE ComicID = ? ORDER BY year DESC, CAST(weeknumber AS INTEGER) DESC', [cs['ComicID']]).fetchone()
                                             if test:
@@ -951,7 +951,7 @@ class PostProcessor(object):
                                     else:
                                         logger.fdebug('not a match')
 
-                                    if all([second_check is False, cs['WatchValues']['Type'] != 'TPB', cs['WatchValues']['Type'] != 'One-Shot']):
+                                    if all([second_check is False, cs['WatchValues']['Type'] != 'TPB', cs['WatchValues']['Type'] != 'GN', cs['WatchValues']['Type'] != 'HC', cs['WatchValues']['Type'] != 'One-Shot']):
                                         logger.fdebug('%s %s in filename don\'t match up to what\'s in the dB for %s [%s]. This is a wrong match. Continuing...' % (watchmatch['series_name'], watchmatch['justthedigits'], cs['ComicName'], cs['ComicID']))
                                         continue
 
@@ -1162,7 +1162,7 @@ class PostProcessor(object):
                                     nm+=1
                                 else:
                                     try:
-                                        if all([v[i]['WatchValues']['Type'] == 'TPB', v[i]['WatchValues']['Total'] > 1]) or all([v[i]['WatchValues']['Type'] == 'One-Shot', v[i]['WatchValues']['Total'] == 1]):
+                                        if (any([v[i]['WatchValues']['Type'] == 'TPB', v[i]['WatchValues']['Type'] == 'GN', v[i]['WatchValues']['Type'] == 'HC']) and v[i]['WatchValues']['Total'] > 1) or all([v[i]['WatchValues']['Type'] == 'One-Shot', v[i]['WatchValues']['Total'] == 1]):
                                             if watchmatch['series_volume'] is not None:
                                                 just_the_digits = re.sub('[^0-9]', '', arcmatch['series_volume']).strip()
                                             else:
@@ -1179,7 +1179,7 @@ class PostProcessor(object):
                                         temploc = re.sub('[\#\']', '', temploc)
                                         #logger.fdebug('temploc: %s' % temploc)
                                     else:
-                                        if any([v[i]['WatchValues']['Type'] == 'TPB', v[i]['WatchValues']['Type'] == 'One-Shot']):
+                                        if any([v[i]['WatchValues']['Type'] == 'TPB', v[i]['WatchValues']['Type'] == 'GN', v[i]['WatchValues']['Type'] == 'HC', v[i]['WatchValues']['Type'] == 'One-Shot']):
                                             temploc = '1'
                                         else:
                                             temploc = None

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -274,7 +274,8 @@ def initialize(config_file):
             update_imprints = True
             if os.path.exists(pub_path):
                 filetime = max(os.path.getctime(pub_path), os.path.getmtime(pub_path))
-                if ((time.time() > filetime) / 3600 > 24):
+                pub_diff = ((time.time() - filetime) / 3600)
+                if pub_diff > 24:
                     logger.info('[IMPRINT_LOADS] Publisher imprint listing found, but possibly stale ( > 24hrs). Retrieving up-to-date listing')
                 else:
                     update_imprints = False

--- a/mylar/cv.py
+++ b/mylar/cv.py
@@ -492,6 +492,8 @@ def GetComicInfo(comicid, dom, safechk=None, series=False):
                 comic['Type'] = 'Digital'
             elif 'paperback' in comic_deck.lower():
                 comic['Type'] = 'TPB'
+            elif 'graphic novel' in comic_deck.lower():
+                comic['Type'] = 'GN'
             elif 'hardcover' in comic_deck.lower():
                 comic['Type'] = 'HC'
             elif 'oneshot' in re.sub('-', '', comic_deck.lower()).strip():
@@ -504,8 +506,10 @@ def GetComicInfo(comicid, dom, safechk=None, series=False):
             comic['Type'] = 'Print'
         elif 'digital' in comic_desc[:60].lower() and 'digital edition can be found' not in comic_desc.lower():
             comic['Type'] = 'Digital'
-        elif all(['paperback' in comic_desc[:60].lower(), 'paperback can be found' not in comic_desc.lower()]) or 'collects' in comic_desc[:60].lower():
+        elif all(['paperback' in comic_desc[:60].lower(), 'paperback can be found' not in comic_desc.lower()]) or all(['hardcover' not in comic_desc[:60].lower(), 'collects' in comic_desc[:60].lower()]):
             comic['Type'] = 'TPB'
+        elif all(['graphic novel' in comic_desc[:60].lower(), 'graphic novel can be found' not in comic_desc.lower()]):
+            comic['Type'] = 'GN'
         elif 'hardcover' in comic_desc[:60].lower() and 'hardcover can be found' not in comic_desc.lower():
             comic['Type'] = 'HC'
         elif any(['one-shot' in comic_desc[:60].lower(), 'one shot' in comic_desc[:60].lower()]) and any(['can be found' not in comic_desc.lower(), 'following the' not in comic_desc.lower(), 'after the' not in comic_desc.lower()]):
@@ -973,6 +977,8 @@ def GetSeriesYears(dom):
                     tempseries['Type'] = 'Digital'
                 elif 'paperback' in comic_deck.lower():
                     tempseries['Type'] = 'TPB'
+                elif 'graphic novel' in comic_deck.lower():
+                    tempseries['Type'] = 'GN'
                 elif 'hardcover' in comic_deck.lower():
                     tempseries['Type'] = 'HC'
                 elif 'oneshot' in re.sub('-', '', comic_deck.lower()).strip():
@@ -985,8 +991,10 @@ def GetSeriesYears(dom):
                 tempseries['Type'] = 'Print'
             elif 'digital' in comic_desc[:60].lower() and 'digital edition can be found' not in comic_desc.lower():
                 tempseries['Type'] = 'Digital'
-            elif all(['paperback' in comic_desc[:60].lower(), 'paperback can be found' not in comic_desc.lower()]) or 'collects' in comic_desc[:60].lower():
+            elif all(['paperback' in comic_desc[:60].lower(), 'paperback can be found' not in comic_desc.lower()]) or all(['hardcover' not in comic_desc[:60].lower(), 'collects' in comic_desc[:60].lower()]):
                 tempseries['Type'] = 'TPB'
+            elif all(['graphic novel' in comic_desc[:60].lower(), 'graphic novel can be found' not in comic_desc.lower()]):
+                tempseries['Type'] = 'GN'
             elif 'hardcover' in comic_desc[:60].lower() and 'hardcover can be found' not in comic_desc.lower():
                 tempseries['Type'] = 'HC'
             elif any(['one-shot' in comic_desc[:60].lower(), 'one shot' in comic_desc[:60].lower()]) and any(['can be found' not in comic_desc.lower(), 'following the' not in comic_desc.lower()]):
@@ -1169,7 +1177,7 @@ def GetSeriesYears(dom):
             else:
                 break
 
-        if all([int(number_issues) == 1, tempseries['SeriesYear'] < helpers.today()[:4], tempseries['Type'] != 'One-Shot', tempseries['Type'] != 'TPB']):
+        if all([int(number_issues) == 1, tempseries['SeriesYear'] < helpers.today()[:4], tempseries['Type'] != 'One-Shot', tempseries['Type'] != 'TPB', tempseries['Type'] != 'HC', tempseries['Type'] != 'GN']):
             booktype = 'One-Shot'
         else:
             booktype = tempseries['Type']

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -807,6 +807,9 @@ class FileChecker(object):
                             elif any([sf.lower() == 'gn', sf.lower() == 'graphic novel']):
                                 logger.fdebug('GRAPHIC NOVEL DETECTED. NOT DETECTING ISSUE NUMBER - ASSUMING VOLUME')
                                 booktype = 'GN'
+                            elif any([sf.lower() == 'hc', sf.lower() == 'hardcover']):
+                                logger.fdebug('HARDCOVER DETECTED. NOT DETECTING ISSUE NUMBER - ASSUMING VOLUME')
+                                booktype = 'HC'
                             else:
                                 if 'could not convert string to float' not in str(e):
                                     logger.fdebug('[%s] Error detecting issue # - ignoring this result : %s' % (e, sf))
@@ -990,7 +993,7 @@ class FileChecker(object):
                     issue_number_position -=1
 
         if issue_number is None:
-            if any([booktype == 'TPB', booktype == 'GN']):
+            if any([booktype == 'TPB', booktype == 'HC', booktype == 'GN']):
                 logger.fdebug('%s detected. Volume assumption is number: %s' % (booktype, volume_found))
             else:
                 if issue_year is not None and issue_number is None and '2000ad' in ''.join(split_file).lower():
@@ -1004,8 +1007,8 @@ class FileChecker(object):
                     issue_number = issue_year
                     issue_year = None
                 elif len(volume_found) > 0:
-                    logger.fdebug('UNKNOWN TPB/GN detected. Volume assumption is number: %s' % (volume_found))
-                    booktype = 'TPB'
+                    logger.fdebug('Possible UNKNOWN TPB/GN/HC detected. Volume assumption is number: %s' % (volume_found))
+                    booktype = 'TPB/GN/HC'
                 else:
                     logger.fdebug('No issue number present in filename.')
         else:
@@ -1235,7 +1238,8 @@ class FileChecker(object):
         if (any([issue_number is None, series_name is None]) and booktype == 'issue'):
 
             if all([issue_number is None, booktype == 'issue', issue_volume is not None]):
-                logger.fdebug('Possible UNKNOWN TPB/GN detected - no issue number present, no clarification in filename, but volume present with series title')
+                logger.fdebug('Possible UNKNOWN TPB/GN/HC detected - no issue number present, no clarification in filename, but volume present with series title')
+                booktype = 'TPB/GN/HC'
             else:
                 logger.fdebug('Cannot parse the filename properly. I\'m going to make note of this filename so that my evil ruler can make it work.')
 

--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -47,7 +47,7 @@ class FileHandlers(object):
             self.issue = None
             self.issueid = None
 
-    def folder_create(self, booktype=None, update_loc=None, secondary=None):
+    def folder_create(self, booktype=None, update_loc=None, secondary=None, imprint=None):
         # dictionary needs to passed called comic with
         #  {'ComicPublisher', 'CorrectedType, 'Type', 'ComicYear', 'ComicName', 'ComicVersion'}
         # or pass in comicid value from __init__
@@ -116,6 +116,13 @@ class FileHandlers(object):
             chunk_f = re.compile(r'\s+')
             chunk_folder_format = chunk_f.sub(' ', chunk_f_f)
 
+        if any([imprint is None, imprint == 'None']):
+            imprint = self.comic['PublisherImprint']
+        if any([imprint is None, imprint == 'None']):
+            chunk_f_f = re.sub('\$Imprint', '', chunk_folder_format)
+            chunk_f = re.compile(r'\s+')
+            chunk_folder_format = chunk_f.sub(' ', chunk_f_f)
+
         chunk_folder_format = re.sub("[()|[]]", '', chunk_folder_format).strip()
         ccf = chunk_folder_format.find('/ ')
         if ccf != -1:
@@ -127,6 +134,7 @@ class FileHandlers(object):
         #do work to generate folder path
         values = {'$Series':        series,
                   '$Publisher':     publisher,
+                  '$Imprint':       imprint,
                   '$Year':          self.comic['ComicYear'],
                   '$series':        series.lower(),
                   '$publisher':     publisher.lower(),
@@ -173,6 +181,9 @@ class FileHandlers(object):
                                 break
                         if self.comic['ComicPublisher'] is not None:
                             if self.comic['ComicPublisher'] in dp:
+                                break
+                        if self.comic['PublisherImprint'] is not None:
+                            if self.comic['PublisherImprint'] in dp:
                                 break
                         if self.comic['ComicVersion'] is not None:
                             if self.comic['ComicVersion'] in dp:

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -199,7 +199,8 @@ def human2bytes(s):
 
 def replace_all(text, dic):
     for i, j in dic.items():
-        text = text.replace(i, j)
+        if all([j != 'None', j is not None]):
+            text = text.replace(i, j)
     return text.rstrip()
 
 def cleanName(string):
@@ -835,16 +836,26 @@ def updateComicLocation():
                     comversion = 'None'
                 #if comversion is None, remove it so it doesn't populate with 'None'
                 if comversion == 'None':
-                    chunk_f_f = re.sub('\$VolumeN', '', mylar.CONFIG.FOLDER_FORMAT)
+                    chunk_f_f = re.sub('\$VolumeN', '', chunk_folder_format)
+                    chunk_f = re.compile(r'\s+')
+                    chunk_folder = chunk_f.sub(' ', chunk_f_f)
+                else:
+                    chunk_folder = chunk_folder_format
+
+                imprint = dl['PublisherImprint']
+                if any([imprint is None, imprint == 'None']):
+                    chunk_f_f = re.sub('\$Imprint', '', chunk_folder)
                     chunk_f = re.compile(r'\s+')
                     folderformat = chunk_f.sub(' ', chunk_f_f)
                 else:
-                    folderformat = mylar.CONFIG.FOLDER_FORMAT
+                    folderformat = chunk_folder
+
 
                 #do work to generate folder path
 
                 values = {'$Series':        comicname_folder,
                           '$Publisher':     publisher,
+                          '$Imprint':       imprint,
                           '$Year':          year,
                           '$series':        comicname_folder.lower(),
                           '$publisher':     publisher.lower(),
@@ -1467,7 +1478,7 @@ def havetotals(refreshit=None):
 
             comictype = comic['Type']
             try:
-                if (any([comictype == 'None', comictype is None, comictype == 'Print']) and comic['Corrected_Type'] != 'TPB') or all([comic['Corrected_Type'] is not None, comic['Corrected_Type'] == 'Print']):
+                if (any([comictype == 'None', comictype is None, comictype == 'Print']) and all([comic['Corrected_Type'] != 'TPB', comic['Corrected_Type'] != 'GN', comic['Corrected_Type'] != 'HC'])) or all([comic['Corrected_Type'] is not None, comic['Corrected_Type'] == 'Print']):
                     comictype = None
                 else:
                     if comic['Corrected_Type'] is not None:

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -241,8 +241,9 @@ def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=No
 
     if comlocation is None:
 
-        comic_values = {'ComicName':        comic['ComicName'], 
+        comic_values = {'ComicName':        comic['ComicName'],
                         'ComicPublisher':   comic['ComicPublisher'],
+                        'PublisherImprint': comic['PublisherImprint'],
                         'ComicYear':        SeriesYear,
                         'ComicVersion':     comicVol,
                         'Type':             comic['Type'],
@@ -363,7 +364,7 @@ def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=No
     logger.fdebug('comicIssues: %s' % comicIssues)
     logger.fdebug('seriesyear: %s / currentyear: %s' % (SeriesYear, helpers.today()[:4]))
     logger.fdebug('comicType: %s' % comic['Type'])
-    if all([int(comicIssues) == 1, SeriesYear < helpers.today()[:4], comic['Type'] != 'One-Shot', comic['Type'] != 'TPB']):
+    if all([int(comicIssues) == 1, SeriesYear < helpers.today()[:4], comic['Type'] != 'One-Shot', comic['Type'] != 'TPB', comic['Type'] != 'HC', comic['Type'] != 'GN']):
         logger.info('Determined to be a one-shot issue. Forcing Edition to One-Shot')
         booktype = 'One-Shot'
     else:
@@ -1604,7 +1605,7 @@ def annual_check(ComicName, SeriesYear, comicid, issuetype, issuechk, annualslis
         if not sresults:
             return
 
-        annual_types_ignore = {'paperback', 'collecting', 'reprinting', 'reprints', 'collected edition', 'print edition', 'tpb', 'available in print', 'collects'}
+        annual_types_ignore = {'paperback', 'collecting', 'reprinting', 'reprints', 'collected edition', 'print edition', 'hardcover', 'hc', 'tpb', 'gn', 'graphic novel', 'available in print', 'collects'}
 
         if len(sresults) > 0:
             logger.fdebug('[IMPORTER-ANNUAL] - there are ' + str(len(sresults)) + ' results.')

--- a/mylar/mb.py
+++ b/mylar/mb.py
@@ -385,6 +385,8 @@ def findComic(name, mode, issue, limityear=None, search_type=None):
                                         xmltype = 'Digital'
                                     elif 'paperback' in xmldeck.lower():
                                         xmltype = 'TPB'
+                                    elif 'graphic novel' in xmldeck.lower():
+                                        xmltype = 'GN'
                                     elif 'hardcover' in xmldeck.lower():
                                         xmltype = 'HC'
                                     elif 'oneshot' in re.sub('-', '', xmldeck.lower()).strip():
@@ -397,8 +399,10 @@ def findComic(name, mode, issue, limityear=None, search_type=None):
                                     xmltype = 'Print'
                                 elif 'digital' in xmldesc[:60].lower() and 'digital edition can be found' not in xmldesc.lower():
                                     xmltype = 'Digital'
-                                elif all(['paperback' in xmldesc[:60].lower(), 'paperback can be found' not in xmldesc.lower()]) or 'collects' in xmldesc[:60].lower():
+                                elif all(['paperback' in xmldesc[:60].lower(), 'paperback can be found' not in xmldesc.lower()]) or all(['hardcover' not in xmldesc[:60].lower(), 'collects' in xmldesc[:60].lower()]):
                                     xmltype = 'TPB'
+                                elif all(['graphic novel' in xmldesc[:60].lower(), 'graphic novel can be found' not in xmldesc.lower()]):
+                                    xmltype = 'GN'
                                 elif 'hardcover' in xmldesc[:60].lower() and 'hardcover can be found' not in xmldesc.lower():
                                     xmltype = 'HC'
                                 elif any(['one-shot' in xmldesc[:60].lower(), 'one shot' in xmldesc[:60].lower()]) and any(['can be found' not in xmldesc.lower(), 'following the' not in xmldesc.lower()]):

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -348,7 +348,7 @@ def search_init(
                 cmloopit = 1
 
         chktpb = 0
-        if booktype == 'TPB':
+        if any([booktype == 'TPB', booktype =='HC', booktype == 'GN']):
             chktpb = 1
 
         if findit['status'] is True:
@@ -623,7 +623,14 @@ def search_init(
                     if tmp_IssueNumber is not None:
                         issuedisplay = tmp_IssueNumber
                     else:
-                        if any([booktype == 'One-Shot', booktype == 'TPB']):
+                        if any(
+                               [
+                                   booktype == 'One-Shot',
+                                   booktype == 'TPB',
+                                   booktype == 'HC',
+                                   booktype == 'GC'
+                               ]
+                        ):
                             issuedisplay = None
                         else:
                             issuedisplay = StoreDate[5:]
@@ -912,7 +919,7 @@ def NZB_SEARCH(
             mod_isssearch = str(issdig) + str(isssearch)
         else:
             if cmloopit == 4:
-                if booktype == 'TPB':
+                if any([booktype == 'TPB', booktype == 'HC', booktype == 'GN']):
                     comsearch = comsrc + "%20v" + str(isssearch)
                 mod_isssearch = ''
             else:
@@ -1785,7 +1792,7 @@ def NZB_SEARCH(
                     or all(
                         [booktype != parsed_comic['booktype'], ignore_booktype is True]
                     )
-                    or booktype == parsed_comic['booktype']
+                    or booktype in parsed_comic['booktype']
                 ):
                     try:
                         fcomic = filechecker.FileChecker(watchcomic=ComicName)
@@ -2063,32 +2070,50 @@ def NZB_SEARCH(
                         logger.fdebug(
                             "We matched on versions for annuals %s" % fndcomicversion
                         )
-                    elif booktype != 'TPB' and (
-                        int(F_ComicVersion) == int(D_ComicVersion)
-                        or int(F_ComicVersion) == int(S_ComicVersion)
+                    elif all(
+                             [
+                                 booktype != 'TPB',
+                                 booktype != 'HC',
+                                 booktype != 'GN',
+                            ]
+                        ) and (
+                            int(F_ComicVersion) == int(D_ComicVersion)
+                            or int(F_ComicVersion) == int(S_ComicVersion)
                     ):
                         logger.fdebug("We matched on versions...%s" % fndcomicversion)
                     else:
-                        if booktype == 'TPB' and (
-                            int(F_ComicVersion) == int(findcomiciss)
-                            and filecomic['justthedigits'] is None
+                        if any(
+                               [
+                                   booktype == 'TPB',
+                                   booktype == 'HC',
+                                   booktype == 'GN',
+                               ]
+                            ) and (
+                                int(F_ComicVersion) == int(findcomiciss)
+                                and filecomic['justthedigits'] is None
                         ):
                             logger.fdebug(
-                                'TPB detected - reassigning volume %s to match as the'
+                                '%s detected - reassigning volume %s to match as the'
                                 ' issue number based on Volume'
-                                % fndcomicversion
+                                % (booktype, fndcomicversion)
                             )
-                        elif booktype == 'TPB' and all(
+                        elif all(
+                                 [
+                                     booktype == 'TPB',
+                                     booktype == 'HC',
+                                     booktype == 'GN',
+                                 ]
+                            ) and all(
                             [
                                 int(F_ComicVersion) == int(findcomiciss),
                                 fndcomicversion is not None,
-                                filecomic['booktype'] == 'TPB',
+                                booktype in filecomic['booktype'],
                                 filecomic['justthedigits'] is None,
                             ]
                         ):
                             logger.fdebug(
-                                'TPB detected - reassigning volume %s to match as the issue number'
-                                % fndcomicversion
+                                '%s detected - reassigning volume %s to match as the issue number'
+                                % (booktype, fndcomicversion)
                             )
                         else:
                             logger.fdebug("Versions wrong. Ignoring possible match.")
@@ -2279,22 +2304,34 @@ def NZB_SEARCH(
                         if (
                             all([intIss is not None, comintIss is not None])
                             and int(intIss) == int(comintIss)
-                            or all(
+                            or (any(
                                 [
-                                    chktpb != 0,
                                     filecomic['booktype'] == 'TPB',
-                                    pc_in is None,
-                                    helpers.issuedigits(F_ComicVersion) == intIss,
+                                    filecomic['booktype'] == 'GN',
+                                    filecomic['booktype'] == 'HC',
+                                    filecomic['booktype'] == 'TPB/GN/HC',
                                 ]
-                            )
-                            or all(
+                                ) and all(
+                                    [
+                                        chktpb != 0,
+                                        pc_in is None,
+                                        helpers.issuedigits(F_ComicVersion) == intIss,
+                                    ]
+                            ))
+                            or (any(
                                 [
-                                    chktpb == 2,
                                     filecomic['booktype'] == 'TPB',
-                                    pc_in is None,
-                                    cmloopit == 1,
+                                    filecomic['booktype'] == 'GN',
+                                    filecomic['booktype'] == 'HC',
+                                    filecomic['booktype'] == 'TPB/GN/HC',
                                 ]
-                            )
+                                )  and all(
+                                    [
+                                        chktpb == 2,
+                                        pc_in is None,
+                                        cmloopit == 1,
+                                    ]
+                            ))
                             or all([cmloopit == 4, findcomiciss is None, pc_in is None])
                             or all([cmloopit == 4, findcomiciss is None, pc_in == 1])
                         ):
@@ -2504,7 +2541,13 @@ def NZB_SEARCH(
         logger.fdebug(
             'booktype:%s / chktpb: %s / findloop: %s' % (booktype, chktpb, findloop)
         )
-        if booktype == 'TPB' and chktpb == 1 and findloop + 1 > findcount:
+        if any(
+               [
+                   booktype == 'TPB',
+                   booktype == 'GN',
+                   booktype == 'HC',
+                ]
+            ) and chktpb == 1 and findloop + 1 > findcount:
             pass  # findloop=-1
         else:
             findloop += 1

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -998,11 +998,16 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
     else:
         altnames = ''
 
-    if (all([rescan['Type'] != 'Print', rescan['Type'] != 'Digital', rescan['Type'] != 'None', rescan['Type'] is not None]) and rescan['Corrected_Type'] != 'Print') or rescan['Corrected_Type'] == 'TPB':
+    if (all([rescan['Type'] != 'Print', rescan['Type'] != 'Digital', rescan['Type'] != 'None', rescan['Type'] is not None]) and rescan['Corrected_Type'] != 'Print') or any([rescan['Corrected_Type'] == 'TPB', rescan['Corrected_Type'] == 'HC', rescan['Corrected_Type'] == 'GN']):
         if rescan['Type'] == 'One-Shot' and rescan['Corrected_Type'] is None:
             booktype = 'One-Shot'
         else:
-            booktype = 'TPB'
+            if rescan['Type'] == 'GN' and rescan['Corrected_Type'] is None:
+                booktype = 'GN'
+            elif rescan['Type'] == 'HC' and rescan['Corrected_Type'] is None:
+                booktype = 'HC'
+            else:
+                booktype = 'TPB'
     else:
         booktype = None
 
@@ -1066,7 +1071,7 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                 break
 
             try:
-                if all([booktype == 'TPB', iscnt > 1]) or all([booktype == 'One-Shot', iscnt == 1, cla['JusttheDigits'] is None]):
+                if all([booktype == 'TPB', iscnt > 1]) or all([booktype == 'GN', iscnt > 1]) or all([booktype =='HC', iscnt > 1]) or all([booktype == 'One-Shot', iscnt == 1, cla['JusttheDigits'] is None]):
                     if cla['SeriesVolume'] is not None:
                         just_the_digits = re.sub('[^0-9]', '', cla['SeriesVolume']).strip()
                     else:
@@ -1177,7 +1182,7 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
             logger.fdebug('temploc: %s' % temploc)
         else:
             #assume 1 if not given
-            if any([booktype == 'TPB', booktype == 'One-Shot']):
+            if any([booktype == 'TPB', booktype == 'GN', booktype == 'HC', booktype == 'One-Shot']):
                 temploc = '1'
             else:
                 temploc = None
@@ -1212,7 +1217,7 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
 
                 if temploc is not None:
                     fcdigit = helpers.issuedigits(temploc)
-                elif any([booktype == 'TPB', booktype == 'One-Shot']) and temploc is None:
+                elif any([booktype == 'TPB', booktype == 'GN', booktype == 'HC', booktype == 'One-Shot']) and temploc is None:
                     fcdigit = helpers.issuedigits('1')
 
                 if int(fcdigit) == int_iss:


### PR DESCRIPTION
- IMP: Add  to ``$Imprint`` to allowable Folder Format fields
- IMP: Imprint text field added to series detail page for manual editing if needed
- IMP: subset booktype from TPB to TPB/GN/HC
- IMP: when editing the directory in the series detail page for a series, will now check to see if both the parent and parent-of-the-parent directories exist - if not it will create them prior to renaming the existing folder
- FIX: fix publisher_imprints not properly checking file stale date 

publisher_imprints also had an update which changed Marvel Comics to Marvel, and Image Comics to Image - so the file state date check update is necessary to pull the new json.