### PR TITLE
prevent AttributeError exception

### DIFF
--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5017,7 +5017,7 @@ class WebInterface(object):
                     else:
                         #logger.fdebug('result: %s' % result)
                         comicstoIMP.append(result['ComicLocation']) #.decode(mylar.SYS_ENCODING, 'replace'))
-                        getiss = result['IssueNumber']
+                        getiss = result['IssueNumber'] or ''
                         #logger.fdebug('getiss: %s' % getiss)
                         if 'annual' in getiss.lower():
                             tmpiss = re.sub('[^0-9]','', getiss).strip()


### PR DESCRIPTION
after tagging some comics with ComicTagger, I found this in the log while trying to import many of the files:

```
Uncaught exception: Traceback (most recent call last):
File "/app/mylar3/mylar/logger.py", line 337, in new_run
old_run(*args, **kwargs)
File "/usr/lib/python3.8/threading.py", line 870, in run
self._target(*self._args, **self._kwargs)
File "/app/mylar3/mylar/webserve.py", line 5022, in preSearchit
if 'annual' in getiss.lower():
AttributeError: 'NoneType' object has no attribute 'lower'
```

Seems like `result['IssueNumber']` can occassionally be `None`, this seemed like the easiest way to prevent the error.