### PR TITLE
FIX: nzbget url change to allow for ? in passwords, FIX: various configuration page fixes

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -255,15 +255,13 @@
                     		 </fieldset>
                          <fieldset>
                              <legend>Annual Handling</legend>
-                                <div>
-                                    <small class="heading"><span style="float: left; margin-right: .3em; margin-top: 4px;" class="ui-icon ui-icon-info"></span>Series need to be Refreshed for annuals to appear</small>
-                                </div>
                              <div class="row checkbox">
-                                 <input type="checkbox" name="annuals_on" value="1" ${config['annuals_on']} /><label>Enable Series-Annual Integration</label>
+                                 <input type="checkbox" name="annuals_on" id="annuals_on" value="1" ${config['annuals_on']} /><label>Enable Series-Annual Integration</label>
                              </div>
-                                 </br><small>Enabled: Annuals are tracked as part of the series it belongs to</small></br>
-                                 <small>Disabled: Annuals are tracked independently and will appear on your watchlist as a series</small>
                          </fieldset>
+                             <div style="text-align:center;">
+                                 <span id="annuals_info" style="display:none;text-align:center;"></span>
+                             </div>
             	</td>
 
                 <td>          
@@ -439,40 +437,28 @@
                                                 %endfor
                                                 </select>
                                 </div>
+                                </br>
 
-                                <div class="row checkbox left clearfix">
-                                    <input id="sab_to_mylar" type="checkbox" onclick="initConfigCheckbox($(this));" name="sab_to_mylar" value="1" ${config['sab_to_mylar']} /><label>Are Mylar / SABnzbd on separate machines</label>
-                                    <small class="heading"><span style="float: left; margin-right: .3em; margin-top: 4px;" class="ui-icon ui-icon-info"></span>This is *ONLY* required if Mylar and SABnzbd are on separate machines, otherwise don't touch it</small>
+                               <div class="row checkbox left clearfix">
+                                    <input type="checkbox" id="sab_client_post_processing" name="sab_client_post_processing" value="1" ${config['sab_client_post_processing']} /><label>Enable Completed Download Handling</label>
                                 </div>
-                                <div class="config">
-                                    <div class="row">
-                                        <label>SABnzbd Download Directory</label>
-                                        <input type="text" name="sab_directory" value="${config['sab_directory']}" size="36" />
-                                        <small>Where your SAB downloads go (required for PP)</small>
+
+                                <div class="row">
+                                    <div class="row checkbox left clearfix">
+                                       <input id="sab_to_mylar" type="checkbox" name="sab_to_mylar" onClick="initConfigCheckbox($(this));" value="1" ${config['sab_to_mylar']} /><label>Are Mylar / SABnzbd on separate machines</label>
                                     </div>
-                                </div>
-
-                                <div class="row checkbox left clearfix" id="sab_cdh" style="display:unset;">
-                                    <input type="checkbox" id="sab_client_post_processing" onclick="initConfigCheckbox($(this));" name="sab_client_post_processing" value="1" ${config['sab_client_post_processing']} /><label>Enable Completed Download Handling</label>
-                                    <div id="sabcompletedinfo">
+                                    <div class="config">
                                        <div class="row">
-                                           <small class="heading"><span style="float: left; margin-right: .3em; margin-top: 4px;" class="ui-icon ui-icon-info"></span>
-                                           ComicRN script cannot be used with this enabled & required SAB version > 0.8.0</small>
+                                          <label>SABnzbd Download Directory</label>
+                                          <input type="text" name="sab_directory" value="${config['sab_directory']}" size="36">
                                        </div>
                                     </div>
                                 </div>
-                                <div class="row checkbox left clearfix" id="sab_nocdh" style="display:none;">
-                                    <div>
-                                       <div class="row">
-                                           <small class="heading"><span style="float: left; margin-right: .3em; margin-top: 4px;" class="ui-icon ui-icon-info"></span>
-                                           Completed Download Handling is not available as your version of SABnzbd is not above 0.8.0</small>
-                                       </div>
-                                    </div>
-                                </div>
+                                </br>
                                 <div align="center" class="row">
                                      <img name="sabnzbd_statusicon" id="sabnzbd_statusicon" src="images/success.png" style="float:right;visibility:hidden;" height="20" width="20" />
                                      <input type="button" value="Test SABnzbd" id="test_sab" style="float:center" /></br>
