### PR TITLE
Reference correct variable when post-processing story arcs

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -1177,7 +1177,7 @@ class PostProcessor(object):
                                 else:
                                     try:
                                         if (any([v[i]['WatchValues']['Type'] == 'TPB', v[i]['WatchValues']['Type'] == 'GN', v[i]['WatchValues']['Type'] == 'HC']) and v[i]['WatchValues']['Total'] > 1) or all([v[i]['WatchValues']['Type'] == 'One-Shot', v[i]['WatchValues']['Total'] == 1]):
-                                            if watchmatch['series_volume'] is not None:
+                                            if arcmatch['series_volume'] is not None:
                                                 just_the_digits = re.sub('[^0-9]', '', arcmatch['series_volume']).strip()
                                             else:
                                                 just_the_digits = re.sub('[^0-9.]', '', arcmatch['justthedigits']).strip()


### PR DESCRIPTION
I noticed the following post-processing error logs for StoryArc grabs

```
29-Sep-2021 16:01:08 - WARNING :: mylar.Process.1185 : Thread-174 : [Exception: local variable 'watchmatch' referenced before assignment] Unable to properly match up/retrieve issue number (or volume) for this [CS: {'StoryArc': 'The Killing Joke', 'StoryArcID': '40503', 'IssueArcID': '40503_8984', 'ComicName': 'Batman: The Killing Joke', 'DynamicComicName': 'batmankillingjoke', 'ComicPublisher': 'DC Comics', 'Publisher': 'DC Comics', 'IssueID': '119383', 'IssueNumber': '1', 'IssueYear': None, 'ReadingOrder': 1, 'IssueDate': '1988-06-30', 'Status': 'Snatched', 'Location': None}] [WATCHMATCH: {'SeriesYear': '1988', 'LatestDate': '1988-06-30', 'ComicVersion': None, 'ComicID': '19967', 'Publisher': 'DC Comics', 'Total': 4, 'Type': 'GN', 'IsArc': True}]
29-Sep-2021 16:01:08 - DEBUG   :: mylar.parseit.838 : SEARCH-QUEUE : datecheck: []
29-Sep-2021 16:01:08 - WARNING :: mylar.Process.1185 : Thread-174 : [Exception: local variable 'watchmatch' referenced before assignment] Unable to properly match up/retrieve issue number (or volume) for this [CS: {'StoryArc': 'The Killing Joke', 'StoryArcID': '40503', 'IssueArcID': '40503_8984', 'ComicName': 'Batman: The Killing Joke', 'DynamicComicName': 'batmankillingjoke', 'ComicPublisher': 'DC Comics', 'Publisher': 'DC Comics', 'IssueID': '119383', 'IssueNumber': '1', 'IssueYear': None, 'ReadingOrder': 1, 'IssueDate': '1988-06-30', 'Status': 'Snatched', 'Location': None}] [WATCHMATCH: {'SeriesYear': '1988', 'LatestDate': '1988-06-30', 'ComicVersion': None, 'ComicID': '19967', 'Publisher': 'DC Comics', 'Total': 4, 'Type': 'GN', 'IsArc': True}]
29-Sep-2021 16:01:08 - DEBUG   :: mylar.parseit.889 : SEARCH-QUEUE : No year present within title - ignoring as a variable.
29-Sep-2021 16:01:08 - WARNING :: mylar.Process.1185 : Thread-174 : [Exception: local variable 'watchmatch' referenced before assignment] Unable to properly match up/retrieve issue number (or volume) for this [CS: {'StoryArc': 'The Killing Joke', 'StoryArcID': '40503', 'IssueArcID': '40503_8984', 'ComicName': 'Batman: The Killing Joke', 'DynamicComicName': 'batmankillingjoke', 'ComicPublisher': 'DC Comics', 'Publisher': 'DC Comics', 'IssueID': '119383', 'IssueNumber': '1', 'IssueYear': None, 'ReadingOrder': 1, 'IssueDate': '1988-06-30', 'Status': 'Snatched', 'Location': None}] [WATCHMATCH: {'SeriesYear': '1988', 'LatestDate': '1988-06-30', 'ComicVersion': None, 'ComicID': '19967', 'Publisher': 'DC Comics', 'Total': 4, 'Type': 'GN', 'IsArc': True}]
29-Sep-2021 16:01:08 - DEBUG   :: mylar.parseit.892 : SEARCH-QUEUE : highest_series_position: 8
29-Sep-2021 16:01:08 - WARNING :: mylar.Process.1185 : Thread-174 : [Exception: local variable 'watchmatch' referenced before assignment] Unable to properly match up/retrieve issue number (or volume) for this [CS: {'StoryArc': 'The Killing Joke', 'StoryArcID': '40503', 'IssueArcID': '40503_8984', 'ComicName': 'Batman: The Killing Joke', 'DynamicComicName': 'batmankillingjoke', 'ComicPublisher': 'DC Comics', 'Publisher': 'DC Comics', 'IssueID': '119383', 'IssueNumber': '1', 'IssueYear': None, 'ReadingOrder': 1, 'IssueDate': '1988-06-30', 'Status': 'Snatched', 'Location': None}] [WATCHMATCH: {'SeriesYear': '1988', 'LatestDate': '1988-06-30', 'ComicVersion': None, 'ComicID': '19967', 'Publisher': 'DC Comics', 'Total': 4, 'Type': 'GN', 'IsArc': True}]
29-Sep-2021 16:01:08 - DEBUG   :: mylar.parseit.990 : SEARCH-QUEUE : issue_position: 8
29-Sep-2021 16:01:08 - WARNING :: mylar.Process.1185 : Thread-174 : [Exception: local variable 'watchmatch' referenced before assignment] Unable to properly match up/retrieve issue number (or volume) for this [CS: {'StoryArc': 'The Killing Joke', 'StoryArcID': '40503', 'IssueArcID': '40503_8984', 'ComicName': 'Batman: The Killing Joke', 'DynamicComicName': 'batmankillingjoke', 'ComicPublisher': 'DC Comics', 'Publisher': 'DC Comics', 'IssueID': '119383', 'IssueNumber': '1', 'IssueYear': None, 'ReadingOrder': 1, 'IssueDate': '1988-06-30', 'Status': 'Snatched', 'Location': None}] [WATCHMATCH: {'SeriesYear': '1988', 'LatestDate': '1988-06-30', 'ComicVersion': None, 'ComicID': '19967', 'Publisher': 'DC Comics', 'Total': 4, 'Type': 'GN', 'IsArc': True}]
29-Sep-2021 16:01:08 - DEBUG   :: mylar.parseit.1016 : SEARCH-QUEUE : No issue number present in filename.
29-Sep-2021 16:01:08 - WARNING :: mylar.Process.1185 : Thread-174 : [Exception: local variable 'watchmatch' referenced before assignment] Unable to properly match up/retrieve issue number (or volume) for this [CS: {'StoryArc': 'The Killing Joke', 'StoryArcID': '40503', 'IssueArcID': '40503_8984', 'ComicName': 'Batman: The Killing Joke', 'DynamicComicName': 'batmankillingjoke', 'ComicPublisher': 'DC Comics', 'Publisher': 'DC Comics', 'IssueID': '119383', 'IssueNumber': '1', 'IssueYear': None, 'ReadingOrder': 1, 'IssueDate': '1988-06-30', 'Status': 'Snatched', 'Location': None}] [WATCHMATCH: {'SeriesYear': '1988', 'LatestDate': '1988-06-30', 'ComicVersion': None, 'ComicID': '19967', 'Publisher': 'DC Comics', 'Total': 4, 'Type': 'GN', 'IsArc': True}]
29-Sep-2021 16:01:08 - DEBUG   :: mylar.parseit.1153 : SEARCH-QUEUE : sf_highest_series_pos: ['batman', 'the', 'killing', 'joke', 'deluxe', 'edition', 'marsh07', 'rar']
```

I'm not very familiar with the codebase, but from looking at the code a little, it looks like maybe there's just a copy/paste error where [this line](https://github.com/mylar3/mylar3/blob/master/mylar/PostProcessor.py#L1178) should be referencing `arcmatch` but it was copied from other code that references `watchmatch` and the reference simply wasn't updated.