### PR TITLE
FIX: DBUpdater would not run when performing large backlog queue, FIX: Status' not updating in Activity/Jobs tab

### DIFF
--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -2038,7 +2038,7 @@ def watchlist_updater(calledfrom=None, sched=False):
             '%Y-%m-%d %H:%M:%S'), loaddate_stamp)
         )
 
-    helpers.job_management(write=True, job='DB Updater', current_run=helpers.utctimestamp(), status='Waiting')
+    helpers.job_management(write=True, job='DB Updater', last_run_completed=helpers.utctimestamp(), status='Waiting')
     mylar.UPDATER_STATUS = 'Waiting'
 
     # once we trigger it the dates above are updated to backfill dates and we can

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -2900,7 +2900,8 @@ class WebInterface(object):
                     status = mylar.VERSION_STATUS
                     interval = str(mylar.CONFIG.CHECK_GITHUB_INTERVAL) + ' mins'
 
-                if status != jb['Status'] and not('rss' in jb['JobName'].lower()):
+                if all([status != 'Running', status != jb['Status'], not('rss' in jb['JobName'].lower())]):
+                    #logger.fdebug('[%s]: jb[status] %s / status:%s' % (jb['JobName'], jb['Status'], status))
                     status = jb['Status']
 
                 tmp.append({'prev_run_datetime':  prev_run,


### PR DESCRIPTION
- FIX: DBUpdater would not run every ``backfill_timespan`` interval (default 10 minutes) when updating large backlog queue, 
- FIX: Status' not indicated as Running in Activity/Jobs tab