-                                     <input type="text" name="sabstatus" style="text-align:center; font-size:11px;" id="sabstatus" size="50" DISABLED />
+                                     <input type="text" name="sabstatus" style="text-align:center;font-size:11px;color:white;" id="sabstatus" size="50" DISABLED />
                                      <div name="sabversion" id="sabversion" style="font-size:11px;" align="center">
                                         <%
                                                if mylar.CONFIG.SAB_VERSION is not None:
@@ -529,18 +515,12 @@
 
                             <div class="row checkbox left clearfix">
                                 <input type="checkbox" id="nzbget_client_post_processing" onclick="initConfigCheckbox($(this));" name="nzbget_client_post_processing" value="1" ${config['nzbget_client_post_processing']} /><label>Enable Completed Download Handling</label>
-                                <div id="nzbgetcompletedinfo">
-                                   <div class="row">
-                                       <small class="heading"><span style="float: left; margin-right: .3em; margin-top: 4px;" class="ui-icon ui-icon-info"></span>
-                                       ComicRN script cannot be used with this enabled</small>
-                                   </div>
-                                </div>
                             </div>
 
                             <div align="center" class="row">
                                  <img name="nzbget_statusicon" id="nzbget_statusicon" src="images/success.png" style="float:right;visibility:hidden;" height="20" width="20" />
                                  <input type="button" value="Test NZBGet" id="test_nzbget" style="float:center" /></br>
-                                 <input type="text" name="nzbgetstatus" style="text-align:center; font-size:11px;" id="nzbgetstatus" size="50" DISABLED />
+                                 <input type="text" name="nzbgetstatus" style="text-align:center; font-size:11px;color:white;" id="nzbgetstatus" size="50" DISABLED />
                             </div>
                          
                          </fieldset>
@@ -1768,6 +1748,19 @@
                });
         }
 
+        function annuals_integration(){
+            var aob = document.getElementById("annuals_info");
+            if ($("#annuals_on").is(":checked")){
+                console.log('on');
+                aob.style = "display:block;";
+                aob.innerHTML = '<small>Annuals will be tracked as part of the series it belongs to</small>';
+            } else {
+                console.log('off');
+                aob.style = "display:block;";
+                aob.innerHTML = '<small>Annuals will be tracked independently</br>( will appear on your watchlist as individual series )</small>';
+            }
+        }
+
         </script>
 	<script>
 	function initThisPage() 
@@ -1791,44 +1784,6 @@
                         else
                         {
                                 $("#apioptions").slideUp();
-                        }
-                });
-                if ($("#sab_client_post_processing").is(":checked"))
-                        {
-                                $("#sabcompletedinfo").show();
-                        }
-                else
-                        {
-                                $("#sabcompletedinfo").hide();
-                        }
-
-                $("#sab_client_post_processing").click(function(){
-                        if ($("#sab_client_post_processing").is(":checked"))
-                        {
-                                $("#sabcompletedinfo").slideDown();
-                        }
-                        else
-                        {
-                                $("#sabcompletedinfo").slideUp();
-                        }
-                });
-                if ($("#nzbget_client_post_processing").is(":checked"))
-                        {
-                                $("#nzbgetcompletedinfo").show();
-                        }
-                else
-                        {
-                                $("#nzbgetcompletedinfo").hide();
-                        }
-
-                $("#nzbget_client_post_processing").click(function(){
-                        if ($("#nzbget_client_post_processing").is(":checked"))
-                        {
-                                $("#nzbgetcompletedinfo").slideDown();
-                        }
-                        else
-                        {
-                                $("#nzbgetcompletedinfo").slideUp();
                         }
                 });
                 if ($("#opds_enable").is(":checked"))
