### PR TITLE
FIX: adjust post-processing location if SABnzbd download location is the same as Directory Location

### DIFF
--- a/mylar/sabnzbd.py
+++ b/mylar/sabnzbd.py
@@ -194,7 +194,10 @@ class SABnzbd(object):
                         tmp_path = os.path.abspath(os.path.join(hq['storage'], os.pardir))
                         tmp_path_b = tmp_path.split(os.path.sep)[:-1]
                         sub_dir = tmp_path.split(os.path.sep)[-1]
-                        rep_tmp_path_b = re.sub(os.path.sep.join(tmp_path_b), mylar.CONFIG.SAB_DIRECTORY, tmp_path).strip()
+                        if tmp_path == mylar.CONFIG.SAB_DIRECTORY:
+                            rep_tmp_path_b = mylar.CONFIG.SAB_DIRECTORY
+                        else:
+                            rep_tmp_path_b = re.sub(os.path.sep.join(tmp_path_b), mylar.CONFIG.SAB_DIRECTORY, tmp_path).strip()
 
                         try:
                             if os.path.exists(os.path.join( rep_tmp_path_b, os.path.sep.join(sub_dir), tmpfile )):


### PR DESCRIPTION
Post-processing calls would fail to properly detect the location of the downloaded file due to incorrect joining of paths when the SABnzbd Directory is the same as the final location where SABnzbd downloads to (ie. the destination path returned from SAB is in the same path as the SABnzbd Directory location provided within Mylar).