### PR TITLE
Filling the kitchen sink with more PR's

### DIFF
--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -398,21 +398,21 @@
                                    <div class="row">
                                        <label>Directory Location</label>
                                        <input type="text" id="com_location" name="com_location" value="${comic['ComicLocation']}" size="90">
-                                       <small>The directory where all the comics are located for this particular comic</small>
+                                       <small>Directory where all the comics are located for this series</small>
                                    </div>
 
                                    <div class="row">
                                        <label>Alternate Search Names</label>
                                        <input type="text" name="alt_search" value="${comic['AlternateSearch']}" size="90" />
                                        <a href="#" title="Seperate multiple entries with ##"><img src="images/info32.png" height="16" alt="" /></a>
-                                       <small>Alternate comic names to be searched in case naming is different (ie. Hack/Slash = hack-slash)</small>
+                                       <small>Alternate comic names to be searched in case naming is different</small>
                                    </div>
 
                                    <div class="row">
                                        <label>Alternate File-Naming</label>
                                        <input type="text" name="alt_filename" value="${comic['AlternateFileName']}" size="90">
                                        <a href="#" title="Alternate File Naming"><img src="images/info32.png" height="16" alt="" /></a>
-                                       <small>Alternate file-naming to be used when post-processing / renaming files instead of the actual title.</small>
+                                       <small>Use this instead of CV name during post-processing / renaming</small>
                                    </div>
 
                                    <div class="row">
@@ -438,8 +438,8 @@
                                        <input type="text" name="torrentid_32p" placeholder="torrent id #" value="${comicConfig['torrentid_32p']}" size="40">
                                    </div>
                                    %endif
+                             <span style="position:absolute;float:right;right:30px;bottom:25px;"><input type="submit" value="Update"/></span>
                         </fieldset>
-                     <input type="submit" style="float:right;bottom:20px;" value="Update"/>
                 </form>
                </td>
              </tr>
@@ -719,6 +719,10 @@
                 $("#issue-box").draggable();
             } else if (action == 'metatag' || action == 'ametatag'){
                 run_single_metatag(issueid, comicid, issuenumber);
+            } else if (action == 'readlistadd'){
+                add2readinglist(issueid);
+            } else if (action == 'downloadissue'){
+                downloadthisissue(issueid);
             } else if (action == 'manqueueit' || action == 'amanqueueit'){
                 if (action == 'amanqueueit'){
                     add_wanted(issueid, comicid, issuenumber, 'want_ann', true);
@@ -841,6 +845,57 @@
                      },
             })).done(function(data) {
                  reload_tables();
+            });
+        }
+
+        function add2readinglist(issueid){
+            $.when($.ajax({
+                 type: "GET",
+                 url: "addtoreadlist",
+                 data: { IssueID: issueid },
+                 success: function(response) {
+                    obj = JSON.parse(response);
+                    $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>"+obj['message']+"</div>");
+                    if (obj['status'] == 'success'){
+                        $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                    } else {
+                        $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                    }
+                 },
+                 error: function(data)
+                     {
+                       alert('ERROR'+data.responseText);
+                     },
+            })).done(function(data) {
+                 //reload_tables();
+            });
+        }
+        function shizzlemedown(filepath){
+            $.ajax({
+                 type: "GET",
+                 url: "downloadthis",
+                 data: { pathfile: filepath },
+            })
+        }
+        function downloadthisissue(issueid){
+            $.ajax({
+                 type: "GET",
+                 url: "download_checkthis",
+                 data: { issueid: issueid },
+                 success: function(response) {
+                    obj = JSON.parse(response);
+                    $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>"+obj['message']+"</div>");
+                    if (obj['status'] == 'success'){
+                        $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                        shizzlemedown(obj['filepath']);
+                    } else {
+                        $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                    }
+                 },
+                 error: function(data)
+                     {
+                       alert('ERROR'+data.responseText);
+                     },
             });
         }
 
@@ -1612,6 +1667,10 @@
                                    }
                                }
                                displayline += '<a id="listbox" name="listbox" href="#issue-box" class="issue-window">'+issueimg+'</a>';
+                               if (full[3] == 'Downloaded'){
+                                   displayline += '<a id="readlistadd" name="readlistadd" title="Add to Reading List" href="#"><img src="images/glasses-icon.png" height="25" width="25" style="margin:2px 1px 3px 3px;" /></a>';
+                                   displayline += '<a href="downloadthis?issueid='+String(full[4])+'" title="Download this issue"><img src="images/download_icon.png" height="25" width="25" style="margin:2px 1px 3px 3px;" /></a>';
+                               }
                                return displayline;
                            }
                        },

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -849,7 +849,14 @@
                         </fieldset>
                         <fieldset>
                                 <div class="row checkbox left clearfix">
-                                    <input type="checkbox" id="enable_ddl" name="enable_ddl" value=1 ${config['enable_ddl']} /><legend>Enable DDL (GetComics)</legend>
+                                     <input id="enable_ddl" type="checkbox" onclick="initConfigCheckbox($(this));" name="enable_ddl" value="1" ${config['enable_ddl']} /><legend>DDL (Direct Download)</legend>
+                                </div>
+                                <div class="config">
+                                   <div id="ddl_providers">
+                                        <div class="row checkbox left clearfix">
+                                            <input type="checkbox" id="enable_getcomics" name="enable_getcomics" value="1" ${config['enable_getcomics']} /><label>Enable GetComics</label>
+                                       </div>
+                                   </div>
                                 </div>
                         </fieldset>
                         <fieldset>
@@ -1824,6 +1831,35 @@
                         else
                         {
                                 $("#opdscredentials").slideUp();
+                        }
+                });
+
+                if ($("#enable_ddl").is(":checked"))
+                        {
+                                if ( document.getElementById("enable_getcomics").checked == false ){
+                                    document.getElementById("enable_getcomics").checked = true;
+                                    document.getElementById("enable_getcomics").setAttribute("disabled", "disabled");
+                                }
+                                $("#ddl_providers").slideDown();
+                        }
+                else    {
+                                document.getElementById("enable_getcomics").checked = false;
+                                $("#ddl_providers").slideUp();
+                        }
+
+                $("#enable_ddl").click(function(){
+                        if ($("#enable_ddl").is(":checked"))
+                        {
+                                if ( document.getElementById("enable_getcomics").checked == false ){
+                                    document.getElementById("enable_getcomics").checked = true;
+                                    document.getElementById("enable_getcomics").setAttribute("disabled", "disabled");
+                                }
+                                $("#ddl_providers").slideDown();
+                        }
+                        else
+                        {
+                                document.getElementById("enable_getcomics").checked = false;
+                                $("#ddl_providers").slideUp();
                         }
                 });
 
@@ -2828,6 +2864,7 @@
                 initConfigCheckbox("#ddump");
                 initConfigCheckbox("#enable_failed");
                 initConfigCheckbox("#enable_meta");
+                initConfigCheckbox("#enable_ddl");
                 initConfigCheckbox("#zero_level");
                 initConfigCheckbox("#post_processing");
                 initConfigCheckbox("#enable_check_folder");

--- a/data/interfaces/default/manage.html
+++ b/data/interfaces/default/manage.html
@@ -237,11 +237,11 @@
                            %for j in jobs:
                               <%
                                     if j['status'] == 'Paused':
-                                        grade = '#D9150F'
+                                        grade = '#EC7564'
                                     elif j['status'] == 'Waiting':
-                                        grade = '#0F49D9'
+                                        grade = '#52A9EE'
                                     elif j['status'] == 'Running':
-                                        grade = '#55D90F'
+                                        grade = '#7AEE52'
                                %>
                               <tr>
                                 <td id="job" style="width: 50px;text-align: center;">${j['jobname']}</td>

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -1248,8 +1248,8 @@ class FileChecker(object):
         if (any([issue_number is None, series_name is None]) and booktype == 'issue'):
 
             if all([issue_number is None, booktype == 'issue', issue_volume is not None]):
-                logger.fdebug('Possible UNKNOWN TPB/GN/HC detected - no issue number present, no clarification in filename, but volume present with series title')
-                booktype = 'TPB/GN/HC'
+                logger.fdebug('Possible UNKNOWN TPB/GN/HC {One-Shot} detected - no issue number present, no clarification in filename, but volume present with series title')
+                booktype = 'TPB/GN/HC/One-Shot'
             else:
                 logger.fdebug('Cannot parse the filename properly. I\'m going to make note of this filename so that my evil ruler can make it work.')
 

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -25,16 +25,108 @@ import re
 import time
 import datetime
 from bs4 import BeautifulSoup
