### PR TITLE
FIX: sending to client via CDH would fail with empty nzb error

### DIFF
--- a/mylar/api.py
+++ b/mylar/api.py
@@ -138,7 +138,7 @@ class Api(object):
             self.apitype = 'normal'
         else:
             if not mylar.CONFIG.API_ENABLED:
-                if kwargs['apikey'] != mylar.DOWNLOAD_APIKEY or kwargs['apikey'] != mylar.SSE_KEY:
+                if kwargs['apikey'] != mylar.DOWNLOAD_APIKEY and kwargs['apikey'] != mylar.SSE_KEY:
                     self.data = self._failureResponse('API not enabled')
                     return
 


### PR DESCRIPTION
invalid api key reference check.