### PR TITLE
FIX: better handling of pull-list data when WS is offline/unavailable.

### DIFF
--- a/mylar/locg.py
+++ b/mylar/locg.py
@@ -55,12 +55,16 @@ def locg(pulldate=None,weeknumber=None,year=None):
         try:
             r = requests.get(url, params=params, verify=True, headers={'User-Agent': mylar.USER_AGENT[:mylar.USER_AGENT.find('/')+7] + mylar.USER_AGENT[mylar.USER_AGENT.find('(')+1]})
         except requests.exceptions.RequestException as e:
-            logger.warn(e)
+            logger.warn('[PULL-LIST] Error encountered retrieving pull-list: %s' % (e,))
             mylar.BACKENDSTATUS_WS = 'down'
             return {'status': 'failure'}
 
         if str(r.status_code) == '619':
             logger.warn('[%s] No date supplied, or an invalid date was provided [%s]' % (r.status_code, pulldate))
+            return {'status': 'failure'}
+        elif str(r.status_code) == '522':
+            logger.warn('[%s] Walksoftly is currently offline. Data shown may be stale until it comes back online' % (r.status_code,))
+            mylar.BACKENDSTATUS_WS = 'down'
             return {'status': 'failure'}
         elif str(r.status_code) == '999' or str(r.status_code) == '111':
             logger.warn('[%s] Unable to retrieve data from site - this is a site.specific issue [%s]' % (r.status_code, pulldate))
@@ -98,6 +102,10 @@ def locg(pulldate=None,weeknumber=None,year=None):
             #clear out the upcoming table here so they show the new values properly.
             #if pulldate == '00000000':
             # 2021-07-03 -> we should always clear out the table to ensure we don't have old data mixed with fresh.
+            if len(pull) == 0:
+                logger.warn('[PULL-LIST] Weekly pull for week %s, %s has no data. This is probably a back-end related error of some kind.' % (weeknumber, year))
+                return {'status': 'failure'}
+
             logger.info('Re-creating pullist to ensure everything\'s fresh.')
             myDB.action('DELETE FROM weekly WHERE weeknumber=? AND year=?',[int(weeknumber), int(year)])
 

--- a/mylar/weeklypull.py
+++ b/mylar/weeklypull.py
@@ -110,12 +110,13 @@ def pullit(forcecheck=None, weeknumber=None, year=None):
                 new_pullcheck(chk_locg['weeknumber'],chk_locg['year'])
             elif chk_locg['status'] == 'update_required':
                 logger.warn('[PULL-LIST] Your version of Mylar is not up-to-date. You MUST update before this works')
-                return
+                return {'status': 'failure'}
             else:
-                logger.info('[PULL-LIST] Unable to retrieve weekly pull-list. Dropping down to legacy method of PW-file')
-                mylar.PULLBYFILE = pull_the_file(newrl)
-                break
-        return
+                logger.warn('[PULL-LIST] Unable to retrieve weekly pull-list. Pull list for week %s, %s may be stale.' % (weeknumber_mod, year_mod))
+                return {'status': 'failure'}
+                #mylar.PULLBYFILE = pull_the_file(newrl)
+                #break
+        return {'status': 'success'}
 
     else:
         logger.info('[PULL-LIST] Populating & Loading pull-list data from file')


### PR DESCRIPTION
- When WS was offline, would cause Mylar to not update the pull - but in some cases it would actually wipe the pull-list prior to attempting to retrieve new data which resulted in an empty pull. When WS came back online, it wouldn't mark the appropriate issues as Wanted thereafter due to the wipe. Will now check if WS is online and data is available prior to wiping the table entries.
- When WS was offline, would return a status code 522 due to being behind CF now - which changed the response action that happens on error which resulted in some weird data mismatches. Will now also update the WS footer status.