### PR TITLE
IMP: Opposite Tier added to Wanted page, FIX: Post-processing of annuals not belonging to series

### DIFF
--- a/data/interfaces/default/upcoming.html
+++ b/data/interfaces/default/upcoming.html
@@ -44,6 +44,7 @@
                                 <option value="Downloaded">Downloaded</option>
                                 <option value="Archived">Archived</option>
                                 <option value="Ignored">Ignored</option>
+                                <option value="OppositeTier">Opposite Tier</option>
                 </select>
                 <input type="hidden" value="Go">
           </div>

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -1393,10 +1393,15 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                                         multiplechk = True
                                         break
                                     if (ma['IssueYear'] in tmpfc['ComicFilename']) and (issyear == ma['IssueYear']):
-                                        logger.fdebug(module + ' Matched to year within filename : ' + str(issyear))
-                                        multiplechk = False
-                                        ANNComicID = ack['ReleaseComicID']
-                                        break
+                                        # make sure that the IssueYear discovered is not preceded by a volume so it matches correctly
+                                        vchk = tmpfc['ComicFilename'].find(ma['IssueYear'])
+                                        if tmpfc['ComicFilename'][vchk-1].lower() == 'v':
+                                            multiplechk = True
+                                        else:
+                                            logger.fdebug(module + ' Matched to year within filename : ' + str(issyear))
+                                            multiplechk = False
+                                            ANNComicID = ack['ReleaseComicID']
+                                            break
                                     else:
                                         logger.fdebug(module + ' Did not match to year within filename : ' + str(issyear))
                                         multiplechk = True


### PR DESCRIPTION
- IMP: ``Opposite Tier`` option via dropdown on Wanted page (change Tier of selected items)
- FIX: Post-processing of annuals that don't belong to a series (with annual integration enabled)
- FIX: Better handling of provider notification errors during post-processing
- FIX: If an ongoing title didn't exist on a previous week's pull (due to no valid pull info), would reject for post-processing
- FIX: Annual checking for series would take V as the issue year (if VXXXX present) resulting in mismatched annuals for a series with multiple annual volumes