-import cfscrape
+import requests
 import zipfile
+import json
 import mylar
-from mylar import db, logger, helpers
-
+from mylar import db, logger, helpers, search_filer
 
 class GC(object):
-    def __init__(self, query=None, issueid=None, comicid=None, oneoff=False):
+
+    def cookie_receipt(self, main_url=None):
+        #self.session_path = self.session_path if self.session_path is not None else os.path.join(mylar.CONFIG.SECURE_DIR, ".gc_cookies.dat")
+
+        # if main_url is not None, it's being passed via the test on the config page.
+        flare_test = False
+        if main_url is None:
+            if mylar.CONFIG.ENABLE_FLARESOLVERR:
+                # (ie. http://192.168.2.2:8191/v1 )
+                main_url = mylar.CONFIG.FLARESOLVERR_URL
+            else:
+                main_url = 'https://getcomics.info'
+        else:
+            flare_test = True
+
+        test_success = False
+        if not os.path.exists(self.session_path):
+            logger.fdebug('[GC_Cookie_Creator] GetComics Session cookie does not exist. Attempting to create.')
+
+            if any([mylar.CONFIG.ENABLE_FLARESOLVERR, flare_test is True]):
+                #get the coookies here for use down-below
+                get_cookies = self.session.post(
+                              main_url,
+                              json={'url': 'https://getcomics.info', 'cmd': 'request.get'},
+                              verify=False,
+                              headers=self.flare_headers,
+                              timeout=30,
+                              )
+                if get_cookies.status_code == 200:
+                    try:
+                        gc_json = get_cookies.json()
+                        gc_cookie = gc_json['solution']['cookies']
+                        with open(self.session_path, 'w') as f:
+                            json.dump(gc_cookie, f)
+                    except Exception as e:
+                        logger.warn('[GC_Cookie_Saver] Unable to save cookie to file - will try to recreate later.')
+                    else:
+                        logger.fdebug('[GC_Cookie_Saver] Successfully saved cookie to file.')
+                        for c in gc_cookie:
+                           self.session.cookies.set(name=c['name'], value=c['value'])
+                        test_success = True
+            else:
+                get_cookies = self.session.get(
+                              main_url,
+                              verify=True,
+                              headers=self.headers,
+                              timeout=30,
+                              )
+                if get_cookies.status_code == 200:
+                    try:
+                        gc_cookie = get_cookies.cookies
+                        with open(self.session_path, 'w') as f:
+                            json.dump(gc_cookie, f)
+                    except Exception as e:
+                        logger.warn('[GC_Cookie_Saver] Unable to save cookie to file - will try to recreate later.')
+                    else:
+                        if gc_cookie is not None:
+                            logger.fdebug('[GC_Cookie_Saver] Successfully saved cookie to file.')
+                            for c in gc_cookie:
+                               self.session.cookies.set(name=c['name'], value=c['value'])
+                        test_success = True
+
+        else:
+            logger.fdebug('[GC_Cookie_Loader] GetComics Session cookie found. Attempting to load...')
+            try:
+                with open(self.session_path, 'r') as f:
+                    gc_load = json.load(f)
+                    for c in gc_load:
+                       self.session.cookies.set(name=c['name'], value=c['value'])
+            except Exception as e:
+                logger.warn('[GC_Cookie_Loader] Unable to load cookie from file - will recreate.')
+            else:
+                logger.fdebug('[GC_Cookie_Loader] Successfully loaded cookie from file.')
+                test_success = True
+
+        if flare_test is True:
+            return test_success
+
+    def __init__(self, query=None, issueid=None, comicid=None, oneoff=False, session_path=None, provider_stat=None):
 
         self.valreturn = []
+
+        self.flare_headers = {
+            'Content-type': 'application/json'
+        }
+
+        self.headers = {
+            'Accept-encoding': 'gzip',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1',
+            'Referer': 'https://getcomics.info/',
+        }
+
+        self.session = requests.Session()
+
+        self.session_path = session_path if session_path is not None else os.path.join(mylar.CONFIG.SECURE_DIR, ".gc_cookies.dat")
 
         self.url = 'https://getcomics.info'
 
@@ -56,21 +148,33 @@ class GC(object):
             'Referer': 'https://getcomics.info/',
         }
 
-    def search(self):
-        results = {}
-        resultset = []
-        try:
-            with cfscrape.create_scraper() as s:
-                try:
-                    cf_cookievalue, cf_user_agent = s.get_tokens(
-                        self.url, headers=self.headers
-                   )
-                except Exception as e:
-                    cf_cookievalue = None
-                    cf_user_agent = None
+        self.provider_stat = provider_stat
 
-                for sf in self.search_format:
-                    sf_issue = self.query['issue']
+    def search(self,is_info=None):
+
+        self.cookie_receipt()
+
+        results = {}
+        try:
+            reversed_order = True
+            total_pages = 1
+            pagenumber = 1
+            if is_info is not None:
+                if is_info['chktpb'] == 0:
+                    logger.debug('removing query from loop that accounts for no issue number')
+                else:
+                    self.search_format.insert(0, self.query['comicname'])
+                    logger.debug('setting no issue number query to be first due to no issue number')
+            for sf in self.search_format:
+                resultset = []
+                verified_matches = []
+                sf_issue = self.query['issue']
+                if is_info['chktpb'] == 1 and self.query['comicname'] == sf:
+                    comicname = re.sub(r'[\&\:\?\,\/\-]', '', self.query['comicname'])
+                    comicname = re.sub("\\band\\b", '', comicname, flags=re.I)
+                    comicname = re.sub("\\bthe\\b", '', comicname, flags=re.I)
+                    queryline = re.sub(r'\s+', ' ', comicname)
+                else:
                     if any([self.query['issue'] == 'None', self.query['issue'] is None]):
                         sf_issue = None
                     if sf.count('%s') == 3:
@@ -86,46 +190,72 @@ class GC(object):
                         else:
                             queryline = sf % (self.query['comicname'], sf_issue, self.query['year'])
                     else:
-                        if sf_issue is None:
+                        if sf == self.search_format[4]:
                             splits = sf.split(' ')
                             splits.pop(1)
                             queryline = ' '.join(splits) % (self.query['comicname'])
                         else:
                             queryline = sf % (self.query['comicname'], sf_issue)
 
-                    logger.fdebug('[DDL-QUERY] Query set to: %s' % queryline)
+                logger.fdebug('[DDL-QUERY] Query set to: %s' % queryline)
+                pause_the_search = mylar.CONFIG.DDL_QUERY_DELAY #mylar.search.check_the_search_delay()
+                diff = mylar.search.check_time(self.provider_stat['lastrun']) # only limit the search queries - the other calls should be direct and not as intensive
+                if diff < pause_the_search:
+                    logger.warn('[PROVIDER-SEARCH-DELAY][DDL] Waiting %s seconds before we search again...' % (pause_the_search - int(diff)))
+                    time.sleep(pause_the_search - int(diff))
+                else:
+                    logger.fdebug('[PROVIDER-SEARCH-DELAY][DDL] Last search took place %s seconds ago. We\'re clear...' % (int(diff)))
 
