### PR TITLE
IMP: reading order sequence writing out for multiple arcs for an issue, FIX: post-processing failing on individual non-watchlisted arc issues

### DIFF
--- a/lib/comictaggerlib/cli.py
+++ b/lib/comictaggerlib/cli.py
@@ -471,6 +471,12 @@ def process_file_cli(filename, opts, settings, match_results):
                     match_results.fetchDataFailures.append(filename)
                     return
 
+            if all([opts.metadata is not None, cv_md is not None]):
+                try:
+                    if opts.metadata.storyArc.lower() != cv_md.storyArc.lower():
+                        cv_md.storyArc = md.storyArc
+                except Exception as e:
+                    pass
             md.overlay(cv_md)
 
         # ok, done building our metadata. time to save

--- a/mylar/cmtagmylar.py
+++ b/mylar/cmtagmylar.py
@@ -99,7 +99,19 @@ def run(dirName, nzbName=None, issueid=None, comversion=None, manual=None, filen
         cvers = "volume="
 
     if readingorder is not None:
-        rorder = 'storyArcNumber=%s' % readingorder
+        if type(readingorder) == list:
+            orderseq = []
+            arcseq = []
+            for osq in readingorder:
+                orderseq.append(str(osq[1]))
+                arcseq.append(osq[0])
+            arcseqn = ','.join(arcseq).strip()
+            arcseqname = re.sub(r',', '^,', arcseqn).strip()
+            ordersn = ','.join(orderseq).strip()
+            orders = re.sub(r',', '^,', ordersn).strip()
+            rorder = 'storyArcNumber=%s, storyArc=%s' % (orders, arcseqname)
+        else:
+            roder = 'storyArcNumber=%s' % readingorder
     else:
         rorder = 'storyArcNumber='
 

--- a/mylar/versioncheck.py
+++ b/mylar/versioncheck.py
@@ -388,7 +388,7 @@ def versionload():
     else:
         vers = 'NONE'
 
-    mylar.USER_AGENT = 'Mylar3/' +str(hash) +'(' +vers +') +http://www.github.com/mylar3/mylar3/'
+    mylar.USER_AGENT = 'Mylar3/' +str(hash) +'(' +vers +') +https://github.com/mylar3/mylar3/'
 
     logger.info('Version information: %s [%s]' % (mylar.CONFIG.GIT_BRANCH, mylar.CURRENT_VERSION))
 

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -2900,8 +2900,7 @@ class WebInterface(object):
                     status = mylar.VERSION_STATUS
                     interval = str(mylar.CONFIG.CHECK_GITHUB_INTERVAL) + ' mins'
 
-                if all([status != 'Running', status != jb['Status'], not('rss' in jb['JobName'].lower())]):
-                    #logger.fdebug('[%s]: jb[status] %s / status:%s' % (jb['JobName'], jb['Status'], status))
+                if status != jb['Status'] and not('rss' in jb['JobName'].lower()):
                     status = jb['Status']
 
                 tmp.append({'prev_run_datetime':  prev_run,
@@ -6322,18 +6321,14 @@ class WebInterface(object):
                 vol_label = comversion
 
             if all([issueid is not None, comicid is not None]):
-                from mylar import db
                 myDB = db.DBConnection()
-                roders = myDB.select('SELECT count(*) as count, ComicName, IssueNumber, StoryArcID, ReadingOrder from storyarcs WHERE ComicID=? AND IssueID=?', [comicid, issueid])
+                roders = myDB.select('SELECT ComicName, IssueNumber, StoryArcID, ReadingOrder from storyarcs WHERE ComicID=? AND IssueID=?', [comicid, issueid])
                 readingorder = None
                 if roders is not None:
+                    readingorder = []
                     for rd in roders:
-                        if int(rd['count']) == 1:
-                            readingorder = rd['ReadingOrder']
-                            logger.fdebug('reading order found: # %s' % readingorder)
-                        else:
-                            logger.fdebug('Multiple storyarcs returned. An issue can only be part of one storyarc atm')
-                            break
+                        readingorder.append((rd['StoryArc'], rd['ReadingOrder']))
+                    logger.fdebug('readingorder: %s' % (readingorder))
 
             metaresponse = cmtagmylar.run(dirName, issueid=issueid, filename=filename, comversion=vol_label, manualmeta=True, readingorder=readingorder, agerating=agerating)
         except ImportError:


### PR DESCRIPTION
- IMP: allow metatagging to write out reading order sequence when dealing with multiple arcs
- FIX: downloading non-watchlisted arc issues would fail to be detected if files were not within a folder (ie. a single file)
- FIX: corrected user-agent url
- FIX: RSS scheduled job was always in a running status, even if it was not