### PR TITLE
FIX:(#944) Metatagging annuals would result in error, IMP: series detail rechecking files incorrectly on page loading

### DIFF
--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -708,7 +708,7 @@
                 document.getElementById("issue-box").style.display = "block";
                 $("#issue-box").draggable();
             } else if (action == 'metatag' || action == 'ametatag'){
-                run_single_metatag(issueid);
+                run_single_metatag(issueid, comicid, issuenumber);
             } else if (action == 'manqueueit' || action == 'amanqueueit'){
                 if (action == 'amanqueueit'){
                     add_wanted(issueid, comicid, issuenumber, 'want_ann', true);
@@ -1002,26 +1002,28 @@
               });
         }
 
-        function run_single_metatag(issueid){
+        function run_single_metatag(issueid, comicid, issuenumber){
+              $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Now metatagging #"+issuenumber+"...</div>");
+              $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
               $.when($.ajax({
                  type: "GET",
                  url: "manual_metatag",
-                 data: { issueid: issueid },
+                 data: { issueid: issueid, comicid: comicid },
                  success: function(response) {
-                    obj = JSON.parse(response);
-                    $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>"+obj['message']+"</div>");
-                    if (obj['status'] == 'success'){
-                        $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
-                    } else {
-                        $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
-                    }
+                    //obj = JSON.parse(response);
+                    //$('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>"+obj['message']+"</div>");
+                    //if (obj['status'] == 'success'){
+                    //    $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                    //} else {
+                    //    $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                    //}
                  },
                  error: function(data)
                      {
                        alert('ERROR'+data.responseText);
                      },
               })).done(function(data) {
-                 reload_table();
+                 //reload_table();
               });
         }
 


### PR DESCRIPTION
- IMP: series detail page will only recheck files on page load if any file has been modified instead of incorrect counts (improved check)
- FIX:(#944) Metatagging annuals would result in error via series detail page
- IMP: quick scan during manual metatagging to ensure proper location is being used (in case of sub-directories, secondary locations, etc)