### PR TITLE
FIX: Auto-Search/Force-Search would add Ttier1 items to queue, but also search simultaneously for Tier2

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -3001,21 +3001,22 @@ def searchforissue(issueid=None, new=False, rsscheck=None, manual=False):
                     else:
                         DateAdded = result['DateAdded']
 
-                    if rsscheck is None and DateAdded >= mylar.SEARCH_TIER_DATE:
-                        logger.info(
-                            'adding: ComicID:%s  IssueiD: %s'
-                            % (result['ComicID'], result['IssueID'])
-                        )
-                        mylar.SEARCH_QUEUE.put(
-                            {
-                                'comicname': comicname,
-                                'seriesyear': SeriesYear,
-                                'issuenumber': result['Issue_Number'],
-                                'issueid': result['IssueID'],
-                                'comicid': result['ComicID'],
-                                'booktype': booktype,
-                            }
-                        )
+                    if rsscheck is None:
+                        if DateAdded >= mylar.SEARCH_TIER_DATE:
+                            logger.info(
+                                'adding: ComicID:%s  IssueiD: %s'
+                                % (result['ComicID'], result['IssueID'])
+                            )
+                            mylar.SEARCH_QUEUE.put(
+                                {
+                                    'comicname': comicname,
+                                    'seriesyear': SeriesYear,
+                                    'issuenumber': result['Issue_Number'],
+                                    'issueid': result['IssueID'],
+                                    'comicid': result['ComicID'],
+                                    'booktype': booktype,
+                                }
+                            )
                         continue
 
                     smode = result['mode']


### PR DESCRIPTION
When the Auto-Search fired off (or a Force Search was done), it would queue up items that were tiered (tier 1). If it was a tier2 item, it would actually perform a threaded search for that issue - resulting in simultaneous requests firing off for different issues (when it shouldn't have done anything for tier2). 

This PR fixes it so if it's a tier1 item, it will be queue as per normal. If it's a tier2 item, it will be ignored - since the Auto-Search / Force Search should only be searching against Tier1 items.

Note that the Tier2 aspect of searching for RSS only when the scheduler kicks off will probably have to be subsequently fixed...