### PR TITLE
FIX: week 0 attempting to be retrieved on initial loading of pull

### DIFF
--- a/mylar/weeklypull.py
+++ b/mylar/weeklypull.py
@@ -85,7 +85,7 @@ def pullit(forcecheck=None, weeknumber=None, year=None):
 
                 weeknumber_mod = int(weeknumber) - 1
                 year_mod = year
-                if weeknumber_mod < 0:
+                if weeknumber_mod <= 0:
                     weeknumber_mod = 52
                     year_mod = int(year) - 1
             else:


### PR DESCRIPTION
If loading the pull for week 1 (the current week) for the first time, would error on attempting to retrieve the previous week which was mistakingly being calculated as week 0, 2022 instead of week 52, 2021.