### PR TITLE
IMP: search-4-missing option added (back), IMP: watchlisted series not being distinguished if in a Skipped status on weeklypull, FIX: CSS fixes

### DIFF
--- a/data/interfaces/carbon/css/data_table.css
+++ b/data/interfaces/carbon/css/data_table.css
@@ -296,11 +296,19 @@ table.display tr.even.gradeC {
 }
 
 table.display tr.even.gradeE {
-	background-color: #F96178;
+	background-color: #444b54;
 }
 
 table.display tr.odd.gradeE {
-	background-color: #F96178;
+	background-color: #444b54;
+}
+
+table.display tr.even.gradeG {
+        background-color: #0A0A0A;
+}
+
+table.display tr.odd.gradeG {
+        background-color: #0A0A0A;
 }
 
 table.display tr.even.gradeH {
@@ -309,6 +317,14 @@ table.display tr.even.gradeH {
 
 table.display tr.odd.gradeH {
         background-color: #ae3431;
+}
+
+table.display tr.odd.gradeI {
+        background-color: #216f70;
+}
+
+table.display tr.even.gradeI {
+        background-color: #216f70;
 }
 
 table.display tr.even.gradeL {
@@ -357,6 +373,7 @@ table.display tr.odd.gradeZ {
 table.display tr.even.gradeZ {
 	-background-color: #2e3338;
 }
+
 table.display tr.odd.gradeT {
         background-color: #bd915a;
 }
@@ -394,7 +411,9 @@ table.display tr.gradeA td,
 table.display tr.gradeB td,
 table.display tr.gradeC td,
 table.display tr.gradeE td,
+table.display tr.gradeG td,
 table.display tr.gradeH td,
+table.display tr.gradeI td,
 table.display tr.gradeL td,
 table.display tr.gradeX td,
 table.display tr.gradeU td,
@@ -439,11 +458,19 @@ table.display_no_select tr.even.gradeC {
 }
 
 table.display_no_select tr.even.gradeE {
-        background-color: #F96178;
+        background-color: #444b54;
 }
 
 table.display_no_select tr.odd.gradeE {
-        background-color: #F96178;
+        background-color: #444b54;
+}
+
+table.display_no_select tr.even.gradeG{
+        background-color: #0A0A0A;
+}
+
+table.display_no_select tr.odd.gradeG {
+        background-color: #0A0A0A;
 }
 
 table.display_no_select tr.even.gradeH{
@@ -454,12 +481,12 @@ table.display_no_select tr.odd.gradeH {
         background-color: #ae3431;
 }
 
-table.display_no_select tr.even.gradeL {
-        background-color: #ebf5ff;
+table.display_no_select tr.even.gradeI {
+        background-color: #216f70;
 }
 
-table.display_no_select tr.odd.gradeL {
-        background-color: #ebf5ff;
+table.display_no_select tr.odd.gradeI {
+        background-color: #216f70;
 }
 
 table.display_no_select tr.odd.gradeX {
@@ -542,7 +569,9 @@ table.display_no_select tr.gradeL #status {
 table.display_no_select tr.gradeA td,
 table.display_no_select tr.gradeC td,
 table.display_no_select tr.gradeE td,
+table.display_no_select tr.gradeG td,
 table.display_no_select tr.gradeH td,
+table.display_no_select tr.gradeI td,
 table.display_no_select tr.gradeL td,
 table.display_no_select tr.gradeX td,
 table.display_no_select tr.gradeU td,

--- a/data/interfaces/default/comicdetails.html
+++ b/data/interfaces/default/comicdetails.html
@@ -25,6 +25,7 @@
                             <a id="menu_link_refresh" onclick="doAjaxCall('manualRename?comicid=${comic['ComicID']}', $(this),'table')" data-success="Renaming files.">Rename Files</a>
                         %endif
                             <a id="menu_link_refresh" onclick="doAjaxCall('forceRescan?ComicID=${comic['ComicID']}', $(this), 'table');"  data-success="${comic['ComicName']} is being rescanned">Recheck Files</a>
+                            <a id="menu_link_searchmissing" onclick="doAjaxCall('searchformissing?ComicID=${comic['ComicID']}', $(this), 'table');" href="#" data-success="Now queueing missing items for ${comic['ComicName']}" title="Search for all issues that are in either a Skipped or Wanted status">Search-4-Missing</a>
                         %if mylar.CONFIG.ENABLE_META:
                             <a id="menu_link_refresh" onclick="doAjaxCall('group_metatag?ComicID=${comic['ComicID']}&dirName=${comic['ComicLocation'] |u}', $(this),'table');refreshLoadSeries();" data-success="(re)tagging every issue present for '${comic['ComicName']}'">Manual MetaTagging</a>
                         %endif

--- a/data/interfaces/default/css/data_table.css
+++ b/data/interfaces/default/css/data_table.css
@@ -280,19 +280,35 @@ table.display tr.even.gradeC {
 }
 
 table.display tr.even.gradeE {
-	background-color: #F96178;
+	background-color: #444b54;
 }
 
 table.display tr.odd.gradeE {
-	background-color: #F96178;
+	background-color: #444b54;
 }
 
 table.display tr.even.gradeH {
         background-color: #FFF5CC;
 }
 
+table.display tr.even.gradeG {
+        background-color: #0A0A0A;
+}
+
+table.display tr.odd.gradeG {
+        background-color: #0A0A0A;
+}
+
 table.display tr.odd.gradeH {
         background-color: #FFF5CC;
+}
+
+table.display tr.odd.gradeI {
+        background-color: #216f70;
+}
+
+table.display tr.even.gradeI {
+        background-color: #216f70;
 }
 
 table.display tr.even.gradeL {
@@ -341,6 +357,7 @@ table.display tr.odd.gradeZ {
 table.display tr.even.gradeZ {
 	background-color: white;
 }
+
 table.display tr.odd.gradeT {
         background-color: #F9CBE6;
 }
@@ -378,7 +395,9 @@ table.display tr.gradeL #status {
 table.display tr.gradeA td,
 table.display tr.gradeC td,
 table.display tr.gradeE td,
+table.display tr.gradeG td,
 table.display tr.gradeH td,
+table.display tr.gradeI td,
 table.display tr.gradeL td,
 table.display tr.gradeX td,
 table.display tr.gradeU td,
@@ -415,11 +434,19 @@ table.display_no_select tr.even.gradeC {
 }
 
 table.display_no_select tr.even.gradeE {
-        background-color: #F96178;
+        background-color: #444b548;
 }
 
 table.display_no_select tr.odd.gradeE {
-        background-color: #F96178;
+        background-color: #444b54;
+}
+
+table.display_no_select tr.even.gradeG{
+        background-color: #0A0A0A;
+}
+
+table.display_no_select tr.odd.gradeG {
+        background-color: #0A0A0A;
 }
 
 table.display_no_select tr.even.gradeH{
@@ -428,6 +455,14 @@ table.display_no_select tr.even.gradeH{
 
 table.display_no_select tr.odd.gradeH {
         background-color: #FFF5CC;
+}
+
+table.display_no_select tr.even.gradeI {
+        background-color: #216f70;
+}
+
+table.display_no_select tr.odd.gradeI {
+        background-color: #216f70;
 }
 
 table.display_no_select tr.even.gradeL {
@@ -518,7 +553,9 @@ table.display_no_select tr.gradeL #status {
 table.display_no_select tr.gradeA td,
 table.display_no_select tr.gradeC td,
 table.display_no_select tr.gradeE td,
+table.display_no_select tr.gradeG td,
 table.display_no_select tr.gradeH td,
+table.display_no_select tr.gradeI td,
 table.display_no_select tr.gradeL td,
 table.display_no_select tr.gradeX td,
 table.display_no_select tr.gradeU td,

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -38,6 +38,9 @@
         function initThisPage() {
             initActions();
             $('#series_table').dataTable( {
+                "preDrawCallback": function (settings){
+                    pageScrollPos = $('#series_table div.datatables_scrollBody').scrollTop();
+                },
                 "sDom": '<"clear"f><"clear"lp><"clear">rt<"clear"ip>',
                 "processing": true,
                 "serverSide": true,
@@ -50,7 +53,7 @@
                        "render":function (data,type,full) {
                            if (full[0]){
                                if (full[0].length > 20){
-                                   cb = '<span title="' + full[0] + '"></span>'+full[0].slice(0,20)+"...";
+                                   cb = '<span title="' + full[0] + '"></span>'+full[0].slice(0,17)+'...';
                                } else {
                                    cb = '<span title="' + full[0] + '"></span>'+full[0];
                                }
@@ -76,8 +79,8 @@
                             } else {
                                 bt = '';
                             }
-                            if (full[0]){
-                               if (full[0].length > 55){
+                            if (full[1]){
+                               if (full[1].length > 55){
                                  cn = full[1].slice(0,55)+"...";
                                } else {
                                  cn = full[1];
@@ -93,7 +96,16 @@
                        "targets": [ 3 ],
                        "visible": true,
                        "render":function (data,type,full) {
-                            return '# ' + full[3];
+                            if (full[3]){
+                               if (full[3].length == 5){
+                                 cn = full[3];
+                               } else if (full[3].length > 5){
+                                 cn = '<span title="#'+full[3]+'">#</span>';
+                               } else {
+                                 cn = '#' + full[3];
+                               }
+                               return cn;
+                            }
                        }
                     },
                     {
@@ -175,7 +187,7 @@
                  },
                  "drawCallback": function (o) {
                      // Jump to top of page
-                     $('html,body').scrollTop(0);
+                     $('#series_table div.dataTables_scrollBody').scrollTop(pageScrollPos);
                  },
                  "serverData": function ( sSource, aoData, fnCallback ) {
                             /* Add some extra data to the sender */
@@ -191,9 +203,6 @@
         $(document).ready(function(){
             initThisPage();
         });
-	$(window).load(function(){
-	    initFancybox();
-	});
 	</script>
 	
 </%def>

--- a/data/interfaces/default/weeklypull.html
+++ b/data/interfaces/default/weeklypull.html
@@ -56,7 +56,7 @@
            <table width="100%" align="center">
              <tr>
               <td style="vertical-align: middle; text-align: right">
-                  <a href="pullist?week=${weekinfo['prev_weeknumber']}&year=${weekinfo['prev_year']}&current=${weekinfo['weeknumber']}-${weekinfo['year']}" title="Previous Week (${weekinfo['prev_weeknumber']})" onclick="$('#pull_table').page('first').draw('page');">
+                  <a href="pullist?week=${weekinfo['prev_weeknumber']}&year=${weekinfo['prev_year']}&current=${weekinfo['weeknumber']}-${weekinfo['year']}" title="Previous Week (${weekinfo['prev_weeknumber']})" onclick="arrows_page();">
                       <img src="${icons['prev']}" width="16" height="18" Alt="Previous"/>
                   </a>
               </td>
@@ -68,7 +68,7 @@
               %endif
               </td>
               <td style="vertical-align: middle; text-align: left">
-                    <a href="pullist?week=${weekinfo['next_weeknumber']}&year=${weekinfo['next_year']}&current=${weekinfo['weeknumber']}-${weekinfo['year']}" title="Next Week (${weekinfo['next_weeknumber']})" onclick="$('#pull_table').page('first').draw('page');">
+                    <a href="pullist?week=${weekinfo['next_weeknumber']}&year=${weekinfo['next_year']}&current=${weekinfo['weeknumber']}-${weekinfo['year']}" title="Next Week (${weekinfo['next_weeknumber']})" onclick="arrows_page();">
                       <img src="${icons['next']}" width="16" height="18" Alt="Next"/>
                   </a>
               </td>
@@ -125,7 +125,7 @@
                                         grade = 'T'
 
                                 #if the comicid is present, but issue isn't marked as wanted.
-                                if weekly['HAVEIT'] == 'Yes' and weekly['STATUS'] == 'Skipped':
+                                if any([weekly['HAVEIT'] == 'Yes', weekly['HAVEIT'] == weekly['COMICID']]) and weekly['STATUS'] == 'Skipped':
                                         grade = 'E'
                                                                
 			%>
@@ -194,12 +194,20 @@
                                             %endif
                                         %elif any([weekly['STATUS'] == 'Skipped', weekly['STATUS'] == 'Wanted']):
                                             %if weekly['STATUS'] == 'Skipped':
-                                                %if weekly['COMICID'] != '' and weekly['COMICID'] is not None:
-                                                    <a href="#" title="auto-add to Watchlist directly by ID available for this series" onclick="doAjaxCall('addbyid?comicid=${weekly['COMICID']}&calledby=True',$(this),'table')" data-success="${weekly['COMIC']} is now being added to your wachlist.">
+                                                %if all([weekly['COMICID'] != '', weekly['COMICID'] is not None]) and all([weekly['HAVEIT'] != 'Yes', weekly['HAVEIT'] != weekly['COMICID']]):
+                                                    <a href="#" title="auto-add to Watchlist directly by ID available for this series" onclick="doAjaxCall('addbyid?comicid=${weekly['COMICID']}&calledby=True&ogcname=${weekly['COMIC']| u}',$(this),'table');return true;">
                                                     %if mylar.CONFIG.SHOW_ICONS:
                                                         <img style="margin: 0px 5px" src="images/add.png" height="25" width="25" class="highqual" />
                                                     %else:
                                                         <span class="ui-icon ui-icon-plus"></span>Add
+                                                    %endif
+                                                    </a>
+                                                %elif weekly['COMICID'] == weekly['HAVEIT'] or weekly['HAVEIT'] == 'Yes':
+                                                    <a href="#" title="mark this issue as Wanted" onclick="doAjaxCall('queueIssue?IssueID=${weekly['ISSUEID']}&ComicID=${weekly['COMICID']}&ComicIssue=${weekly['ISSUE']}&mode=want',$(this),'table')" data-success="${weekly['COMIC']} #${weekly['ISSUE']} has now been marked as Wanted.">
+                                                    %if mylar.CONFIG.SHOW_ICONS:
+                                                        <img style="margin: 0px 5px" src="images/add.png" height="25" width="25" class="highqual" />
+                                                    %else:
+                                                        <span class="ui-icon ui-icon-plus"></span>Mark
                                                     %endif
                                                     </a>
                                                 %else:
@@ -289,10 +297,11 @@
         <div style="z-index:10;position:relative;float:right;margin-top:10px;">
             <table style="border-spacing:3px;border-collapse:separate;">
               <tr>
-                <td style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:#641716;"></span> monitored series</td>
-                <td style="margin-left:5px;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:#ae3431;"></span> auto-want</td>
-                <td style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:#382f64;"></span> mismatched</td>
-                <td style="margin-left:5px;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:#bd915a;"></span> one-off</td>
+                <td style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:#641716;" title="Series is monitored & issue is Wanted"></span> monitored series</td>
+                <td style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:#444b54;" title="Series is Monitored & issue is Skipped"></span> monitored series</td>
+                <td style="margin-left:5px;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:#ae3431;" title="Will auo-add series to watchlist when available"></span> auto-want</td>
+                <td style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:#382f64;" title="Incorrectly matched series"></span> mismatched</td>
+                <td style="margin-left:5px;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:#bd915a;" title="Downloaded issue is not on your watchlist"></span> one-off</td>
               </tr>
             </table>
        </div>
@@ -399,6 +408,11 @@
                         }
             });
         };
+
+        function arrows_page() {
+            var tables = $('table.display').DataTable();
+            tables.page('first').draw('page');
+        }
 
         function run_them() {
             var pubs = document.getElementsByName("publishers[]");


### PR DESCRIPTION
- IMP: ``search-4-missing`` option added to series detail page
- FIX: catch invalid name when deleting series via Delete Series
- IMP: ``+mark`` option added for watchlisted series that have issues in a Skipped status on weeklypull
- IMP: series issues in Skipped status on the weeklypull colour-graded now
- FIX: correct some invalid css
- FIX: adjust column layouts for better fit on index page