-                    t = s.get(
-                        self.url + '/',
+                if queryline:
+                    gc_url = self.url
+                    if pagenumber != 1 and pagenumber != total_pages:
+                        gc_url = '%s/page/%s' % (self.url, pagenumber)
+                        logger.fdebug('parsing for page %s' % pagenumber)
+                    logger.fdebug('session cookies: %s' % (self.session.cookies,))
+                    t = self.session.get(
+                        gc_url + '/',
                         params={'s': queryline},
                         verify=True,
-                        cookies=cf_cookievalue,
                         headers=self.headers,
                         stream=True,
                         timeout=30,
                     )
 
+                    write_time = time.time()
+                    mylar.search.last_run_check(write={'DDL(GetComics)': {'active': True, 'lastrun': write_time, 'type': 'DDL'}})
+                    self.provider_stat['lastrun'] = write_time
+
                     with open(self.local_filename, 'wb') as f:
                         for chunk in t.iter_content(chunk_size=1024):
-                            if chunk:  # filter out keep-alive new chunks
+                           if chunk:  # filter out keep-alive new chunks
                                 f.write(chunk)
                                 f.flush()
 
-                    for x in self.search_results()['entries']:
-                        bb = next((item for item in resultset if item['link'] == x['link']), None)
-                        try:
-                            if 'Weekly' not in self.query['comicname'] and 'Weekly' in x['title']:
-                                continue
-                            elif bb is None:
-                                resultset.append(x)
-                        except:
-                            resultset.append(x)
-                        else:
+                for x in self.search_results(pagenumber,total_pages)['entries']:
+                    if total_pages != 1:
+                        total_pages = x['total_pages']
+                    if pagenumber != 1:
+                        pagenumber = x['page']
+                    bb = next((item for item in resultset if item['link'] == x['link']), None)
+                    try:
+                        if 'Weekly' not in self.query['comicname'] and 'Weekly' in x['title']:
                             continue
+                        elif bb is None:
+                            resultset.append(x)
+                    except Exception as e:
+                        resultset.append(x)
+                    else:
+                        continue
 
-                    if len(resultset) > 1:
+                if len(resultset) >= 1:
+                    results['entries'] = resultset
+                    sfs = search_filer.search_check()
+                    verified_matches = sfs.checker(results, is_info)
+                    if verified_matches:
+                        logger.fdebug('verified_matches: %s' % (verified_matches,))
                         break
-                    time.sleep(2)
+                logger.fdebug('sleep...%s%s' % (mylar.CONFIG.DDL_QUERY_DELAY, 's'))
+                time.sleep(mylar.CONFIG.DDL_QUERY_DELAY)
 
         except requests.exceptions.Timeout as e:
             logger.warn(
@@ -188,36 +318,31 @@ class GC(object):
 
             return 'no results'
         else:
-            results['entries'] = resultset
-            return results
+            #results['entries'] = resultset
+            return verified_matches
+            #return results
 
     def loadsite(self, id, link):
+        self.cookie_receipt()
+
         title = os.path.join(mylar.CONFIG.CACHE_DIR, 'getcomics-' + id)
-        with cfscrape.create_scraper() as s:
-            try:
-                self.cf_cookievalue, cf_user_agent = s.get_tokens(
-                    link, headers=self.headers
-                )
-            except Exception as e:
-                self.cf_cookievalue = None
-                self.cf_user_agent = None
+        logger.fdebug('now loading info from local html to resolve via url: %s' % link)
 
-            t = s.get(
-                link,
-                verify=True,
-                cookies=self.cf_cookievalue,
-                headers=self.headers,
-                stream=True,
-                timeout=30,
-            )
+        logger.fdebug('session cookies: %s' % (self.session.cookies,))
+        t = self.session.get(
+            link,
+            verify=True,
+            stream=True,
+            timeout=30,
+        )
 
-            with open(title + '.html', 'wb') as f:
-                for chunk in t.iter_content(chunk_size=1024):
-                    if chunk:  # filter out keep-alive new chunks
-                        f.write(chunk)
-                        f.flush()
+        with open(title + '.html', 'wb') as f:
+            for chunk in t.iter_content(chunk_size=1024):
+                if chunk:  # filter out keep-alive new chunks
+                    f.write(chunk)
+                    f.flush()
 
-    def search_results(self):
+    def search_results(self, pagenumber=1, total_pages=1):
         results = {}
         resultlist = []
         soup = BeautifulSoup(open(self.local_filename, encoding='utf-8'), 'html.parser')
@@ -226,6 +351,19 @@ class GC(object):
             strip=True
         )
         logger.info('There are %s results' % re.sub('Articles', '', resultline).strip())
+
+        if pagenumber == 1 and int(re.sub('Articles', '', resultline).strip()) == 12:
+            # get paging (soon)
+            pagelines = soup.findAll("a", {"class": "page-numbers"})
+            logger.fdebug('pagelines: %s' % (pagelines,))
+            if len(pagelines) > 1:
+                page_line = pagelines[len(pagelines)-1]['href']
+                logger.fdebug('page_line: %s' % page_line)
+                pages_ref = urllib.parse.urlsplit(page_line)
+                logger.fdebug('page_url: %s' % (pages_ref,))
+                page_cnt = list(filter(None, pages_ref.path.rsplit('/')))
+                pages = page_cnt[len(page_cnt)-1]
+                logger.fdebug('number of pages: %s' % pages)
 
         for f in soup.findAll("article"):
             id = f['id']
@@ -290,15 +428,9 @@ class GC(object):
             # if it's a pack - remove the issue-range and the possible issue years
             # (cause it most likely will span) and pass thru as separate items
             if pack is True:
-                brackets = re.findall("\(.*?\)", title)
-                for b in brackets:
-                    if issues in b:
-                        title = re.sub(b, '', title).strip()
-                        break
-                if not brackets:
-                    title = re.sub(issues, '', title).strip()
+                title = re.sub(issues, '', title).strip()
                 # kill any brackets in the issue line here.
-                issues = re.sub(r'[\(|\)|\[|\]]', '', issues).strip()
+                issues = re.sub(r'[\(\)\[\]]', '', issues).strip()
                 if title.endswith('#'):
                     title = title[:-1].strip()
             else:
@@ -370,7 +502,9 @@ class GC(object):
                     "link": link,
                     "year": year,
                     "id": re.sub('post-', '', id).strip(),
-                    "site": 'DDL',
+                    "site": 'DDL(GetComics)',
+                    "page": pagenumber,
+                    "total_pages": total_pages,
                 }
             )
 
@@ -384,6 +518,7 @@ class GC(object):
             booktype = comicinfo[0]['booktype']
         except Exception:
             booktype = None
+
         myDB = db.DBConnection()
         series = None
         year = None
@@ -571,6 +706,7 @@ class GC(object):
                 'comicid': self.comicid,
                 'link': x['link'],
                 'mainlink': mainlink,
+                'site': 'DDL(GetComics)',
                 'updated_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M'),
                 'status': 'Queued',
             }
@@ -587,6 +723,7 @@ class GC(object):
                     'issueid': self.issueid,
                     'oneoff': self.oneoff,
                     'id': mod_id,
+                    'site': 'DDL(GetComics)',
                     'resume': None,
                 }
             )
@@ -607,25 +744,19 @@ class GC(object):
 
         myDB = db.DBConnection()
         filename = None
+        self.cookie_receipt()
         try:
-            with cfscrape.create_scraper() as s:
+            with requests.Session() as s:
                 if resume is not None:
                     logger.info(
                         '[DDL-RESUME] Attempting to resume from: %s bytes' % resume
                     )
                     self.headers['Range'] = 'bytes=%d-' % resume
-                try:
-                    cf_cookievalue, cf_user_agent = s.get_tokens(
-                        mainlink, headers=self.headers, timeout=30
-                    )
-                except Exception as e:
-                    cf_cookievalue = None
-                    cf_user_agent = None
 