@@ -2333,19 +2288,6 @@
                             vsab = numberWithDecimals(versionsab);
                             $('#sabstatus').val(obj['message']);
                             $('#sabversion span').text('SABnzbd version: '+versionsab);
-                            if ( vsab < "0.8.0" ){
-                                scdh = document.getElementById("sab_cdh");
-                                scdh.style.display = "none";
-                                nocdh = document.getElementById("sab_nocdh");
-                                nocdh.style.display = "unset";
-                                scdh_line = document.getElementById("sab_client_post_processing");
-                                scdh_line.value = 0;
-                            } else {
-                                scdh = document.getElementById("sab_cdh");
-                                scdh.style.display = "unset";
-                                nocdh = document.getElementById("sab_nocdh");
-                                nocdh.style.display = "none";
-                            }
                             $('#ajaxMsg').removeClass();
                             $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>"+obj['message']+"</div>");
                             if (obj['status']){
@@ -2360,6 +2302,10 @@
                                 $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
                             }
                     });
+                });
+
+                $('#annuals_on').click(function () {
+                    annuals_integration();
                 });
 
                 $('#test_nzbget').click(function () {
@@ -2382,13 +2328,14 @@
                                 imagechk.src = "";
                                 imagechk.src = "images/success.png";
                                 imagechk.style.visibility = "visible";
+                                $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
                             } else {
                                 imagechk.src = "";
                                 imagechk.src = "images/x_red.png";
                                 imagechk.style.visibility = "visible";
+                                $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
                             }
                     });
-                    $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
                 });
 
                 if ($("#enable_https").is(":checked"))
@@ -2891,6 +2838,7 @@
 	}
 	$(document).ready(function() {
 		initThisPage();
+                annuals_integration()
 	});
 	
 	</script>

--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -2999,6 +2999,11 @@ class PostProcessor(object):
 
             try:
                 if ml['IssueArcID']:
+                    pass
+            except Exception as e:
+                pass
+            else:
+                try:
                     logger.info('Watchlist Story Arc match detected.')
                     logger.info(ml)
                     arcsforever = myDB.select('SELECT * FROM storyarcs where ComicID=? AND IssueID=?', [ml['ComicID'], ml['IssueID']])
@@ -3068,8 +3073,8 @@ class PostProcessor(object):
                         myDB.upsert("storyarcs", newVal, ctrlVal)
                         logger.fdebug('%s [%s] Post-Processing completed for: %s' % (module, arcinfo['StoryArc'], grab_dst))
 
-            except Exception as e:
-                logger.error('error encountered: %s' % e)
+                except Exception as e:
+                    logger.error('error encountered: %s' % e)
 
             if mylar.CONFIG.WEEKFOLDER or mylar.CONFIG.SEND2READ:
                 #mylar.CONFIG.WEEKFOLDER = will *copy* the post-processed file to the weeklypull list folder for the given week.

--- a/mylar/cmtagmylar.py
+++ b/mylar/cmtagmylar.py
@@ -226,8 +226,8 @@ def run(dirName, nzbName=None, issueid=None, comversion=None, manual=None, filen
             # use subprocess to run the command and capture output
             p = subprocess.Popen(script_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             out, err = p.communicate()
-            logger.info(out)
-            logger.info(err)
+            #logger.info(out)
+            #logger.info(err)
             if out is not None:
                 out = out.decode('utf-8')
             if err is not None:


### PR DESCRIPTION
- FIX: NZBGet would not work if the password contained a ``?``
- FIX: NZBGet Test Connection option in the configuration page was not working correctly
- FIX: Updated Annuals Integration option in configuration to better indicate what enabling/disabling does and changed color
- FIX: SABnzbd section of configuration would not show Test Connection unless CDH was enabled - reworked the layout abit
- IMP: Removed all references/checks to SABnzbd being 0.8.0 or greater and the info line about ComicRN in the configuration
- FIX: Removed ``IssueArcID`` logging warning when post-processing issues that were not part of a story-arc.
- FIX: Removed logging of CT metatagging output/errors (it's handled with better wording already)