### PR TITLE
FIX: (#929) Verify taken from config when searching was being passed as a string instead of a boolean

### DIFF
--- a/mylar/rsscheck.py
+++ b/mylar/rsscheck.py
@@ -510,7 +510,7 @@ def nzbs(provider=None, forcerss=False):
             params = {'sort': 'agedesc',
                       'max':   max_entries,
                       'more':  '1'}
-            check = _parse_feed('experimental', 'http://nzbindex.nl/rss/alt.binaries.comics.dcp', False, params)
+            check = _parse_feed('experimental', 'https://nzbindex.nl/rss/alt.binaries.comics.dcp', True, params)
             if check == 'disable':
                 helpers.disable_provider(site)
 
@@ -521,7 +521,7 @@ def nzbs(provider=None, forcerss=False):
                       'i':         mylar.CONFIG.NZBSU_UID,
                       'r':         mylar.CONFIG.NZBSU_APIKEY,
                       'num_items': num_items}
-            check = _parse_feed('nzb.su', 'https://api.nzb.su/rss', mylar.CONFIG.NZBSU_VERIFY, params)
+            check = _parse_feed('nzb.su', 'https://api.nzb.su/rss', bool(int(mylar.CONFIG.NZBSU_VERIFY)), params)
             if check == 'disable':
                 helpers.disable_provider(site)
 
@@ -533,7 +533,7 @@ def nzbs(provider=None, forcerss=False):
                       't':          'search',
                       'dl':         '1'}
 
-            check = _parse_feed('dognzb', 'https://api.dognzb.cr/api', mylar.CONFIG.DOGNZB_VERIFY, params)
+            check = _parse_feed('dognzb', 'https://api.dognzb.cr/api', bool(int(mylar.CONFIG.DOGNZB_VERIFY)), params)
             if check == 'disable':
                 helpers.disable_provider(site)
 
@@ -551,7 +551,7 @@ def nzbs(provider=None, forcerss=False):
                           'dl':        '1',
                           'apikey':    newznab_host[3].rstrip(),
                           'num':       '100'}
-                check = _parse_feed(site, url, bool(newznab_host[2]), params)
+                check = _parse_feed(site, url, bool(int(newznab_host[2])), params)
             else:
                 url = newznab_host[1].rstrip() + '/rss'
                 params = {'t':         str(newznabcat),
@@ -560,7 +560,7 @@ def nzbs(provider=None, forcerss=False):
                           'r':         newznab_host[3].rstrip(),
                           'num':       '100'}
 
-                check = _parse_feed(site, url, bool(newznab_host[2]), params)
+                check = _parse_feed(site, url, bool(int(newznab_host[2])), params)
                 if check is False and 'rss' in url[-3:]:
                     logger.fdebug('RSS url returning 403 error. Attempting to use API to get most recent items in lieu of RSS feed')
                     url = newznab_host[1].rstrip() + '/api'
@@ -569,7 +569,7 @@ def nzbs(provider=None, forcerss=False):
                               'dl':        '1',
                               'apikey':    newznab_host[3].rstrip(),
                               'num':       '100'}
-                    check = _parse_feed(site, url, bool(newznab_host[2]), params)
+                    check = _parse_feed(site, url, bool(int(newznab_host[2])), params)
                 if check == 'disable':
                     helpers.disable_provider(site)
 

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -752,17 +752,16 @@ def NZB_SEARCH(
     untouched_name = None
     if nzbprov == 'nzb.su':
         apikey = mylar.CONFIG.NZBSU_APIKEY
-        verify = bool(mylar.CONFIG.NZBSU_VERIFY)
+        verify = bool(int(mylar.CONFIG.NZBSU_VERIFY))
     elif nzbprov == 'dognzb':
         apikey = mylar.CONFIG.DOGNZB_APIKEY
-        verify = bool(mylar.CONFIG.DOGNZB_VERIFY)
+        verify = bool(int(mylar.CONFIG.DOGNZB_VERIFY))
     elif nzbprov == 'experimental':
         apikey = 'none'
-        verify = False
     elif nzbprov == 'torznab':
         name_torznab = torznab_host[0].rstrip()
         host_torznab = torznab_host[1].rstrip()
-        verify = bool(torznab_host[2])
+        verify = bool(int(torznab_host[2]))
         apikey = torznab_host[3].rstrip()
         category_torznab = torznab_host[4]
         if any([category_torznab is None, category_torznab == 'None']):
@@ -783,7 +782,7 @@ def NZB_SEARCH(
             name_newznab = name_newznab[:-10].strip()
             newznab_local = False
         apikey = newznab_host[3].rstrip()
-        verify = bool(newznab_host[2])
+        verify = bool(int(newznab_host[2]))
         if '#' in newznab_host[4].rstrip():
             catstart = newznab_host[4].find('#')
             category_newznab = re.sub('#', ',', newznab_host[4][catstart + 1 :]).strip()
@@ -3766,7 +3765,7 @@ def searcher(
             # experimental - direct link.
             down_url = link
             headers = None
-            verify = False
+            verify = True
 
         if payload is None:
             tmp_line = down_url


### PR DESCRIPTION
- Corrected so that instead of a boolean string (which will always return True), will be the boolean of an integer of a string.
- Also fixed Experimental hitting non-https for some reason when retrieving RSS feed.