### PR TITLE
FIX: don't hide the Failed filter (handled by javascript)

### DIFF
--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -462,9 +462,7 @@
         <label for="Skipped" class="checkbox inline Skipped" id="skippedlabel" style="display:none;"><input type="checkbox" name="Skipped" id="Skipped" checked="checked" /> Skipped: <b><span id="skippedcount"></span></b></label>
         <label for="Ignored" class="checkbox inline Ignored" id="ignoredlabel" style="display:none;"><input type="checkbox" name="Ignored" id="Ignored" checked="checked" /> Ignored: <b><span id="ignoredcount"></span></b></label>
         <label for="Snatched" class="checkbox inline Snatched" id="snatchedlabel" style="display:none;"><input type="checkbox" name="Snatched" id="Snatched" checked="checked" /> Snatched: <b><span id="snatchedcount"></span></b></label>
-        %if mylar.CONFIG.FAILED_DOWNLOAD_HANDLING:
-            <label for="Failed" class="checkbox inline Failed" id="failedlabel" style="display:none;"><input type="checkbox" name="Failed" id="Failed" checked="checked" /> Failed: <b><span id="failedcount"></span></b></label>
-        %endif
+        <label for="Failed" class="checkbox inline Failed" id="failedlabel" style="display:none;"><input type="checkbox" name="Failed" id="Failed" checked="checked" /> Failed: <b><span id="failedcount"></span></b></label>
     </div>
    </div>
   </div>


### PR DESCRIPTION
Would fail to render series detail page if Failed Download Handling was not enabled.