### PR TITLE
FIX: api url appending 'api' incorrectly when testing newznab and searching (in some cases)

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -34,6 +34,7 @@ import hashlib
 import gzip
 import os, errno
 import urllib
+from urllib.parse import urljoin
 from io import StringIO
 from apscheduler.triggers.interval import IntervalTrigger
 
@@ -3778,10 +3779,13 @@ def newznab_test(name, host, ssl, apikey):
               'apikey':  apikey,
               'o':       'xml'}
 
-    if host[:-1] == '/':
-        host = host + 'api'
-    else:
-        host = host + '/api'
+    if not host.endswith('api'):
+        if not host.endswith('/'):
+            host += '/'
+        host = urljoin(host, 'api')
+        logger.fdebug('[TEST-NEWZNAB] Appending `api` to end of host: %s' % host)
+
+
     headers = {'User-Agent': str(mylar.USER_AGENT)}
     logger.info('host: %s' % host)
     try:

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -1048,12 +1048,11 @@ def NZB_SEARCH(
                     )
                 elif nzbprov == 'newznab':
                     # let's make sure the host has a '/' at the end, if not add it.
-                    if host_newznab[len(host_newznab) - 1 : len(host_newznab)] != '/':
-                        host_newznab_fix = str(host_newznab) + "/"
-                    else:
-                        host_newznab_fix = host_newznab
+                    host_newznab_fix = host_newznab
                     if not host_newznab_fix.endswith('api'):
-                        host_newznab_fix += 'api'
+                        if not host_newznab_fix.endswith('/'):
+                            host_newznab_fix += '/'
+                        host_newznab_fix = urljoin(host_newznab_fix, 'api')
                     findurl = '%s?t=search&q=%s&o=xml&cat=%s' % (
                         host_newznab_fix,
                         comsearch,


### PR DESCRIPTION
- FIX: newznab test option would incorrectly append ``api`` endpoint in some situations
- FIX: reworked newznab api url in search to better detect url's with ``api`` endpoint already included