### PR TITLE
FIX: multiple fixes for story-arc post-processing, IMP: clear status option in story arc details, FIX: history page

### DIFF
--- a/data/interfaces/carbon/css/style.css
+++ b/data/interfaces/carbon/css/style.css
@@ -1069,15 +1069,15 @@ div#artistheader h2 a {
   vertical-align: middle;
 }
 #arc_detail th#options {
-  min-width: 130px;
-  text-align: left;
+  max-width: 200px;
+  text-align: center;
 }
 #arc_detail th#comicname {
-  min-width: 290px;
+  min-width: 280px;
   text-align: left;
 }
 #arc_detail th#issue {
-  max-width: 15px;
+  max-width: 25px;
   text-align: center;
 }
 #arc_detail th#status {
@@ -1089,19 +1089,19 @@ div#artistheader h2 a {
   text-align: center;
 }
 #arc_detail th#readingorder {
-  max-width: 10px;
-  text-align: left;
+  max-width: 15px;
+  text-align: right;
   vertical-align: middle;
 }
 #arc_detail td#comicname {
-  min-width: 290px;
+  min-width: 280px;
   text-align: left;
   vertical-align: middle;
   font-size: 12px;
 }
 #arc_detail td#issue {
-  max-width: 15px;
-  text-align: left;
+  max-width: 25px;
+  text-align: right;
   vertical-align: middle;
 }
 #arc_detail td#status {
@@ -1115,13 +1115,13 @@ div#artistheader h2 a {
   vertical-align: middle;
 }
 #arc_detail td#options {
-  min-width: 130px;
+  max-width: 200px;
   text-align: left;
   vertical-align: middle;
 }
 #arc_detail td#readingorder {
-  max-width: 10px;
-  text-align: left;
+  max-width: 15px;
+  text-align: right;
   vertical-align: middle;
 }
 #weekly_pull th#publisher {

--- a/data/interfaces/default/history.html
+++ b/data/interfaces/default/history.html
@@ -61,6 +61,45 @@
 	<script src="js/libs/jquery.dataTables.min.js"></script>
         <script src="js/libs/full_numbers_no_ellipses.js"></script>
         <script>
