### PR TITLE
fixes for imageURL being incorrectly referenced/created during series add/refresh

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -1493,12 +1493,18 @@ def havetotals(refreshit=None):
             else:
                 cversion = comic['ComicVersion']
 
+            if comic['ComicImage'] is None:
+                comicImage = 'cache/%s.jpg' % comic['ComicID']
+            else:
+                comicImage = comic['ComicImage']
+
+
             comics.append({"ComicID":         comic['ComicID'],
                            "ComicName":       comic['ComicName'],
                            "ComicSortName":   comic['ComicSortName'],
                            "ComicPublisher":  comic['ComicPublisher'],
                            "ComicYear":       comic['ComicYear'],
-                           "ComicImage":      comic['ComicImage'],
+                           "ComicImage":      comicImage,
                            "LatestIssue":     comic['LatestIssue'],
                            "LatestDate":      comic['LatestDate'],
                            "ComicVolume":     cversion,

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -1754,7 +1754,7 @@ def image_it(comicid, latestissueid, comlocation, ComicImage):
         cloc_it = []
         if (comlocation is not None and all([os.path.isdir(comlocation) is True, os.path.isfile(os.path.join(comlocation, 'cover.jpg')) is False])):
             cloc_it.append(comlocation)
-        elif ([mylar.CONFIG.MULTIPLE_DEST_DIRS is not None, mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None']):
+        elif all([mylar.CONFIG.MULTIPLE_DEST_DIRS is not None, mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None']):
             if all([os.path.isdir(os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comlocation))) is True, os.path.isfile(os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comlocation), 'cover.jpg')) is False]):
                 cloc_it.append(os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comlocation)))
             else:


### PR DESCRIPTION
- FIX: incorrect image references on Manage page if imageURL is None
- FIX: ImageUrl not being generated correctly during add/refresh of series due to invalid if statement