-                t = s.get(
+                logger.fdebug('session cookies: %s' % (self.session.cookies,))
+                t = self.session.get(
                     link,
                     verify=True,
-                    cookies=cf_cookievalue,
                     headers=self.headers,
                     stream=True,
                     timeout=30,
@@ -644,10 +775,10 @@ class GC(object):
                     if 'run.php-urls' not in link:
                         link = re.sub('run.php-url=', 'run.php-urls', link)
                         link = re.sub('go.php-url=', 'run.php-urls', link)
-                        t = s.get(
+                        logger.fdebug('session cookies: %s' % (self.session.cookies,))
+                        t = self.session.get(
                             link,
                             verify=True,
-                            cookies=cf_cookievalue,
                             headers=self.headers,
                             stream=True,
                             timeout=30,

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3186,8 +3186,9 @@ def ddl_downloader(queue):
                    'updated_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M')}
             myDB.upsert('ddl_info', val, ctrlval)
 
-            ddz = getcomics.GC()
-            ddzstat = ddz.downloadit(item['id'], item['link'], item['mainlink'], item['resume'])
+            if item['site'] == 'DDL(GetComics)':
+                ddz = getcomics.GC()
+                ddzstat = ddz.downloadit(item['id'], item['link'], item['mainlink'], item['resume'])
 
             if ddzstat['success'] is True:
                 tdnow = datetime.datetime.now()
@@ -3607,7 +3608,7 @@ def date_conversion(originaldate):
     hours = (absdiff.days * 24 * 60 * 60 + absdiff.seconds) / 3600.0
     return hours
 
-def job_management(write=False, job=None, last_run_completed=None, current_run=None, status=None):
+def job_management(write=False, job=None, last_run_completed=None, current_run=None, status=None, failure=False):
         jobresults = []
 
         #import db
@@ -3793,7 +3794,12 @@ def job_management(write=False, job=None, last_run_completed=None, current_run=N
                                 jobstore = jbst
                                 break
                             elif job == 'Auto-Search' and 'search' in jb.lower():
-                                nextrun_stamp = utctimestamp() + (mylar.CONFIG.SEARCH_INTERVAL * 60)
+                                if failure is True:
+                                   logger.info('Previous job could not run due to other jobs. Scheduling Auto-Search for 10 minutes from now.')
+                                   s_interval = (10 * 60)
+                                else:
+                                   s_interval = mylar.CONFIG.SEARCH_INTERVAL * 60
+                                nextrun_stamp = utctimestamp() + s_interval
                                 jobstore = jbst
                                 break
                             elif job == 'RSS Feeds' and 'rss' in jb.lower():

--- a/mylar/readinglist.py
+++ b/mylar/readinglist.py
@@ -49,7 +49,7 @@ class Readinglist(object):
             readlist = myDB.selectone("SELECT * from annuals where IssueID=?", [self.IssueID]).fetchone()
             if readlist is None:
                 logger.error(self.module + ' Cannot locate IssueID - aborting..')
-                return
+                return {'status': 'failure', 'message': 'Unable to locate issue in database. Does it exist?'}
             else:
                 logger.fdebug('%s Successfully found annual for %s' % (self.module, readlist['ComicID']))
                 annualize = True
@@ -57,6 +57,7 @@ class Readinglist(object):
         logger.info(self.module + ' Attempting to add issueid ' + readlist['IssueID'])
         if comicinfo is None:
             logger.info(self.module + ' Issue not located on your current watchlist. I should probably check story-arcs but I do not have that capability just yet.')
+            return {'status': 'failure', 'message': 'Unable to locate issue in your watchlist. Does it exist?'}
         else:
             locpath = None
             if all([mylar.CONFIG.MULTIPLE_DEST_DIRS is not None, mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None']):
@@ -102,7 +103,7 @@ class Readinglist(object):
 
                 myDB.upsert("readlist", newval, ctrlval)
                 logger.info(self.module + ' Added ' + dspinfo + ' to the Reading list.')
-        return
+        return {'status': 'success', 'message': 'Successfully added %s to your reading list' % dspinfo}
 
     def markasRead(self, IssueID=None, IssueArcID=None):
         myDB = db.DBConnection()

--- a/mylar/search_filer.py
+++ b/mylar/search_filer.py
@@ -1,0 +1,1046 @@
+
+import re
+import email.utils
+import datetime
+import time
+from wsgiref.handlers import format_date_time
+
+import mylar
+from mylar import logger, filechecker, helpers, search
+
+
+class search_check(object):
+
+    def __init__(self):
+        pass
+
+
+    def checker(self, entries, is_info=None):
+        mylar.COMICINFO = []
+        hold_the_matches = []
+        if is_info:
+            ComicName = is_info['ComicName']
+            nzbprov = is_info['nzbprov']
+            RSS = is_info['RSS']
+            UseFuzzy = is_info['UseFuzzy']
+            StoreDate = is_info['StoreDate']
+            IssueDate = is_info['IssueDate']
+            digitaldate = is_info['digitaldate']
+            booktype = is_info['booktype']
+            ignore_booktype = is_info['ignore_booktype']
+            SeriesYear = is_info['SeriesYear']
+            ComicVersion = is_info['ComicVersion']
+            IssDateFix = is_info['IssDateFix']
+            ComicYear = comyear = is_info['ComicYear']
+            IssueID = is_info['IssueID']
+            ComicID = is_info['ComicID']
+            IssueNumber = is_info['IssueNumber']
+            manual = is_info['manual']
+            newznab_host = is_info['newznab_host']
+            torznab_host = is_info['torznab_host']
+            oneoff = is_info['oneoff']
+            tmpprov = is_info['tmpprov']
+            SARC = is_info['SARC']
+            IssueArcID = is_info['IssueArcID']
+            cmloopit = is_info['cmloopit']
+            findcomiciss = is_info['findcomiciss']
+            intIss = is_info['intIss']
+            chktpb = is_info['chktpb']
+            provider_stat = is_info['provider_stat']
+
+        logger.info('entries: %s' % (entries,))
+        for entry in entries['entries']:
+                alt_match = False
+                logger.fdebug('entry: %s' % (entry,))
+                # brief match here against 32p since it returns the direct issue number
+
+                logger.fdebug("checking search result: %s" % entry['title'])
+                # some nzbsites feel that comics don't deserve a nice regex to strip
+                # the crap from the header, the end result is that we're dealing with
+                # the actual raw header which causes incorrect matches below. This is a
+                # temporary cut from the experimental search option (findcomicfeed) as
+                # it does this part well usually.
+                except_list = [
+                    'releases',
+                    'gold line',
+                    'distribution',
+                    '0-day',
+                    '0 day',
+                ]
+                splitTitle = entry['title'].split("\"")
+                _digits = re.compile(r'\d')
+
+                ComicTitle = entry['title']
+                for subs in splitTitle:
+                    logger.fdebug('sub: %s' % subs)
+                    try:
+                        if (
+                            len(subs) >= len(ComicName.split())
+                            and not any(d in subs.lower() for d in except_list)
+                            and bool(_digits.search(subs)) is True
+                        ):
+                            if subs.lower().startswith('for'):
+                                if ComicName.lower().startswith('for'):
+                                    pass
+                                else:
+                                    # this is the crap we ignore. Continue
+                                    continue
+                                logger.fdebug(
+                                    'Detected crap within header. Ignoring this portion'
+                                    ' of the result in order to see if it\'s a valid'
+                                    ' match.'
+                                )
+                            ComicTitle = subs
+                            break
+                    except Exception:
+                        break
+
+                comsize_m = 0
+                if nzbprov != "dognzb":
+                    # rss for experimental doesn't have the size constraints embedded.
+                    # So we do it here.
+                    if RSS == "yes":
+                        comsize_b = entry['length']
+                    else:
+                        # Experimental already has size constraints done.
+                        if nzbprov == 'experimental':
+                            # we only want the size from the rss as
+                            # the search/api has it already.
+                            comsize_b = entry['length']
+                        else:
+                            try:
+                                if entry['site'] == 'DDL(GetComics)':
+                                    comsize_b = entry['size']
+                                    if comsize_b is not None:
+                                        cb2 = re.sub(r'[^0-9]', '', comsize_b).strip()
+                                        if cb2 == '':
+                                            logger.warn(
+                                                'Invalid filesize encountered. Ignoring'
+                                            )
+                                            comsize_b = None
+                                        else:
+                                            comsize_b = helpers.human2bytes(entry['size'])
+                            except Exception:
+                                tmpsz = entry.enclosures[0]
+                                comsize_b = tmpsz['length']
+
+                    logger.fdebug('comsize_b: %s' % comsize_b)
+                    # file restriction limitation here
+                    # Experimental (has it embeded in search and rss checks)
+
+                    if comsize_b is None or comsize_b == '0':
+                        logger.fdebug(
+                            'Size of file cannot be retrieved.'
+                            ' Ignoring size-comparison and continuing.'
+                        )
+                        # comsize_b = 0
+                    else:
+                        if entry['title'][:17] != '0-Day Comics Pack':
+                            comsize_m = helpers.human_size(comsize_b)
+                            logger.fdebug('size given as: %s' % comsize_m)
+                            # ----size constraints.
+                            # if it's not within size constaints - dump it now.
+                            if mylar.CONFIG.USE_MINSIZE:
+                                conv_minsize = helpers.human2bytes(
+                                    mylar.CONFIG.MINSIZE + "M"
+                                )
+                                logger.fdebug(
+                                    'comparing Min threshold %s .. to .. nzb %s'
+                                    % (conv_minsize, comsize_b)
+                                )
+                                if int(conv_minsize) > int(comsize_b):
+                                    logger.fdebug(
+                                        'Failure to meet the Minimum size threshold'
+                                        ' - skipping'
+                                    )
+                                    continue
+                            if mylar.CONFIG.USE_MAXSIZE:
+                                conv_maxsize = helpers.human2bytes(
+                                    mylar.CONFIG.MAXSIZE + "M"
+                                )
+                                logger.fdebug(
+                                    'comparing Max threshold %s .. to .. nzb %s'
+                                    % (conv_maxsize, comsize_b)
+                                )
+                                if int(comsize_b) > int(conv_maxsize):
+                                    logger.fdebug(
+                                        'Failure to meet the Maximium size threshold'
+                                        ' - skipping'
+                                    )
+                                    continue
+
+                if mylar.CONFIG.IGNORE_COVERS is True:
+                    cvrchk = re.sub(r'[\s\s+\_\.]', '', entry['title']).lower()
+                    if any(['coversonly' in cvrchk, 'coveronly' in cvrchk]):
+                        logger.fdebug('Cover(s) only detected. Ignoring result.')
+                        continue
+
+                # ---- date constaints.
+                # if the posting date is prior to the publication date,
+                # dump it and save the time.
+                # logger.fdebug('entry: %s' % entry)
+                if nzbprov == 'experimental':
+                    pubdate = entry['pubdate']
+                else:
+                    try:
+                        pubdate = entry['updated']
+                    except Exception:
+                        try:
+                            pubdate = entry['pubdate']
+                        except Exception as e:
+                            logger.fdebug(
+                                'Invalid date found. Unable to continue'
+                                ' - skipping result. Error returned: %s' % e
+                            )
+                            continue
+
+                if UseFuzzy == "1":
+                    logger.fdebug(
+                        'Year has been fuzzied for this series,'
+                        ' ignoring store date comparison entirely.'
+                    )
+                    postdate_int = None
+                    issuedate_int = None
+                else:
+                    # use store date instead of publication date for comparisons since
+                    # publication date is usually +2 months
+                    if StoreDate is None or StoreDate == '0000-00-00':
+                        if IssueDate is None or IssueDate == '0000-00-00':
+                            logger.fdebug(
+                                'Invalid store date & issue date detected - you'
+                                ' probably should refresh the series or wait for CV'
+                                ' to correct the data'
+                            )
+                            continue
+                        else:
+                            stdate = IssueDate
+                        logger.fdebug('issue date used is : %s' % stdate)
+                    else:
+                        stdate = StoreDate
+                        logger.fdebug('store date used is : %s' % stdate)
+                    logger.fdebug('date used is : %s' % stdate)
+
+                    postdate_int = None
+                    if all(['DDL' in nzbprov, len(pubdate) == 10]):
+                        postdate_int = pubdate
+                        logger.fdebug(
+                            '[%s] postdate_int (%s): %s'
+                            % (nzbprov, type(postdate_int), postdate_int)
+                        )
+                    if any(
+                        [postdate_int is None, type(postdate_int) != int]
+                    ) or not RSS == 'no':
+                        # convert it to a tuple
+                        dateconv = email.utils.parsedate_tz(pubdate)
+
+                        try:
+                            dateconv2 = datetime.datetime(*dateconv[:6])
+                        except TypeError as e:
+                            logger.warn(
+                                'Unable to convert timestamp from : %s [%s]'
+                                % ((dateconv,), e)
+                            )
+                        try:
+                            # convert it to a numeric time, then subtract the
+                            # timezone difference (+/- GMT)
+                            if dateconv[-1] is not None:
+                                postdate_int = (
+                                    time.mktime(dateconv[: len(dateconv) - 1])
+                                    - dateconv[-1]
+                                )
+                            else:
+                                postdate_int = time.mktime(
+                                    dateconv[: len(dateconv) - 1]
+                                )
+                        except Exception as e:
+                            logger.warn(
+                                'Unable to parse posting date from provider result set'
+                                ' for : %s. Error returned: %s' % (entry['title'], e)
+                            )
+                            continue
+
+                    if all([digitaldate != '0000-00-00', digitaldate is not None]):
+                        i = 0
+                    else:
+                        digitaldate_int = '00000000'
+                        i = 1
+
+                    while i <= 1:
+                        if i == 0:
+                            usedate = digitaldate
+                        else:
+                            usedate = stdate
+                        logger.fdebug('usedate: %s' % usedate)
+                        # convert it to a Thu, 06 Feb 2014 00:00:00 format
+                        issue_converted = datetime.datetime.strptime(
+                            usedate.rstrip(), '%Y-%m-%d'
+                        )
+                        issue_convert = issue_converted + datetime.timedelta(days=-1)
+                        # to get past different locale's os-dependent dates, let's
+                        # convert it to a generic datetime format
+                        try:
+                            stamp = time.mktime(issue_convert.timetuple())
+                            issconv = format_date_time(stamp)
+                        except OverflowError as e:
+                            logger.fdebug(
+                                'Error converting the timestamp into a generic format:'
+                                ' %s' % e
+                            )
+                            issconv = issue_convert.strftime('%a, %d %b %Y %H:%M:%S')
+                        # convert it to a tuple
+                        econv = email.utils.parsedate_tz(issconv)
+                        econv2 = datetime.datetime(*econv[:6])
+                        # convert it to a numeric and drop the GMT/Timezone
+                        try:
+                            usedate_int = time.mktime(econv[: len(econv) - 1])
+                        except OverflowError:
+                            logger.fdebug(
+                                'Unable to convert timestamp to integer format.'
+                                ' Forcing things through.'
+                            )
+                            isyear = econv[1]
+                            epochyr = '1970'
+                            if int(isyear) <= int(epochyr):
+                                tm = datetime.datetime(1970, 1, 1)
+                                try:
+                                    usedate_int = int(time.mktime(tm.timetuple()))
+                                except Exception as e:
+                                    logger.warn(
+                                        '[%s] Failed to convert tm of [%s]' % (e,tm)
+                                    )
+                                    logger.fdebug('issconv: %s' % issconv)
+                                    diff = issue_convert - tm
+                                    logger.fdebug('diff: %s' % diff)
+                                    usedate_int = diff.total_seconds()
+                            else:
+                                continue
+                        if i == 0:
+                            digitaldate_int = usedate_int
+                            digconv2 = econv2
+                        else:
+                            issuedate_int = usedate_int
+                            issconv2 = econv2
+                        i += 1
+
+                    try:
+                        # try new method to get around issues populating in a diff
+                        # timezone thereby putting them in a different day.
+                        # logger.info('digitaldate: %s' % digitaldate)
+                        # logger.info('dateconv2: %s' % dateconv2.date())
+                        # logger.info('digconv2: %s' % digconv2.date())
+                        if (
+                            digitaldate != '0000-00-00'
+                            and dateconv2.date() >= digconv2.date()
+                        ):
+                            logger.fdebug(
+                                '%s is after DIGITAL store date of %s'
+                                % (pubdate, digitaldate)
+                            )
+                        elif dateconv2.date() < issconv2.date():
+                            logger.fdebug(
+                                '[CONV] pubdate: %s  < storedate: %s'
+                                % (dateconv2.date(), issconv2.date())
+                            )
+                            logger.fdebug(
+                                '%s is before store date of %s. Ignoring search result'
+                                ' as this is not the right issue.'
+                                % (pubdate, stdate)
+                            )
+                            continue
+                        else:
+                            logger.fdebug(
+                                '[CONV] %s is after store date of %s'
+                                % (pubdate, stdate)
+                            )
+                    except Exception:
+                        # if the above fails, drop down to the integer compare method
+                        # as a failsafe.
+                        if (
+                            digitaldate != '0000-00-00'
+                            and postdate_int >= digitaldate_int
+                        ):
+                            logger.fdebug(
+                                '%s is after DIGITAL store date of %s'
+                                % (pubdate, digitaldate)
+                            )
+                        elif postdate_int < issuedate_int:
+                            logger.fdebug(
+                                '[INT]pubdate: %s  < storedate: %s'
+                                % (postdate_int, issuedate_int)
+                            )
+                            logger.fdebug(
+                                '%s is before store date of %s. Ignoring search result'
+                                ' as this is not the right issue.'
+                                % (pubdate, stdate)
+                            )
+                            continue
+                        else:
+                            logger.fdebug(
+                                '[INT] %s is after store date of %s' % (pubdate, stdate)
+                            )
+                # -- end size constaints.
+                if '(digital first)' in ComicTitle.lower():
+                    dig_moving = re.sub(
+                        r'\(digital first\)', '', ComicTitle.lower()
+                    ).strip()
+                    dig_moving = re.sub(r'[\s+]', ' ', dig_moving)
+                    dig_mov_end = '%s (Digital First)' % dig_moving
+                    thisentry = dig_mov_end
+                else:
+                    thisentry = ComicTitle
+
+                logger.fdebug('Entry: %s' % thisentry)
+                cleantitle = thisentry
+
+                if 'mixed format' in cleantitle.lower():
+                    cleantitle = re.sub('mixed format', '', cleantitle).strip()
+                    logger.fdebug(
+                        'removed extra information after issue # that'
+                        ' is not necessary: %s' % cleantitle
+                    )
+
+                # send it to the parser here.
+                p_comic = filechecker.FileChecker(file=ComicTitle, watchcomic=ComicName)
+                parsed_comic = p_comic.listFiles()
+
+                logger.fdebug('parsed_info: %s' % parsed_comic)
+                logger.fdebug(
+                    'booktype: %s / parsed_booktype: %s [ignore_booktype: %s]'
+                    % (booktype, parsed_comic['booktype'], ignore_booktype)
+                )
+                if parsed_comic['parse_status'] == 'success' and (
+                    all([booktype is None, parsed_comic['booktype'] == 'issue'])
+                    or all([booktype == 'Print', parsed_comic['booktype'] == 'issue'])
+                    or all(
+                        [booktype == 'One-Shot', any(
+                            [parsed_comic['booktype'] == 'issue',
+                            'One-Shot' in parsed_comic['booktype']
+                             ]
+                        )
+                        ]
+                    )
+                    or all(
+                        [booktype != parsed_comic['booktype'], ignore_booktype is True]
+                    )
+                    or booktype in parsed_comic['booktype']
+                ):
+                    try:
+                        fcomic = filechecker.FileChecker(watchcomic=ComicName)
+                        filecomic = fcomic.matchIT(parsed_comic)
+                    except Exception as e:
+                        logger.error('[PARSE-ERROR]: %s' % e)
+                        continue
+                    else:
+                        logger.fdebug('match_check: %s' % filecomic)
+                        if filecomic['process_status'] == 'fail':
+                            logger.fdebug(
+                                '%s was not a match to %s (%s)'
+                                % (cleantitle, ComicName, SeriesYear)
+                            )
+                            continue
+                        elif filecomic['process_status'] == 'alt_match':
+                            # if it's an alternate series match, we'll retain each value
+                            # until the search has compeletely run, compiling matches.
+                            # If at any point it's a standard match (ie. non-alternate
+                            # series) that will be accepted as the one match and
+                            # ignore the alts. Once all the search options have been
+                            # exhausted and no matches aside from alternate series then
+                            # we go get the best result from that list
+                            logger.fdebug(
+                                '%s was a match due to alternate matching.  Continuing'
+                                ' to search, but retaining this result just in case.'
+                                % ComicTitle
+                            )
+                            alt_match = True
+                elif booktype != parsed_comic['booktype'] and ignore_booktype is False:
+                    logger.fdebug(
+                        'Booktypes do not match. Looking for %s, this is a %s.'
+                        ' Ignoring this result.' % (booktype, parsed_comic['booktype'])
+                    )
+                    continue
+                else:
+                    logger.fdebug(
+                        'Unable to parse name properly: %s. Ignoring this result'
+                        % parsed_comic
+                    )
+                    continue
+
+                # adjust for covers only by removing them entirely...
+                vers4year = "no"
+                vers4vol = "no"
+                versionfound = "no"
+
+                if ComicVersion:
+                    ComVersChk = re.sub("[^0-9]", "", ComicVersion)
+                    if ComVersChk == '' or ComVersChk == '1':
+                        ComVersChk = 0
+                else:
+                    ComVersChk = 0
+
+                fndcomicversion = None
+
+                if parsed_comic['series_volume'] is not None:
+                    versionfound = "yes"
+                    if len(parsed_comic['series_volume'][1:]) == 4 and (
+                        parsed_comic['series_volume'][1:].isdigit()
+                    ):  # v2013
+                        logger.fdebug(
+                            "[Vxxxx] Version detected as %s"
+                            % (parsed_comic['series_volume'])
+                        )
+                        vers4year = "yes"
+                        fndcomicversion = parsed_comic['series_volume']
+                    elif len(parsed_comic['series_volume'][1:]) == 1 and (
+                        parsed_comic['series_volume'][1:].isdigit()
+                    ):  # v2
+                        logger.fdebug(
+                            "[Vx] Version detected as %s"
+                            % parsed_comic['series_volume']
+                        )
+                        vers4vol = parsed_comic['series_volume']
+                        fndcomicversion = parsed_comic['series_volume']
+                    elif (
+                        parsed_comic['series_volume'][1:].isdigit()
+                        and len(parsed_comic['series_volume']) < 4
+                    ):
+                        logger.fdebug(
+                            '[Vxxx] Version detected as %s'
+                            % parsed_comic['series_volume']
+                        )
+                        vers4vol = parsed_comic['series_volume']
+                        fndcomicversion = parsed_comic['series_volume']
+                    elif (
+                        parsed_comic['series_volume'].isdigit()
+                        and len(parsed_comic['series_volume']) <= 4
+                    ):
+                        # this stuff is necessary for 32P volume manipulation
+                        if len(parsed_comic['series_volume']) == 4:
+                            vers4year = "yes"
+                            fndcomicversion = parsed_comic['series_volume']
+                        elif len(parsed_comic['series_volume']) == 1:
+                            vers4vol = parsed_comic['series_volume']
+                            fndcomicversion = parsed_comic['series_volume']
+                        elif len(parsed_comic['series_volume']) < 4:
+                            vers4vol = parsed_comic['series_volume']
+                            fndcomicversion = parsed_comic['series_volume']
+                        else:
+                            logger.fdebug(
+                                "error - unknown length for : %s"
+                                % parsed_comic['series_volume']
+                            )
+
+                logger.info('here')
+                yearmatch = "false"
+                if vers4vol != "no" or vers4year != "no":
+                    logger.fdebug(
+                        'Series Year not provided but Series Volume detected of %s.'
+                        ' Bypassing Year Match.'
+                        % fndcomicversion
+                    )
+                    yearmatch = "true"
+                elif ComVersChk == 0 and parsed_comic['issue_year'] is None:
+                    logger.fdebug(
+                        'Series version detected as V1 (only series in existance with'
+                        ' that title). Bypassing Year/Volume check'
+                    )
+                    yearmatch = "true"
+                elif (
+                    any(
+                        [
+                            UseFuzzy == "0",
+                            UseFuzzy == "2",
+                            UseFuzzy is None,
+                            IssDateFix != "no",
+                        ]
+                    )
+                    and parsed_comic['issue_year'] is not None
+                ):
+                    if any(
+                        [
+                            parsed_comic['issue_year'][:-2] == '19',
+                            parsed_comic['issue_year'][:-2] == '20',
+                        ]
+                    ):
+                        if str(comyear) == parsed_comic['issue_year']:
+                            logger.fdebug('%s - right years match baby!' % comyear)
+                            yearmatch = "true"
+                        else:
+                            logger.fdebug(
+                                '%s - not right - years do not match' % comyear
+                            )
+                            yearmatch = "false"
+                            if UseFuzzy == "2":
+                                # Fuzzy the year +1 and -1
+                                ComUp = int(ComicYear) + 1
+                                ComDwn = int(ComicYear) - 1
+                                if (
+                                    str(ComUp) in parsed_comic['issue_year']
+                                    or str(ComDwn) in parsed_comic['issue_year']
+                                ):
+                                    logger.fdebug(
+                                        'Fuzzy Logicd the Year and matched to a year'
+                                        ' of %s' % parsed_comic['issue_year']
+                                    )
+                                    yearmatch = "true"
+                                else:
+                                    logger.fdebug(
+                                        '%s Fuzzy logicd the Year and year still did'
+                                        ' not match.' % comyear
+                                    )
+                            # let's do this here and save a few extra loops ;)
+                            # fix for issue dates between Nov-Dec/Jan
+                            if IssDateFix != "no" and UseFuzzy != "2":
+                                if (
+                                    IssDateFix == "01"
+                                    or IssDateFix == "02"
+                                    or IssDateFix == "03"
+                                ):
+                                    ComicYearFix = int(ComicYear) - 1
+                                    if str(ComicYearFix) in parsed_comic['issue_year']:
+                                        logger.fdebug(
+                                            'Further analysis reveals this was'
+                                            ' published inbetween Nov-Jan, decreasing'
+                                            ' year to %s has resulted in a match!'
+                                            % ComicYearFix
+                                        )
+                                        yearmatch = "true"
+                                    else:
+                                        logger.fdebug(
+                                            '%s- not the right year.' % comyear
+                                        )
+                                else:
+                                    ComicYearFix = int(ComicYear) + 1
+                                    if str(ComicYearFix) in parsed_comic['issue_year']:
+                                        logger.fdebug(
+                                            'Further analysis reveals this was'
+                                            ' published inbetween Nov-Jan, incrementing'
+                                            ' year to %s has resulted in a match!'
+                                            % ComicYearFix
+                                        )
+                                        yearmatch = "true"
+                                    else:
+                                        logger.fdebug(
+                                            '%s - not the right year.' % comyear
+                                        )
+                elif UseFuzzy == "1":
+                    yearmatch = "true"
+
+                if yearmatch == "false":
+                    continue
+
+                annualize = "false"
+                if 'annual' in ComicName.lower():
+                    logger.fdebug(
+                        "IssueID of : %s This is an annual...let's adjust." % IssueID
+                    )
+                    annualize = "true"
+
+                F_ComicVersion = None
+
+                if versionfound == "yes":
+                    logger.fdebug("volume detection commencing - adjusting length.")
+                    logger.fdebug("watch comicversion is %s" % ComicVersion)
+                    logger.fdebug("version found: %s" % fndcomicversion)
+                    logger.fdebug("vers4year: %s" % vers4year)
+                    logger.fdebug("vers4vol: %s" % vers4vol)
+
+                    if vers4year != "no" or vers4vol != "no":
+                        # if the volume is None, assume it's a V1 to increase % hits
+                        if ComVersChk == 0:
+                            D_ComicVersion = 1
+                        else:
+                            D_ComicVersion = ComVersChk
+
+                    # if this is a one-off, SeriesYear will be None and cause errors.
+                    if SeriesYear is None:
+                        S_ComicVersion = 0
+                    else:
+                        S_ComicVersion = str(SeriesYear)
+
+                    F_ComicVersion = re.sub("[^0-9]", "", fndcomicversion)
+                    # if found volume is a vol.0, up it to vol.1 (since there is no V0)
+                    if F_ComicVersion == '0':
+                        # need to convert dates to just be yyyy-mm-dd and do comparison,
+                        # time operator in the below calc
+                        F_ComicVersion = '1'
+
+                    logger.fdebug('FCVersion: %s' % F_ComicVersion)
+                    logger.fdebug('DCVersion: %s' % D_ComicVersion)
+                    logger.fdebug('SCVersion: %s' % S_ComicVersion)
+
+                    # here's the catch, sometimes annuals get posted as the Pub Year
+                    # instead of the Series they belong to (V2012 vs V2013)
+                    if annualize == "true" and int(ComicYear) == int(F_ComicVersion):
+                        logger.fdebug(
+                            "We matched on versions for annuals %s" % fndcomicversion
+                        )
+                    elif all(
+                            [
+                                 booktype != 'TPB',
+                                 booktype != 'HC',
+                                 booktype != 'GN',
+                            ]
+                        ) and (
+                            int(F_ComicVersion) == int(D_ComicVersion)
+                            or int(F_ComicVersion) == int(S_ComicVersion)
+                    ):
+                        logger.fdebug("We matched on versions...%s" % fndcomicversion)
+                    else:
+                        if any(
+                               [
+                                   booktype == 'TPB',
+                                   booktype == 'HC',
+                                   booktype == 'GN',
+                               ]
+                            ) and (
+                                int(F_ComicVersion) == int(findcomiciss)
+                                and filecomic['justthedigits'] is None
+                        ):
+                            logger.fdebug(
+                                '%s detected - reassigning volume %s to match as the'
+                                ' issue number based on Volume'
+                                % (booktype, fndcomicversion)
+                            )
+                        elif all(
+                                 [
+                                     booktype == 'TPB',
+                                     booktype == 'HC',
+                                     booktype == 'GN',
+                                 ]
+                            ) and all(
+                            [
+                                int(F_ComicVersion) == int(findcomiciss),
+                                fndcomicversion is not None,
+                                booktype in filecomic['booktype'],
+                                filecomic['justthedigits'] is None,
+                            ]
+                        ):
+                            logger.fdebug(
+                                '%s detected - reassigning volume %s to match as the issue number'
+                                % (booktype, fndcomicversion)
+                            )
+                        else:
+                            logger.fdebug("Versions wrong. Ignoring possible match.")
+                            continue
+
+                downloadit = False
+
+                try:
+                    pack_test = entry['pack']
+                except Exception:
+                    pack_test = False
+
+
+                if all(['DDL' in nzbprov, pack_test is True]):
+                    logger.fdebug(
+                        '[PACK-QUEUE] %s Pack detected for %s.'
+                        % (nzbprov, entry['filename'])
+                    )
+
+                    # find the pack range.
+                    pack_issuelist = None
+                    issueid_info = None
+                    try:
+                        if not entry['title'].startswith('0-Day Comics Pack'):
+                            pack_issuelist = entry['issues']
+                            issueid_info = helpers.issue_find_ids(
+                                ComicName, ComicID, pack_issuelist, IssueNumber
+                            )
+                            if issueid_info['valid'] is True:
+                                logger.info(
+                                    'Issue Number %s exists within pack. Continuing.'
+                                    % IssueNumber
+                                )
+                            else:
+                                logger.fdebug(
+                                    'Issue Number %s does NOT exist within this pack.'
+                                    ' Skipping' % IssueNumber
+                                )
+                                continue
+                    except Exception as e:
+                        logger.error(
+                            'Unable to identify pack range for %s. Error returned: %s'
+                            % (entry['title'], e)
+                        )
+                        continue
+                    # pack support.
+                    nowrite = False
+                    if 'DDL' in nzbprov:
+                        if 'getcomics' in entry['link']:
+                            nzbid = entry['id']
+                    else:
+                        nzbid = search.generate_id(provider_stat, entry['link'])
+                    if all([manual is not True, alt_match is False]):
+                        downloadit = True
+                    else:
+                        for x in mylar.COMICINFO:
+                            if (
+                                all(
+                                    [
+                                        x['link'] == entry['link'],
+                                        x['tmpprov'] == tmpprov,
+                                    ]
+                                )
+                                or all(
+                                    [x['nzbid'] == nzbid, x['newznab'] == newznab_host]
+                                )
+                                or all(
+                                    [x['nzbid'] == nzbid, x['torznab'] == torznab_host]
+                                )
+                            ):
+                                nowrite = True
+                                break
+
+                    if nowrite is False:
+                        if any(
+                            [
+                                nzbprov == 'dognzb',
+                                nzbprov == 'nzb.su',
+                                nzbprov == 'experimental',
+                                'newznab' in nzbprov,
+                            ]
+                        ):
+                            tprov = nzbprov
+                            kind = 'usenet'
+                            if newznab_host is not None:
+                                tprov = newznab_host[0]
+                        else:
+                            tprov = nzbprov
+                            kind = 'torrent'
+                            if torznab_host is not None:
+                                tprov = torznab_host[0]
+
+                        search_values = {
+                            "ComicName": ComicName,
+                            "ComicID": ComicID,
+                            "IssueID": IssueID,
+                            "ComicVolume": ComicVersion,
+                            "IssueNumber": IssueNumber,
+                            "IssueDate": IssueDate,
+                            "comyear": comyear,
+                            "pack": True,
+                            "pack_numbers": pack_issuelist,
+                            "pack_issuelist": issueid_info,
+                            "modcomicname": entry['title'],
+                            "oneoff": oneoff,
+                            "nzbprov": nzbprov,
+                            "nzbtitle": entry['title'],
+                            "nzbid": nzbid,
+                            "provider": tprov,
+                            "link": entry['link'],
+                            "pubdate": pubdate,
+                            "size": comsize_m,
+                            "tmpprov": tmpprov,
+                            "kind": kind,
+                            "SARC": SARC,
+                            "booktype": booktype,
+                            "IssueArcID": IssueArcID,
+                            "newznab": newznab_host,
+                            "torznab": torznab_host,
+                            "downloadit": downloadit,
+                            "ComicTitle": ComicTitle,
+                            "entry": entry,
+                            "provider_stat": provider_stat,
+                        }
+
+                        mylar.COMICINFO.append(search_values)
+
+                        hold_the_matches.append(search_values)
+
+                else:
+                    if filecomic['process_status'] == 'match':
+                        if cmloopit != 4:
+                            logger.fdebug(
+                                "issue we are looking for is : %s" % findcomiciss
+                            )
+                            logger.fdebug(
+                                "integer value of issue we are looking for : %s"
+                                % intIss
+                            )
+                        else:
+                            if intIss is None and all(
+                                [
+                                    booktype == 'One-Shot',
+                                    helpers.issuedigits(parsed_comic['issue_number'])
+                                    == 1000,
+                                ]
+                            ):
+                                intIss = 1000
+                            else:
+                                intIss = 9999999999
+                        if filecomic['justthedigits'] is not None:
+                            logger.fdebug(
+                                "issue we found for is : %s"
+                                % filecomic['justthedigits']
+                            )
+                            comintIss = helpers.issuedigits(filecomic['justthedigits'])
+                            logger.fdebug(
+                                "integer value of issue we have found : %s" % comintIss
+                            )
+                        else:
+                            comintIss = 11111111111
+
+                        # do this so that we don't touch the actual value but just
+                        # use it for comparisons
+                        if filecomic['justthedigits'] is None:
+                            pc_in = None
+                        else:
+                            pc_in = helpers.issuedigits(filecomic['justthedigits'])
+                        # issue comparison now as well
+                        if (
+                            all([intIss is not None, comintIss is not None])
+                            and int(intIss) == int(comintIss)
+                            or (any(
+                                [
+                                    filecomic['booktype'] == 'TPB',
+                                    filecomic['booktype'] == 'GN',
+                                    filecomic['booktype'] == 'HC',
+                                    filecomic['booktype'] == 'TPB/GN/HC',
+                                ]
+                                ) and all(
+                                    [
+                                        chktpb != 0,
+                                        pc_in is None,
+                                        helpers.issuedigits(F_ComicVersion) == intIss,
+                                    ]
+                            ))
+                            or (any(
+                                [
+                                    filecomic['booktype'] == 'TPB',
+                                    filecomic['booktype'] == 'GN',
+                                    filecomic['booktype'] == 'HC',
+                                    filecomic['booktype'] == 'TPB/GN/HC',
+                                ]
+                                )  and all(
+                                    [
+                                        chktpb == 2,
+                                        pc_in is None,
+                                        cmloopit == 1,
+                                    ]
+                            ))
+                            or all([cmloopit == 4, findcomiciss is None, pc_in is None])
+                            or all([cmloopit == 4, findcomiciss is None, pc_in == 1])
+                        ):
+                            nowrite = False
+                            logger.info('[nzbprov:%s] provider_stat: %s' % (nzbprov, provider_stat,))
+                            if nzbprov == 'torznab' or provider_stat['type'] == 'torznab':
+                                nzbid = search.generate_id(provider_stat, entry['id'])
+                            elif 'DDL' in nzbprov:
+                                if 'GetComics' in nzbprov:
+                                    if RSS == "yes":
+                                        entry['id'] = entry['link']
+                                        entry['link'] = 'https://getcomics.info/?p=' + str(
+                                            entry['id']
+                                        )
+                                        entry['filename'] = entry['title']
+                                    else:
+                                        nzbid = entry['id']
+                                    if '/cat/' in entry['link']:
+                                        entry['link'] = 'https://getcomics.info/?p=%s' % entry['id']
+                                entry['title'] = entry['filename']
+                            else:
+                                nzbid = search.generate_id(provider_stat, entry['link'])
+                                #try:
+                                #    entry['link'] = entry.enclosures[0]['url']
+                                #except Exception:
+                                #    pass
+                            if all([manual is not True, alt_match is False]):
+                                downloadit = True
+                            else:
+                                for x in mylar.COMICINFO:
+                                    if (
+                                        all(
+                                            [
+                                                x['link'] == entry['link'],
+                                                x['tmpprov'] == tmpprov,
+                                            ]
+                                        )
+                                        or all(
+                                            [
+                                                x['nzbid'] == nzbid,
+                                                x['newznab'] == newznab_host,
+                                            ]
+                                        )
+                                        or all(
+                                            [
+                                                x['nzbid'] == nzbid,
+                                                x['torznab'] == torznab_host,
+                                            ]
+                                        )
+                                    ):
+                                        nowrite = True
+                                        break
+
+                            # modify the name for annualization to be displayed properly
+                            if annualize is True:
+                                modcomicname = '%s Annual' % ComicName
+                            else:
+                                modcomicname = ComicName
+
+                            if IssueID is None:
+                                cyear = ComicYear
+                            else:
+                                cyear = comyear
+
+                            if nowrite is False:
+                                if any(
+                                    [
+                                        nzbprov == 'dognzb',
+                                        nzbprov == 'nzb.su',
+                                        nzbprov == 'experimental',
+                                        'newznab' in nzbprov,
+                                    ]
+                                ):
+                                    tprov = nzbprov
+                                    kind = 'usenet'
+                                    if newznab_host is not None:
+                                        tprov = newznab_host[0]
+                                else:
+                                    kind = 'torrent'
+                                    tprov = nzbprov
+                                    if torznab_host is not None:
+                                        tprov = torznab_host[0]
+
+                                search_values = {
+                                    "ComicName": ComicName,
+                                    "ComicID": ComicID,
+                                    "IssueID": IssueID,
+                                    "ComicVolume": ComicVersion,
+                                    "IssueNumber": IssueNumber,
+                                    "IssueDate": IssueDate,
+                                    "comyear": cyear,
+                                    "pack": False,
+                                    "pack_numbers": None,
+                                    "pack_issuelist": None,
+                                    "modcomicname": modcomicname,
+                                    "oneoff": oneoff,
+                                    "nzbprov": nzbprov,
+                                    "provider": tprov,
+                                    "nzbtitle": entry['title'],
+                                    "nzbid": nzbid,
+                                    "link": entry['link'],
+                                    "pubdate": pubdate,
+                                    "size": comsize_m,
+                                    "tmpprov": tmpprov,
+                                    "kind": kind,
+                                    "booktype": booktype,
+                                    "SARC": SARC,
+                                    "IssueArcID": IssueArcID,
+                                    "newznab": newznab_host,
+                                    "torznab": torznab_host,
+                                    "downloadit": downloadit,
+                                    "ComicTitle": ComicTitle,
+                                    "entry": entry,
+                                    "provider_stat": provider_stat,
+                                }
+
+                                mylar.COMICINFO.append(search_values)
+
+                                hold_the_matches.append(search_values)
+
+                        else:
+                            #log2file = log2file + "issues don't match.." + "\n"
+                            downloadit = False
+                            #foundc['status'] = False
+        logger.info('returning hold_the_matches: %s' % (hold_the_matches,))
+        return hold_the_matches


### PR DESCRIPTION
IMP: Skipped2Wanted will now take both issues & annuals into account for a series
IMP: Break out DDL into ``DDL(GetComics)`` to allow for future additions (config auto-update to v12)
IMP: Force Enable DDL to mirror DDL(GetComics) when enabling/disabling via GUI since only option available atm
IMP: Break out search matching functionality from search module into it's own module
IMP: (refactor) Breaking out allows DDL items to be verified for matches during queries saving hits & time
IMP: Priority Alternate Search Name added - use ``!!`` instead of ``##`` to denote priority vs normal
IMP: Provider-search delay (global setting) is now honoured on a per provider basis and is persistent across restarts. 
IMP: Flaresolverr support added (specifically for GC usage only)
IMP: Cookie receipts when using GC 
IMP: Extra loop for tpb/gn/one-shot/annual inclusion when using DDL to account for issues with no issue number
IMP: ``ddl_query_delay``available to delay search queries to GC (default 15s) and only affects search queries
FIX: ``Add to Readinglist`` and ``Download`` icons & functionality restored to series detail page
FIX: Deleting series in GUI via seriesdetail page would sometimes throw a 500 error
FIX: Make sure to return a null dataset instead of just null when no searchresults returned
FIX: Remove some extra logging lines needed during testing
FIX: Search-4-missing would not throw a popup after queue submission
FIX: Forgot to include One-Shot as part of the TPB/GN/HC json return to show possibility of having no issue numbers
FIX: Status colours on Scheduler Management page
FIX: Extra spacing at bottom of Edit Settings tab on series detail page causing tab size to be bigger than necessary