### PR TITLE
Fix for StoryAdd error and various searchresults problems

### DIFF
--- a/data/interfaces/carbon/css/style.css
+++ b/data/interfaces/carbon/css/style.css
@@ -2451,3 +2451,9 @@ div.botpad { padding-bottom: 20px; }
 div.toppad { padding-top: 20px; }
 div.bigbotpad { padding-bottom: 40px; }
 div.bigtoppad { padding-top: 40px; }
+
+.spinny  { animation: spinning-cog 1.3s infinite ease; }
+@keyframes spinning-cog  { 0% { transform: rotate(0deg); } 20% { transform: rotate(-45deg); }	100% { transform: rotate(360deg); } }
+img.mylarload { height:64px;width:64px;position:relative;filter:drop-shadow(0px 0px 14px #c0c010); }
+img.mylarload.lastgood { filter: drop-shadow(0px 0px 14px #00f010); }
+img.mylarload.lastbad { filter: drop-shadow(0px 0px 14px #f01000); }

--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -51,7 +51,7 @@
 		<header>			
 			<div class="wrapper">
 			<div id="logo">
-				<a href="home"><img src="images/mylarlogo.png" height="64" width="64" alt="mylar"></a>
+				<a href="home"><img class="mylarload" src="images/mylarlogo.png" alt="mylar" style=""></a>
 			</div>
 			<ul id="nav">
 				<li>
@@ -77,7 +77,7 @@
                 <form action="searchit" method="get">
                     <input type="text" value="" placeholder="Search" onfocus="if(this.value==this.defaultValue) this.value='';" name="name"/>
                     <span class="mini-icon"></span>
-                    <input type="submit" value="Search"/>
+                    <input type="submit" value="Search" onclick="flippylogo();"/>
                 </form>
             </div>
            
@@ -563,6 +563,9 @@
             }
         }
 
+        function flippylogo() {
+            $('img.mylarload').addClass('spinny').removeClass('lastgood').removeClass('lastbad');
+        }
 
         function data_the_table(){
             $('#notifs_table').dataTable( {

--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -2329,3 +2329,9 @@ div.botpad { padding-bottom: 20px; }
 div.toppad { padding-top: 20px; }
 div.bigbotpad { padding-bottom: 40px; }
 div.bigtoppad { padding-top: 40px; }
+
+.spinny  { animation: spinning-cog 1.3s infinite ease; }
+@keyframes spinning-cog  { 0% { transform: rotate(0deg); } 20% { transform: rotate(-45deg); }  100% { transform: rotate(360deg); } }
+img.mylarload { height:64px;width:64px;position:relative;filter:drop-shadow(0px 0px 14px #c0c010); }
+img.mylarload.lastgood { filter: drop-shadow(0px 0px 14px #00f010); }
+img.mylarload.lastbad { filter: drop-shadow(0px 0px 14px #f01000); }

--- a/data/interfaces/default/searchresults.html
+++ b/data/interfaces/default/searchresults.html
@@ -121,6 +121,27 @@
            }
         }
 
+        function addstoryarc(arcid, query_id){
+            document.getElementById("loading_spinner_"+arcid).style.display = "block";
+            $.when($.ajax({
+                 type: "GET",
+                 url: "addbyid",
+                 data: { comicid: comicid, query_id: query_id },
+                 success: function(response) {
+                    obj = JSON.parse(response);
+                    console.log(obj);
+                 },
+                 error: function(data)
+                     {
+                       alert('ERROR'+data.responseText);
+                     },
+            })).done(function(data) {
+                 document.getElementById("loading_spinner_"+arcid).style.display = "none";
+                 window.location.href = "detailStoryArc?StoryArcID="+obj['StoryArcID']+"&StoryArcName="+obj['StoryArcName']+"&CV_ArcID="+obj['CV_ArcID']+"";
+                 //reload_table();
+            });
+        }
+
         function addseries(comicid, query_id, com_location, booktype){
             if(typeof(com_location) === "undefined" || com_location === null){
                 com_location = null;
@@ -162,6 +183,8 @@
                 //query_id = dataline[10];
                 if (action.startsWith('addbyid')) {
                     addseries(comicid, query_id);
+                } else if (action.startsWith('addbyarcid')) {
+                    addstoryarc(comicid, query_id);
                 } else if (action == 'extend_detail'){
                     var table = $('#searchresults_table').DataTable();
                     var tr = $(this).closest('tr');
@@ -312,6 +335,7 @@
 
         function initThisPage(){
                 initActions();
+                var search_type = "${search_type}";
                 $.fn.DataTable.ext.pager.numbers_length = 3;
                 $('#searchresults_table').dataTable( {
                     "preDrawCallback": function (settings){
@@ -388,12 +412,22 @@
                            "targets": [5],
                            "visible": true,
                            "render": function (data,type,full){
-                               if (full[9] === "No") {
-                                   displayline = '<a id="addbyid_'+full[0]+'" name="addbyid" href="#"><span class="ui-icon ui-icon-plus"></span>Add this Comic</a>';
-                                   displayline += '<a id="extend_detail" name="extend_detail" href="#"><span class="ui-icon ui-icon-plus"></span>Edit</a>';
-                                   displayline += '<span id="loading_spinner_'+full[0]+'" style="top:-5px;position:relative;display:none;float:right;"><img src="images/loader_black.gif"  alt="loading"/></span>';
+                               console.log(search_type);
+                               if (search_type == "story_arc"){
+                                   if (full[9] === "No") {
+                                       displayline = '<a id="addbyarcid_'+full[0]+'" name="addbyarcid" href="#"><span class="ui-icon ui-icon-plus"></span>Add this StoryArc</a>';
+                                       displayline += '<span id="loading_spinner_'+full[0]+'" style="display:none;float:right;"><img src="images/loader_black.gif"  height="20" width="20" alt="loading"/></span>';
+                                   } else {
+                                       displayline = '<a id="alreadyhave" name="alreadyhave" href="detailStoryArc?StoryArcID=' + full[0] + '&StoryArcName=' + full[1] + '"><span class="ui-icon ui-icon-arrowreturnthick-1-n"></span>Already in Library</a>';
+                                   }
                                } else {
-                                   displayline = '<a id="alreadyhave" name="alreadyhave" href="comicDetails?ComicID=' + full[0] + '"><span class="ui-icon ui-icon-arrowreturnthick-1-n"></span>Already in Library</a>';
+                                   if (full[9] === "No") {
+                                       displayline = '<a id="extend_detail" name="extend_detail" href="#"><span class="ui-icon ui-icon-plus"></span>Edit</a>';
+                                       displayline += '<a id="addbyid_'+full[0]+'" name="addbyid" href="#"><span class="ui-icon ui-icon-plus"></span>Add this Comic</a>';
+                                       displayline += '<span id="loading_spinner_'+full[0]+'" style="display:none;float:right;"><img src="images/loader_black.gif"  height="20" width="20" alt="loading"/></span>';
+                                   } else {
+                                       displayline = '<a id="alreadyhave" name="alreadyhave" href="comicDetails?ComicID=' + full[0] + '"><span class="ui-icon ui-icon-arrowreturnthick-1-n"></span>Already in Library</a>';
+                                   }
                                }
                                return displayline;
                            }

--- a/data/interfaces/default/storyarc.html
+++ b/data/interfaces/default/storyarc.html
@@ -31,10 +31,11 @@
               <form action="searchit" method="get">
                <fieldset>
                 <legend>Add StoryArc</legend>
-                    <input type="hidden" name="search_type" value="story_arc">
-                    <input type="text" value="" placeholder="Search for Story Arc" onfocus="if(this.value==this.defaultValue)  this.value='';" name="name" />
+                    <input type="hidden" id="search_type" name="search_type" value="story_arc">
+                    <input type="text" value="" id="name" placeholder="Search for Story Arc" onfocus="if(this.value==this.defaultValue)  this.value='';" name="name" />
                     <span class="mini-icon"></span>
-                    <input type="submit" value="Search"/>
+                    <input type="submit" value="Search" onclick="flippylogo();">
+                    <span id="loading_spinner" style="position:relative;display:none;float:right;"><img src="images/loader_black.gif"  alt="loading"/></span>
                </fieldset>
               </form>
 <!--
@@ -169,6 +170,12 @@
             $('#chkoptions').submit();
             return true;
         });
+
+        function showspinner() {
+            console.log('SPINNNER');
+            //$('img.mylarload').addClass('spinny').removeClass('lastgood').removeClass('lastbad');
+            document.getElementById("loading_spinner").style.display = "block";
+        }
         </script>
         <script>
         function initThisPage() {

--- a/data/interfaces/default/storyarc_detail.poster.html
+++ b/data/interfaces/default/storyarc_detail.poster.html
@@ -37,7 +37,11 @@
                  <td id="mainimg">
                    <fieldset>
                       <div id="aristImg">
-                          <img src="${storyarcbanner}" onload="resizeimage('${bannerwidth}')" height="400" width="${bannerwidth}" id="banner" style="text-decoration: none;position: relative;top:0px;right:0px;left:0px;"/>
+                          %if storyarcbanner is not None:
+                              <img src="${storyarcbanner}" onload="resizeimage('${bannerwidth}')" height="400" width="${bannerwidth}" id="banner" style="text-decoration: none;position: relative;top:0px;right:0px;left:0px;"/>
+                          %else:
+                              </br>
+                          %endif
                                  <%
                                          if arcdetail['percent'] == 101:
                                                  css = '<div class=\"progress-container warning\">'

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -746,7 +746,7 @@ def dbcheck():
         c.execute('SELECT ReleaseDate from storyarcs')
     except sqlite3.OperationalError:
         try:
-            c.execute('CREATE TABLE IF NOT EXISTS storyarcs(StoryArcID TEXT, ComicName TEXT, IssueNumber TEXT, SeriesYear TEXT, IssueYEAR TEXT, StoryArc TEXT, TotalIssues TEXT, Status TEXT, inCacheDir TEXT, Location TEXT, IssueArcID TEXT, ReadingOrder INT, IssueID TEXT, ComicID TEXT, ReleaseDate TEXT, IssueDate TEXT, Publisher TEXT, IssuePublisher TEXT, IssueName TEXT, CV_ArcID TEXT, Int_IssueNumber INT, DynamicComicName TEXT, Volume TEXT, Manual TEXT, DateAdded TEXT, DigitalDate TEXT, Type TEXT, Aliases TEXT)')
+            c.execute('CREATE TABLE IF NOT EXISTS storyarcs(StoryArcID TEXT, ComicName TEXT, IssueNumber TEXT, SeriesYear TEXT, IssueYEAR TEXT, StoryArc TEXT, TotalIssues TEXT, Status TEXT, inCacheDir TEXT, Location TEXT, IssueArcID TEXT, ReadingOrder INT, IssueID TEXT, ComicID TEXT, ReleaseDate TEXT, IssueDate TEXT, Publisher TEXT, IssuePublisher TEXT, IssueName TEXT, CV_ArcID TEXT, Int_IssueNumber INT, DynamicComicName TEXT, Volume TEXT, Manual TEXT, DateAdded TEXT, DigitalDate TEXT, Type TEXT, Aliases TEXT, ArcImage TEXT)')
             c.execute('INSERT INTO storyarcs(StoryArcID, ComicName, IssueNumber, SeriesYear, IssueYEAR, StoryArc, TotalIssues, Status, inCacheDir, Location, IssueArcID, ReadingOrder, IssueID, ComicID, ReleaseDate, IssueDate, Publisher, IssuePublisher, IssueName, CV_ArcID, Int_IssueNumber, DynamicComicName, Volume, Manual) SELECT StoryArcID, ComicName, IssueNumber, SeriesYear, IssueYEAR, StoryArc, TotalIssues, Status, inCacheDir, Location, IssueArcID, ReadingOrder, IssueID, ComicID, StoreDate, IssueDate, Publisher, IssuePublisher, IssueName, CV_ArcID, Int_IssueNumber, DynamicComicName, Volume, Manual FROM readinglist')
             c.execute('DROP TABLE readinglist')
         except sqlite3.OperationalError:
@@ -769,7 +769,7 @@ def dbcheck():
     c.execute('CREATE TABLE IF NOT EXISTS oneoffhistory (ComicName TEXT, IssueNumber TEXT, ComicID TEXT, IssueID TEXT, Status TEXT, weeknumber TEXT, year TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS jobhistory (JobName TEXT, prev_run_datetime timestamp, prev_run_timestamp REAL, next_run_datetime timestamp, next_run_timestamp REAL, last_run_completed TEXT, successful_completions TEXT, failed_completions TEXT, status TEXT, last_date timestamp)')
     c.execute('CREATE TABLE IF NOT EXISTS manualresults (provider TEXT, id TEXT, kind TEXT, comicname TEXT, volume TEXT, oneoff TEXT, fullprov TEXT, issuenumber TEXT, modcomicname TEXT, name TEXT, link TEXT, size TEXT, pack_numbers TEXT, pack_issuelist TEXT, comicyear TEXT, issuedate TEXT, tmpprov TEXT, pack TEXT, issueid TEXT, comicid TEXT, sarc TEXT, issuearcid TEXT)')
-    c.execute('CREATE TABLE IF NOT EXISTS storyarcs(StoryArcID TEXT, ComicName TEXT, IssueNumber TEXT, SeriesYear TEXT, IssueYEAR TEXT, StoryArc TEXT, TotalIssues TEXT, Status TEXT, inCacheDir TEXT, Location TEXT, IssueArcID TEXT, ReadingOrder INT, IssueID TEXT, ComicID TEXT, ReleaseDate TEXT, IssueDate TEXT, Publisher TEXT, IssuePublisher TEXT, IssueName TEXT, CV_ArcID TEXT, Int_IssueNumber INT, DynamicComicName TEXT, Volume TEXT, Manual TEXT, DateAdded TEXT, DigitalDate TEXT, Type TEXT, Aliases TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS storyarcs(StoryArcID TEXT, ComicName TEXT, IssueNumber TEXT, SeriesYear TEXT, IssueYEAR TEXT, StoryArc TEXT, TotalIssues TEXT, Status TEXT, inCacheDir TEXT, Location TEXT, IssueArcID TEXT, ReadingOrder INT, IssueID TEXT, ComicID TEXT, ReleaseDate TEXT, IssueDate TEXT, Publisher TEXT, IssuePublisher TEXT, IssueName TEXT, CV_ArcID TEXT, Int_IssueNumber INT, DynamicComicName TEXT, Volume TEXT, Manual TEXT, DateAdded TEXT, DigitalDate TEXT, Type TEXT, Aliases TEXT, ArcImage TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS ddl_info (ID TEXT UNIQUE, series TEXT, year TEXT, filename TEXT, size TEXT, issueid TEXT, comicid TEXT, link TEXT, status TEXT, remote_filesize TEXT, updated_date TEXT, mainlink TEXT, issues TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS exceptions_log(date TEXT UNIQUE, comicname TEXT, issuenumber TEXT, seriesyear TEXT, issueid TEXT, comicid TEXT, booktype TEXT, searchmode TEXT, error TEXT, error_text TEXT, filename TEXT, line_num TEXT, func_name TEXT, traceback TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS tmp_searches (query_id INTEGER, comicid INTEGER, comicname TEXT, publisher TEXT, publisherimprint TEXT, comicyear TEXT, issues TEXT, volume TEXT, deck TEXT, url TEXT, type TEXT, cvarcid TEXT, arclist TEXT, description TEXT, haveit TEXT, mode TEXT, searchtype TEXT, comicimage TEXT, thumbimage TEXT, PRIMARY KEY (query_id, comicid))')
@@ -1347,6 +1347,11 @@ def dbcheck():
         c.execute('SELECT Aliases from storyarcs')
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE storyarcs ADD COLUMN Aliases TEXT')
+
+    try:
+        c.execute('SELECT ArcImage from storyarcs')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE storyarcs ADD COLUMN ArcImage TEXT')
 
     ## -- searchresults Table --
     try:

--- a/mylar/mb.py
+++ b/mylar/mb.py
@@ -222,6 +222,7 @@ def findComic(name, mode, issue, limityear=None, search_type=None):
                                 'url':                  xmlurl,
                                 'issues':               arcinfolist['issues'],
                                 'comicimage':           arcinfolist['comicimage'],
+                                'comicthumb':           arcinfolist['comicthumb'],
                                 'publisher':            xmlpub,
                                 'description':          arcinfolist['description'],
                                 'deck':                 arcinfolist['deck'],
@@ -236,6 +237,7 @@ def findComic(name, mode, issue, limityear=None, search_type=None):
                                 'url':                  xmlurl,
                                 'issues':               issuecount,
                                 'comicimage':           xmlimage,
+                                'comicthumb':           xmlthumb,
                                 'publisher':            xmlpub,
                                 'description':          xmldesc,
                                 'deck':                 xmldeck,
@@ -586,6 +588,19 @@ def storyarcinfo(xmlid):
         xmlimage = "cache/blankcover.jpg"
 
     try:
+        xmlimage = result.getElementsByTagName('super_url')[0].firstChild.wholeText
+    except Exception:
+        try:
+            xmlimage = result.getElementsByTagName('small_url')[0].firstChild.wholeText
+        except Exception:
+            xmlimage = "cache/blankcover.jpg"
+
+    try:
+        xmlthumb = result.getElementsByTagName('thumb_url')[0].firstChild.wholeText
+    except Exception:
+        xmlthumb = "cache/blankcover.jpg"
+
+    try:
         xmldesc = arcdom.getElementsByTagName('desc')[0].firstChild.wholeText
     except:
         xmldesc = "None"
@@ -613,6 +628,7 @@ def storyarcinfo(xmlid):
             'comicid':              xmlid,
             'issues':               issuecount,
             'comicimage':           xmlimage,
+            'comicthumb':           xmlthumb,
             'description':          xmldesc,
             'deck':                 xmldeck,
             'arclist':              arclist,


### PR DESCRIPTION
FIX: Adding a story arc would error due to te previous PR which changed how new Additions were handled
FIX: Sorting by column / filtering for searchresults was broken
FIX: story arc images would always resize to default even when a different sizing method was chosen & saved
FIX: ``clear`` option from story arc detail page would not remove all instances of previous images
FIX: reversed ``Add this Comic`` and ``Edit``positioning wise so row doesn't jitter when Edit is clicked
IMP: Store filename for CoverImage for storyarcs in db for easier / proper referencing
IMP: searchresults for storyarcs moved to a separate js function
IMP: mylar-logo will rotate when searchresults (main search dialog/ storyarcs) are being queried until results page displays