### PR TITLE
FIX:(#900) check_github and check_github_on_startup not being honoured, FIX: Schedulers displaying incorrect status

### DIFF
--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -429,11 +429,11 @@ def start():
 
                     duration_diff = (helpers.utctimestamp() - search_timestamp)/60
                     if duration_diff >= int(CONFIG.SEARCH_INTERVAL):
-                        logger.fdebug('[AUTO-SEARCH]Auto-Search set to a delay of one minute before initialization as it has been %s minutes since the last run' % duration_diff)
-                        SCHED.add_job(func=ss.run, id='search', name='Auto-Search', trigger=IntervalTrigger(hours=0, minutes=CONFIG.SEARCH_INTERVAL, timezone='UTC'))
+                        logger.fdebug('[AUTO-SEARCH]Auto-Search set to an initial delay of 2 minutes before initialization as it has been %s minutes since the last run' % duration_diff)
+                        SCHED.add_job(func=ss.run, id='search', name='Auto-Search', next_run_time=(datetime.datetime.utcnow() + timedelta(minutes=2)), trigger=IntervalTrigger(hours=0, minutes=CONFIG.SEARCH_INTERVAL, timezone='UTC'))
                     else:
                         search_diff = datetime.datetime.utcfromtimestamp(helpers.utctimestamp() + ((int(CONFIG.SEARCH_INTERVAL) * 60)  - (duration_diff*60)))
-                        logger.fdebug('[AUTO-SEARCH] Scheduling next run @ %s every %s minutes' % (search_diff, CONFIG.SEARCH_INTERVAL))
+                        logger.fdebug('[AUTO-SEARCH] Scheduling next run @ %s (every %s minutes)' % (search_diff, CONFIG.SEARCH_INTERVAL))
                         SCHED.add_job(func=ss.run, id='search', name='Auto-Search', next_run_time=search_diff, trigger=IntervalTrigger(hours=0, minutes=CONFIG.SEARCH_INTERVAL, timezone='UTC'))
             else:
                 ss = searchit.CurrentSearcher()

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3555,7 +3555,10 @@ def job_management(write=False, job=None, last_run_completed=None, current_run=N
             weekly_nextrun = None
             search_newstatus = 'Waiting'
             search_nextrun = None
-            version_newstatus = 'Waiting'
+            if mylar.CONFIG.CHECK_GITHUB is True:
+               version_newstatus = 'Waiting'
+            else:
+               version_newstatus = 'Paused'
             version_nextrun = None
             if mylar.CONFIG.ENABLE_CHECK_FOLDER is True:
                 monitor_newstatus = 'Waiting'
@@ -3570,37 +3573,37 @@ def job_management(write=False, job=None, last_run_completed=None, current_run=N
                     if mylar.SCHED_DBUPDATE_LAST is None:
                         mylar.SCHED_DBUPDATE_LAST = ji['prev_run_timestamp']
                     dbupdate_newstatus = ji['status']
-                    mylar.UPDATER_STATUS = dbupdate_newstatus
+                    #mylar.UPDATER_STATUS = dbupdate_newstatus
                     dbupdate_nextrun = ji['next_run_timestamp']
                 elif 'search' in ji['JobName'].lower():
                     if mylar.SCHED_SEARCH_LAST is None:
                         mylar.SCHED_SEARCH_LAST = ji['prev_run_timestamp']
                     search_newstatus = ji['status']
-                    mylar.SEARCH_STATUS = search_newstatus
+                    #mylar.SEARCH_STATUS = search_newstatus
                     search_nextrun = ji['next_run_timestamp']
                 elif 'rss' in ji['JobName'].lower():
                     if mylar.SCHED_RSS_LAST is None:
                         mylar.SCHED_RSS_LAST = ji['prev_run_timestamp']
                     rss_newstatus = ji['status']
-                    mylar.RSS_STATUS = rss_newstatus
+                    #mylar.RSS_STATUS = rss_newstatus
                     rss_nextrun = ji['next_run_timestamp']
                 elif 'weekly' in ji['JobName'].lower():
                     if mylar.SCHED_WEEKLY_LAST is None:
                         mylar.SCHED_WEEKLY_LAST = ji['prev_run_timestamp']
                     weekly_newstatus = ji['status']
-                    mylar.WEEKLY_STATUS = weekly_newstatus
+                    #mylar.WEEKLY_STATUS = weekly_newstatus
                     weekly_nextrun = ji['next_run_timestamp']
                 elif 'version' in ji['JobName'].lower():
                     if mylar.SCHED_VERSION_LAST is None:
                         mylar.SCHED_VERSION_LAST = ji['prev_run_timestamp']
                     version_newstatus = ji['status']
-                    mylar.VERSION_STATUS = version_newstatus
+                    #mylar.VERSION_STATUS = version_newstatus
                     version_nextrun = ji['next_run_timestamp']
                 elif 'monitor' in ji['JobName'].lower():
                     if mylar.SCHED_MONITOR_LAST is None:
                         mylar.SCHED_MONITOR_LAST = ji['prev_run_timestamp']
                     monitor_newstatus = ji['status']
-                    mylar.MONITOR_STATUS = monitor_newstatus
+                    #mylar.MONITOR_STATUS = monitor_newstatus
                     monitor_nextrun = ji['next_run_timestamp']
 
             monitors = {'weekly': mylar.SCHED_WEEKLY_LAST,
@@ -3618,28 +3621,34 @@ def job_management(write=False, job=None, last_run_completed=None, current_run=N
                     continue
                 elif 'update' in jobinfo.lower():
                     prev_run_timestamp = mylar.SCHED_DBUPDATE_LAST
-                    newstatus = dbupdate_newstatus
-                    mylar.UPDATER_STATUS = newstatus
+                    newstatus = mylar.UPDATER_STATUS
+                    #newstatus = dbupdate_newstatus
+                    #mylar.UPDATER_STATUS = newstatus
                 elif 'search' in jobinfo.lower():
                     prev_run_timestamp = mylar.SCHED_SEARCH_LAST
-                    newstatus = search_newstatus
-                    mylar.SEARCH_STATUS = newstatus
+                    newstatus = mylar.SEARCH_STATUS
+                    #newstatus = search_newstatus
+                    #mylar.SEARCH_STATUS = newstatus
                 elif 'rss' in jobinfo.lower():
                     prev_run_timestamp = mylar.SCHED_RSS_LAST
-                    newstatus = rss_newstatus
-                    mylar.RSS_STATUS = newstatus
+                    newstatus = mylar.RSS_STATUS
+                    #newstatus = rss_newstatus
+                    #mylar.RSS_STATUS = newstatus
                 elif 'weekly' in jobinfo.lower():
                     prev_run_timestamp = mylar.SCHED_WEEKLY_LAST
-                    newstatus = weekly_newstatus
-                    mylar.WEEKLY_STATUS = newstatus
+                    newstatus = mylar.WEEKLY_STATUS
+                    #newstatus = weekly_newstatus
+                    #mylar.WEEKLY_STATUS = newstatus
                 elif 'version' in jobinfo.lower():
                     prev_run_timestamp = mylar.SCHED_VERSION_LAST
-                    newstatus = version_newstatus
-                    mylar.VERSION_STATUS = newstatus
+                    newstatus = mylar.VERSION_STATUS
+                    #newstatus = version_newstatus
+                    #mylar.VERSION_STATUS = newstatus
                 elif 'monitor' in jobinfo.lower():
                     prev_run_timestamp = mylar.SCHED_MONITOR_LAST
-                    newstatus = monitor_newstatus
-                    mylar.MONITOR_STATUS = newstatus
+                    newstatus = mylar.MONITOR_STATUS
+                    #newstatus = monitor_newstatus
+                    #mylar.MONITOR_STATUS = newstatus
 
                 jobname = jobinfo[:jobinfo.find('(')-1].strip()
                 #logger.fdebug('jobinfo: %s' % jobinfo)

--- a/mylar/versioncheck.py
+++ b/mylar/versioncheck.py
@@ -102,7 +102,7 @@ def getVersion():
         cur_commit_hash = output[:opp]
         cur_branch = output[opp:output.find('\n', opp+1)].strip()
 
-        if cur_commit_hash.startswith('v'):
+        if cur_commit_hash.startswith('v') and mylar.CONFIG.CHECK_GITHUB_ON_STARTUP is True:
             url2 = 'https://api.github.com/repos/%s/mylar3/tags' % (mylar.CONFIG.GIT_USER)
             try:
                 response = requests.get(url2, verify=True, auth=mylar.CONFIG.GIT_TOKEN)
@@ -209,7 +209,7 @@ def getVersion():
             except Exception as e:
                 logger.error('error: %s' % e)
 
-        if current_version_name is not None:
+        if current_version_name is not None and mylar.CONFIG.CHECK_GITHUB_ON_STARTUP is True:
             url2 = 'https://api.github.com/repos/%s/mylar3/releases/tags/%s' % (mylar.CONFIG.GIT_USER, current_version_name)
             try:
                 response = requests.get(url2, verify=True, auth=mylar.CONFIG.GIT_TOKEN)

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -2983,10 +2983,10 @@ class WebInterface(object):
                 else:
                     next_run = None
                 if 'rss' in jb['JobName'].lower():
-                    if jb['Status'] == 'Waiting' and mylar.CONFIG.ENABLE_RSS is False:
-                        mylar.RSS_STATUS = 'Paused'
-                    elif jb['Status'] == 'Paused' and mylar.CONFIG.ENABLE_RSS is True:
-                        mylar.RSS_STATUS = 'Waiting'
+                    #if mylar.CONFIG.ENABLE_RSS is False:
+                    #    mylar.RSS_STATUS = 'Paused'
+                    #elif jb['Status'] == 'Paused' and mylar.CONFIG.ENABLE_RSS is True:
+                    #    mylar.RSS_STATUS = 'Waiting'
                     status = mylar.RSS_STATUS
                     interval = str(mylar.CONFIG.RSS_CHECKINTERVAL) + ' mins'
                 if 'weekly' in jb['JobName'].lower():
@@ -2994,20 +2994,32 @@ class WebInterface(object):
                     if mylar.CONFIG.ALT_PULL == 2: interval = '4 hrs'
                     else: interval = '24 hrs'
                 if 'search' in jb['JobName'].lower():
+                    #if mylar.CONFIG.NZB_STARTUP_SEARCH is False and jb['Status'] != 'Running':
+                    #    mylar.SEARCH_STATUS = 'Waiting'
+                    #elif jb['Status'] == 'Paused' and mylar.CONFIG.NZB_STARTUP_SEARCH is True:
+                    #    mylar.SEARCH_STATUS = 'Waiting'
                     status = mylar.SEARCH_STATUS
                     interval = str(mylar.CONFIG.SEARCH_INTERVAL) + ' mins'
                 if 'updater' in jb['JobName'].lower():
                     status = mylar.UPDATER_STATUS
                     interval = str(int(mylar.DBUPDATE_INTERVAL)) + ' mins'
                 if 'folder' in jb['JobName'].lower():
+                    #if mylar.CONFIG.ENABLE_CHECK_FOLDER is False:
+                    #    mylar.MONITOR_STATUS = 'Paused'
+                    #elif jb['Status'] == 'Paused' and mylar.CONFIG.ENABLE_CHECK_FOLDER is True:
+                    #    mylar.MONITOR_STATUS = 'Waiting'
                     status = mylar.MONITOR_STATUS
                     interval = str(mylar.CONFIG.DOWNLOAD_SCAN_INTERVAL) + ' mins'
                 if 'version' in jb['JobName'].lower():
+                    #if mylar.CONFIG.CHECK_GITHUB is False:
+                    #    mylar.VERSION_STATUS = 'Paused'
+                    #elif jb['Status'] == 'Paused' and mylar.CONFIG.CHECK_GITHUB is True:
+                    #    mylar.VERSION_STATUS = 'Waiting'
                     status = mylar.VERSION_STATUS
                     interval = str(mylar.CONFIG.CHECK_GITHUB_INTERVAL) + ' mins'
 
-                if status != jb['Status'] and not('rss' in jb['JobName'].lower()):
-                    status = jb['Status']
+                #if status != jb['Status'] and not('rss' in jb['JobName'].lower()):
+                #    status = jb['Status']
 
                 tmp.append({'prev_run_datetime':  prev_run,
                             'next_run_datetime': next_run,
@@ -3067,6 +3079,18 @@ class WebInterface(object):
             if jobid.lower() in str(jb).lower():
                 logger.info('[%s] Now force submitting job for jobid %s' % (jb, jobid))
                 if any([jobid == 'rss', jobid == 'weekly', jobid =='search', jobid == 'version', jobid == 'updater', jobid == 'monitor']):
+                    if jobid == 'rss':
+                        mylar.RSS_STATUS = 'Running'
+                    elif jobid == 'weekly':
+                        mylar.WEEKLY_STATUS = 'Running'
+                    elif jobid == 'search':
+                        mylar.SEARCH_STATUS = 'Running'
+                    elif jobid == 'version':
+                        mylar.VERSION_STATUS = 'Running'
+                    elif jobid == 'updater':
+                        mylar.UPDATER_STATUS = 'Running'
+                    elif jobid == 'monitor':
+                        mylar.MONITOR_STATUS = 'Running'
                     jb.modify(next_run_time=datetime.datetime.utcnow())
                     break
     schedulerForceCheck.exposed = True


### PR DESCRIPTION
- FIX:(#900) ``check_github`` and ``check_github_on_startup`` not being honoured if both were set to ``False`` (would still hit github)
- FIX: Schedulers displaying incorrect status (either always Running, or always Waiting)