+        $(document).ready(function() {
+            // get the click value from the last column (options) where the filelisting option is present.
+            $('table.display').on('click', 'a', function() {
+                var action = this.id;
+                if (!action){
+                    return;
+                }
+                var dataline = $('#history_table').DataTable().row(this.closest('tr')).data();
+                if (action == 'retry'){
+                    retryit(dataline[1], dataline[5], dataline[4], dataline[2], 'history');
+                }
+            });
+        });
+
+        function retryit(comicname, comicid, issueid, issuenumber, redirect){
+            $.ajax({
+                 type: "GET",
+                 url: "retryissue",
+                 data: { ComicName: comicname, ComicID: comicid, IssueID: issueid , IssueNumber: issuenumber, redirect: redirect },
+                 success: function(response) {
+                    //console.log(response);
+                    obj = JSON.parse(response);
+                    $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>"+obj['message']+"</div>");
+                    if (obj['status'] == 'success'){
+                        $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                    } else {
+                        $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                    }
+                 },
+                 error: function(data)
+                     {
+                       alert('ERROR'+data.responseText);
+                     },
+            });
+            var tables = $('table.display').DataTable();
+            tables.ajax.reload(null,false);
+        }
+
+
         $.fn.DataTable.ext.pager.numbers_length = 3;
 	function initThisPage() {
 	    $('#history_table').dataTable({
@@ -91,7 +130,22 @@
                        "targets": [ 2 ],
                        "visible": true,
                        "render":function (data,type,full) {
-                           return '<a href="comicDetails?ComicID=' + full[5] + '">' + full[1] + '</a>';
+                           //console.log(full);
+                           if ( full[4].includes('_') || full[8] !== null ){
+                               vals = full[4].split('_');
+                               if (full[4].includes('_') && full[7] !== null){
+                                   // exists only in storyarcs
+                                   dline = '<a href="detailStoryArc?StoryArcID=' + vals[0] + '">' + full[1] + ' <b>[' + full[7] + ']</b></a>';
+                               } else if (full[8] !== null){
+                                   // exists in both watchlist & storyarcs
+                                   dline = '<a href="comicDetails?ComicID=' + full[5] + '">' + full[1] + '</a> <b>[<a href="detailStoryArc?StoryArcID=' + full[9] + '">' + full[7] + ']</b></a>';
+                               } else {
+                                   dline = '<a href="detailStoryArc?StoryArcID=' + full[5] + '">' + full[1] + '</a>';
+                               }
+                           } else {
+                               dline = '<a href="comicDetails?ComicID=' + full[5] + '">' + full[1] + '</a>';
+                           }
+                           return dline;
                        }
                     },
                     {
@@ -118,8 +172,7 @@
                        "targets": [ 5 ],
                        "visible": true,
                        "render":function (data,type,full) {
-                           aline = "'retryit?ComicName=" + full[1] + "&ComicID=" + full[5] + "&IssueID=" + full[4] + "&IssueNumber=" + full[2] + "&redirect=history, $(this), 'table')"; 
-                           return '[<a href="#" onclick="doAjaxCall(' + aline + '" data-success="re-download submitted.">retry</a>]';
+                           return '[<a id="retry" name="retry" title="Retry search for issue" href="#">retry</a>]';
                        }
                     },
                 ],

--- a/data/interfaces/default/storyarc_detail.html
+++ b/data/interfaces/default/storyarc_detail.html
@@ -215,10 +215,10 @@
                      <a href="#" onclick="doAjaxCall('queueit?ComicName=${item['ComicName'] | u}&ComicIssue=${item['IssueNumber']}&ComicYear=${issuedate}&mode=readlist&SARC=${item['StoryArc']}&IssueArcID=${item['IssueArcID']}&SeriesYear=${item['SeriesYear']}',$(this),'table')" data-success="Now searching for ${item['ComicName']} #${item['IssueNumber']}"><span class="ui-icon ui-icon-plus"></span>Grab</a>
                  %elif item['Status'] == 'Snatched':
                      <a href="#" onclick="doAjaxCall('queueit?ComicName=${item['ComicName'] | u}&ComicIssue=${item['IssueNumber']}&ComicYear=${issuedate}&mode=readlist&SARC=${item['StoryArc']}&IssueArcID=${item['IssueArcID']}&SeriesYear=${item['SeriesYear']}',$(this),'table')" data-success="Trying to search again for issue"><span class="ui-icon ui-icon-plus"></span>Retry</a>
-                     <a href="#" onclick="doAjaxCall('clear_arcstatus?issuearcid=${item['IssueArcID']}',$(this),'table')"><data success="Clearing status of ${item['Status']} for ${item['ComicName']} #${item['IssueNumber']}"><span class="ui-icon ui-icon-plus"></span>Clear Status</a>
                  %elif item['Status'] == 'Downloaded' and item['Location'] is not None:
                      <a href="downloadthis?pathfile=${item['Location'] |u}"><span class="ui-icon ui-icon-plus"></span>Download</a>
                  %endif
+                 <a href="#" onclick="doAjaxCall('clear_arcstatus?issuearcid=${item['IssueArcID']}',$(this),'table')"><data success="Clearing status of ${item['Status']} for ${item['ComicName']} #${item['IssueNumber']}"><span class="ui-icon ui-icon-plus"></span>Clear Status</a>
                  <a href="#" title="Remove Issue from Story Arc" onclick="doAjaxCall('removefromreadlist?IssueArcID=${item['IssueArcID']}&manual=${item['Manual']}',$(this),'table')" data-success='Successfully deleted ${item['IssueArcID']}'><span class="ui-icon ui-icon-minus"></span>Remove</a>
                 </td>
          </tr>

--- a/data/interfaces/default/storyarc_detail.poster.html
+++ b/data/interfaces/default/storyarc_detail.poster.html
@@ -214,10 +214,10 @@
                      <a href="#" onclick="doAjaxCall('queueit?ComicName=${item['ComicName'] | u}&ComicIssue=${item['IssueNumber']}&ComicYear=${issuedate}&mode=readlist&SARC=${item['StoryArc']}&IssueArcID=${item['IssueArcID']}&SeriesYear=${item['SeriesYear']}',$(this),'table')" data-success="Now searching for ${item['ComicName']} #${item['IssueNumber']}"><span class="ui-icon ui-icon-plus"></span>Grab</a>
                  %elif item['Status'] == 'Snatched':
                      <a href="#" onclick="doAjaxCall('queueit?ComicName=${item['ComicName'] | u}&ComicIssue=${item['IssueNumber']}&ComicYear=${issuedate}&mode=readlist&SARC=${item['StoryArc']}&IssueArcID=${item['IssueArcID']}&SeriesYear=${item['SeriesYear']}',$(this),'table')" data-success="Trying to search again for issue"><span class="ui-icon ui-icon-plus"></span>Retry</a>
-                     <a href="#" onclick="doAjaxCall('clear_arcstatus?issuearcid=${item['IssueArcID']}',$(this),'table')"><data success="Clearing status of ${item['Status']} for ${item['ComicName']} #${item['IssueNumber']}"><span class="ui-icon ui-icon-plus"></span>Clear Status</a>
                  %elif item['Status'] == 'Downloaded' and item['Location'] is not None:
                      <a href="downloadthis?pathfile=${item['Location'] |u}"><span class="ui-icon ui-icon-plus"></span>Download</a>
                  %endif
+                 <a href="#" onclick="doAjaxCall('clear_arcstatus?issuearcid=${item['IssueArcID']}',$(this),'table')"><data success="Clearing status of ${item['Status']} for ${item['ComicName']} #${item['IssueNumber']}"><span class="ui-icon ui-icon-plus"></span>Clear Status</a>
                  <a href="#" title="Remove Issue from Story Arc" onclick="doAjaxCall('removefromreadlist?IssueArcID=${item['IssueArcID']}&manual=${item['Manual']}',$(this),'table')" data-success='Successfully deleted ${item['IssueArcID']}'><span class="ui-icon ui-icon-minus"></span>Remove</a>
                 </td>
          </tr>

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -2650,6 +2650,15 @@ def NZB_SEARCH(
                     alt_nzbname=alt_nzbname,
                     oneoff=oneoff,
                 )
+                updater.foundsearch(
+                    ComicID,
+                    IssueID,
+                    mode=mode,
+                    provider=tmpprov,
+                    SARC=SARC,
+                    IssueArcID=IssueArcID
+                )
+
             # send out the notifications for the snatch.
             if any([oneoff is True, IssueID is None]):
                 cyear = ComicYear
@@ -3124,7 +3133,7 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                     ComicVersion = result['Volume']
                     SARC = result['StoryArc']
                     IssueArcID = issueid
-                    actissueid = None
+                    actissueid = result['IssueID'] #None
                     IssueDate = result['IssueDate']
                     StoreDate = result['ReleaseDate']
                     DigitalDate = result['DigitalDate']
@@ -3365,7 +3374,7 @@ def searchIssueIDList(issuelist):
                     'comicname': comicname,
                     'seriesyear': seriesyear,
                     'issuenumber': issuenumber,
-                    'issueid': issue['IssueID'],
+                    'issueid': issue['IssueID'], #issueid,
                     'comicid': issue['ComicID'],
                     'booktype': booktype,
                 }

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -854,7 +854,7 @@ def foundsearch(ComicID, IssueID, mode=None, down=None, provider=None, SARC=None
         if mode == 'story_arc':
             IssueNum = issue['IssueNumber']
             newsnatchValues = {"ComicName":       ComicName,
-                               "ComicID":         'None',
+                               "ComicID":         ComicID, #'None',
                                "Issue_Number":    IssueNum,
                                "DateAdded":       helpers.now(),
                                "Status":          "Snatched",


### PR DESCRIPTION
- FIX: Post-processing of story-arc issues that were not on the watchlist, and was a single file download, would incorrectly join the file path resulting in an invalid path.
- FIX: Post-processing of story-arc issues that belonged to multiple storyarcs will now be flung into multiple arc directories (if applicable)
- FIX: Post-processing of story-arc issues would not update status (history table) when completed 
- FIX: ``Clear Status`` button was not available in story-arc detail page to clear existing status of an issue to Skipped
- FIX: better spacing of some table elements in story arc detail page
- FIX: history page retry button would not work
- IMP: story arcs will now be shown (and clickable) if applicable to the given item the history page