### PR TITLE
Here. Hold my sink. And all of this.

### DIFF
--- a/Mylar.py
+++ b/Mylar.py
@@ -25,7 +25,7 @@ sys.path.insert(1, os.path.join(os.path.dirname(__file__), 'lib'))
 
 import mylar
 
-from mylar import webstart, logger, filechecker, versioncheck, maintenance
+from mylar import webstart, logger, filechecker, versioncheck, maintenance, maintenance_webstart
 
 import argparse
 
@@ -103,7 +103,6 @@ def main():
     # Set up and gather command line arguments
     parser = argparse.ArgumentParser(description='Automated Comic Book Downloader')
     subparsers = parser.add_subparsers(title='Subcommands', dest='maintenance')
-    parser_maintenance = subparsers.add_parser('maintenance', help='Enter maintenance mode (no GUI). Additional commands are available (maintenance --help)')
 
     #main parser
     parser.add_argument('-v', '--verbose', action='store_true', help='Increase console logging verbosity')
@@ -112,23 +111,47 @@ def main():
     parser.add_argument('-p', '--port', type=int, help='Force mylar to run on a specified port')
     parser.add_argument('-b', '--backup', action='store_true', help='Will automatically backup & keep the last 2 copies of the .db & ini files prior to startup')
     parser.add_argument('-w', '--noweekly', action='store_true', help='Turn off weekly pull list check on startup (quicker boot sequence)')
+    parser.add_argument('-iu', '--ignoreupdate', action='store_true', help='Do not update db if required (for problem bypass)')
     parser.add_argument('--datadir', help='Specify a directory where to store your data files')
     parser.add_argument('--config', help='Specify a config file to use')
     parser.add_argument('--nolaunch', action='store_true', help='Prevent browser from launching on startup')
     parser.add_argument('--pidfile', help='Create a pid file (only relevant when running as a daemon)')
     parser.add_argument('--safe', action='store_true', help='redirect the startup page to point to the Manage Comics screen on startup')
-    parser_maintenance.add_argument('-xj', '--exportjson', action='store', help='Export existing mylar.db to json file')
-    parser_maintenance.add_argument('-id', '--importdatabase', action='store', help='Import a mylar.db into current db')
-    parser_maintenance.add_argument('-ij', '--importjson', action='store', help='Import a specified json file containing just {"ComicID": "XXXXX"} into current db')
-    parser_maintenance.add_argument('-st', '--importstatus', action='store_true', help='Provide current maintenance status')
-    parser_maintenance.add_argument('-u', '--update', action='store_true', help='force mylar to perform an update as if in GUI')
-    parser_maintenance.add_argument('-fs', '--fixslashes', action='store_true', help='remove double-slashes from within paths in db')
+
+    parser_maintenance = subparsers.add_parser('maintenance', help='Enter maintenance mode (no GUI). Additional commands are available (maintenance --help)')
+    parser_maintenance.add_argument('-xj', '--exportjson', action='store', help='Export existing mylar.db to json file', default=argparse.SUPPRESS)
+    parser_maintenance.add_argument('-id', '--importdatabase', action='store', help='Import a mylar.db into current db', default=argparse.SUPPRESS)
+    parser_maintenance.add_argument('-ij', '--importjson', action='store', help='Import a specified json file containing just {"ComicID": "XXXXX"} into current db', default=argparse.SUPPRESS)
+    parser_maintenance.add_argument('-st', '--importstatus', action='store_true', help='Provide current maintenance status', default=argparse.SUPPRESS)
+    parser_maintenance.add_argument('-u', '--update', action='store_true', help='force mylar to perform an update as if in GUI', default=argparse.SUPPRESS)
+    parser_maintenance.add_argument('-fs', '--fixslashes', action='store_true', help='remove double-slashes from within paths in db', default=argparse.SUPPRESS)
     #parser_maintenance.add_argument('-it', '--importtext', action='store', help='Import a specified text file into current db')
 
     args = parser.parse_args()
 
+    #these need to be set for things to register
+    args_exportjson = None
+    args_importdatabase = None
+    args_importjson = None
+    args_importstatus = False
+    args_update = False
+    args_fixslashes = False
+
+    if 'exportjson' in args:
+        args_exportjson = args.exportjson
+    if 'importdatabase' in args:
+        args_importdatabase = args.importdatabase
+    if 'importjson' in args:
+        args_importjson = args.importjson
+    if 'importstatus' in args:
+        args_importstatus = True
+    if 'update'in args:
+        args_update = True
+    if 'fixslashes' in args:
+        args_fixslashes = True
+
     if args.maintenance:
-        if all([args.exportjson is None, args.importdatabase is None, args.importjson is None, args.importstatus is False, args.update is False, args.fixslashes is False]):
+        if all([args_exportjson is None, args_importdatabase is None, args_importjson is None, args_importstatus is False, args_update is False, args_fixslashes is False]):
             print('Expecting subcommand with the maintenance positional argumeent')
             sys.exit()
         mylar.MAINTENANCE = True
@@ -144,6 +167,9 @@ def main():
         mylar.LOG_LEVEL = 0
     else:
         mylar.LOG_LEVEL = None
+
+    if args.ignoreupdate:
+        mylar.MAINTENANCE = False
 
     if args.daemon:
         if sys.platform == 'win32':
@@ -260,30 +286,61 @@ def main():
     if mylar.DAEMON:
         mylar.daemonize()
 
-    if mylar.MAINTENANCE is True and any([args.exportjson, args.importjson, args.update is True, args.importstatus is True, args.fixslashes is True]):
+    print('mylar.MAINTENANCE: %s'%  mylar.MAINTENANCE)
+    print('mylar.MAINTENANCE_TOTAL: %s'%  mylar.MAINTENANCE_DB_TOTAL)
+    if mylar.MAINTENANCE is True and (mylar.MAINTENANCE_UPDATE or any([args_exportjson, args_importjson, args_update is True, args_importstatus is True, args_fixslashes is True])):
+        print("here")
+        # Start up a temporary maintenance server for GUI display only.
+        maint_config = {
+            'http_port': int(mylar.CONFIG.HTTP_PORT),
+            'http_host': mylar.CONFIG.HTTP_HOST,
+            'http_root': mylar.CONFIG.HTTP_ROOT,
+            'enable_https': mylar.CONFIG.ENABLE_HTTPS,
+            'https_cert': mylar.CONFIG.HTTPS_CERT,
+            'https_key': mylar.CONFIG.HTTPS_KEY,
+            'https_chain': mylar.CONFIG.HTTPS_CHAIN,
+            'http_username': mylar.CONFIG.HTTP_USERNAME,
+            'http_password': mylar.CONFIG.HTTP_PASSWORD,
+            'authentication': mylar.CONFIG.AUTHENTICATION,
+            'login_timeout': mylar.CONFIG.LOGIN_TIMEOUT
+        }
+
+        # Try to start the server.
+        maintenance_webstart.initialize(maint_config)
+        versioncheck.versionload()
+        print("started")
         loggermode = '[MAINTENANCE-MODE]'
-        if args.importstatus: #mylar.MAINTENANCE is True:
+
+        restart_method = True  #True will restart, False will shutdown.
+
+        if mylar.MAINTENANCE_UPDATE:
+            ur = maintenance.Maintenance('db update')
+            restart_method = ur.update_db()
+            if restart_method is None:
+                restart_method = True
+
+        elif args_importstatus:
             cs = maintenance.Maintenance('status')
             cstat = cs.check_status()
         else:
             logger.info('%s Initializing maintenance mode' % loggermode)
 
-            if args.update is True:
+            if args_update is True:
                 logger.info('%s Attempting to update Mylar so things can work again...' % loggermode)
                 try:
                     mylar.shutdown(restart=True, update=True, maintenance=True)
                 except Exception as e:
                     sys.exit('%s Mylar failed to update: %s' % (loggermode, e))
 
-            elif args.importdatabase:
+            elif args_importdatabase:
                 #for attempted db import.
-                maintenance_path = args.importdatabase
+                maintenance_path = args_importdatabase
                 logger.info('%s db path accepted as %s' % (loggermode, maintenance_path))
                 di = maintenance.Maintenance('database-import', file=maintenance_path)
                 d = di.database_import()
-            elif args.importjson:
+            elif args_importjson:
                 #for attempted file re-import (json format)
-                maintenance_path = args.importjson
+                maintenance_path = args_importjson
                 logger.info('%s file indicated as being in json format - path accepted as %s' % (loggermode, maintenance_path))
                 ij = maintenance.Maintenance('json-import', file=maintenance_path)
                 j = ij.json_import()
@@ -293,24 +350,27 @@ def main():
             #    logger.info('%s file indicated as being in list format - path accepted as %s' % (loggermode, maintenance_path))
             #    it = maintenance.Maintenance('list-import', file=maintenance_path)
             #    t = it.list_import()
-            elif args.exportjson:
+            elif args_exportjson:
                 #for export of db comicid's in json format
-                maintenance_path = args.exportjson
+                maintenance_path = args_exportjson
                 logger.info('%s file indicated as being written to json format - destination accepted as %s' % (loggermode, maintenance_path))
                 ej = maintenance.Maintenance('json-export', output=maintenance_path)
                 j = ej.json_export()
-            elif args.fixslashes:
+            elif args_fixslashes:
                 #for running the fix slashes on the db manually
                 logger.info('%s method indicated as fix slashes' % loggermode)
                 fs = maintenance.Maintenance('fixslashes')
                 j = fs.fix_slashes()
             else:
-                logger.info('%s Not a valid command: %s' % (loggermode, maintenance_info))
+                logger.info('%s Not a valid command: %s' % (loggermode, args.maintenance))
                 sys.exit()
             logger.info('%s Exiting Maintenance mode' % (loggermode))
 
-        #possible option to restart automatically after maintenance has completed...
-        sys.exit()
+        #restart automatically after maintenance has completed...
+
+        maintenance_webstart.shutdown()
+        logger.info('%s Maintenance webserver has been shut down.'% (loggermode))
+        mylar.shutdown(restart=restart_method, maintenance=True)
 
     # Force the http port if neccessary
     if args.port:
@@ -350,12 +410,12 @@ def main():
         'opds_pagesize': mylar.CONFIG.OPDS_PAGESIZE,
     }
 
+    # Try to start the server.
+    webstart.initialize(web_config)
+
     #check for version here after web server initialized so it doesn't try to repeatidly hit github
     #for version info if it's already running
     versioncheck.versionload()
-
-    # Try to start the server.
-    webstart.initialize(web_config)
 
     if mylar.CONFIG.LAUNCH_BROWSER and not args.nolaunch:
         mylar.launch_browser(mylar.CONFIG.HTTP_HOST, http_port, mylar.CONFIG.HTTP_ROOT)

--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -398,21 +398,21 @@
                                    <div class="row">
                                        <label>Directory Location</label>
                                        <input type="text" id="com_location" name="com_location" value="${comic['ComicLocation']}" size="90">
-                                       <small>The directory where all the comics are located for this particular comic</small>
+                                       <small>Directory where all the comics are located for this series</small>
                                    </div>
 
                                    <div class="row">
                                        <label>Alternate Search Names</label>
                                        <input type="text" name="alt_search" value="${comic['AlternateSearch']}" size="90" />
                                        <a href="#" title="Seperate multiple entries with ##"><img src="images/info32.png" height="16" alt="" /></a>
-                                       <small>Alternate comic names to be searched in case naming is different (ie. Hack/Slash = hack-slash)</small>
+                                       <small>Alternate comic names to be searched in case naming is different<small>
                                    </div>
 
                                    <div class="row">
                                        <label>Alternate File-Naming</label>
                                        <input type="text" name="alt_filename" value="${comic['AlternateFileName']}" size="90">
                                        <a href="#" title="Alternate File Naming"><img src="images/info32.png" height="16" alt="" /></a>
-                                       <small>Alternate file-naming to be used when post-processing / renaming files instead of the actual title.</small>
+                                       <small>Use this insetad of CV name during post-processing / renaming</small>
                                    </div>
 
                                    <div class="row">
@@ -438,8 +438,8 @@
                                        <input type="text" name="torrentid_32p" placeholder="torrent id #" value="${comicConfig['torrentid_32p']}" size="40">
                                    </div>
                                    %endif
+                             <span style="position:absolute;float:right;right:30px;bottom:25px;"><input type="submit" value="Update"/></span>
                         </fieldset>
-                     <input type="submit" style="float:right;bottom:20px;" value="Update"/>
                 </form>
                </td>
              </tr>
@@ -719,6 +719,10 @@
                 $("#issue-box").draggable();
             } else if (action == 'metatag' || action == 'ametatag'){
                 run_single_metatag(issueid, comicid, issuenumber);
+            } else if (action == 'readlistadd'){
+                add2readinglist(issueid);
+            } else if (action == 'downloadissue'){
+                downloadthisissue(issueid);
             } else if (action == 'manqueueit' || action == 'amanqueueit'){
                 if (action == 'amanqueueit'){
                     add_wanted(issueid, comicid, issuenumber, 'want_ann', true);
@@ -841,6 +845,57 @@
                      },
             })).done(function(data) {
                  reload_tables();
+            });
+        }
+
+        function add2readinglist(issueid){
+            $.when($.ajax({
+                 type: "GET",
+                 url: "addtoreadlist",
+                 data: { IssueID: issueid },
+                 success: function(response) {
+                    obj = JSON.parse(response);
+                    $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>"+obj['message']+"</div>");
+                    if (obj['status'] == 'success'){
+                        $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                    } else {
+                        $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                    }
+                 },
+                 error: function(data)
+                     {
+                       alert('ERROR'+data.responseText);
+                     },
+            })).done(function(data) {
+                 //reload_tables();
+            });
+        }
+        function shizzlemedown(filepath){
+            $.ajax({
+                 type: "GET",
+                 url: "downloadthis",
+                 data: { pathfile: filepath },
+            })
+        }
+        function downloadthisissue(issueid){
+            $.ajax({
+                 type: "GET",
+                 url: "download_checkthis",
+                 data: { issueid: issueid },
+                 success: function(response) {
+                    obj = JSON.parse(response);
+                    $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>"+obj['message']+"</div>");
+                    if (obj['status'] == 'success'){
+                        $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                        shizzlemedown(obj['filepath']);
+                    } else {
+                        $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                    }
+                 },
+                 error: function(data)
+                     {
+                       alert('ERROR'+data.responseText);
+                     },
             });
         }
 
@@ -1612,6 +1667,10 @@
                                    }
                                }
                                displayline += '<a id="listbox" name="listbox" href="#issue-box" class="issue-window">'+issueimg+'</a>';
+                               if (full[3] == 'Downloaded'){
+                                   displayline += '<a id="readlistadd" name="readlistadd" title="Add to Reading List" href="#"><img src="images/glasses-icon.png" height="25" width="25" style="margin:2px 1px 3px 3px;" /></a>';
+                                   displayline += '<a href="downloadthis?issueid='+String(full[4])+'" title="Download this issue"><img src="images/download_icon.png" height="25" width="25" style="margin:2px 1px 3px 3px;" /></a>';
+                               }
                                return displayline;
                            }
                        },

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -849,7 +849,14 @@
                         </fieldset>
                         <fieldset>
                                 <div class="row checkbox left clearfix">
-                                    <input type="checkbox" id="enable_ddl" name="enable_ddl" value=1 ${config['enable_ddl']} /><legend>Enable DDL (GetComics)</legend>
+                                     <input id="enable_ddl" type="checkbox" onclick="initConfigCheckbox($(this));" name="enable_ddl" value="1" ${config['enable_ddl']} /><legend>DDL (Direct Download)</legend>
+                                </div>
+                                <div class="config">
+                                   <div id="ddl_providers">
+                                        <div class="row checkbox left clearfix">
+                                            <input type="checkbox" id="enable_getcomics" name="enable_getcomics" value="1" ${config['enable_getcomics']} /><label>Enable GetComics</label>
+                                       </div>
+                                   </div>
                                 </div>
                         </fieldset>
                         <fieldset>
@@ -1824,6 +1831,35 @@
                         else
                         {
                                 $("#opdscredentials").slideUp();
+                        }
+                });
+
+                if ($("#enable_ddl").is(":checked"))
+                        {
+                                if ( document.getElementById("enable_getcomics").checked == false ){
+                                    document.getElementById("enable_getcomics").checked = true;
+                                    document.getElementById("enable_getcomics").setAttribute("disabled", "disabled");
+                                }
+                                $("#ddl_providers").slideDown();
+                        }
+                else    {
+                                document.getElementById("enable_getcomics").checked = false;
+                                $("#ddl_providers").slideUp();
+                        }
+
+                $("#enable_ddl").click(function(){
+                        if ($("#enable_ddl").is(":checked"))
+                        {
+                                if ( document.getElementById("enable_getcomics").checked == false ){
+                                    document.getElementById("enable_getcomics").checked = true;
+                                    document.getElementById("enable_getcomics").setAttribute("disabled", "disabled");
+                                }
+                                $("#ddl_providers").slideDown();
+                        }
+                        else
+                        {
+                                document.getElementById("enable_getcomics").checked = false;
+                                $("#ddl_providers").slideUp();
                         }
                 });
 
@@ -2828,6 +2864,7 @@
                 initConfigCheckbox("#ddump");
                 initConfigCheckbox("#enable_failed");
                 initConfigCheckbox("#enable_meta");
+                initConfigCheckbox("#enable_ddl");
                 initConfigCheckbox("#zero_level");
                 initConfigCheckbox("#post_processing");
                 initConfigCheckbox("#enable_check_folder");

--- a/data/interfaces/default/maintenance_base.html
+++ b/data/interfaces/default/maintenance_base.html
@@ -1,0 +1,96 @@
+<%
+	import mylar
+%>
+<!doctype html>
+<!--[if lt IE 7 ]> <html lang="en" class="no-js ie6"> <![endif]-->
+<!--[if IE 7 ]>    <html lang="en" class="no-js ie7"> <![endif]-->
+<!--[if IE 8 ]>    <html lang="en" class="no-js ie8"> <![endif]-->
+<!--[if IE 9 ]>    <html lang="en" class="no-js ie9"> <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--> <html lang="en" class="no-js"> <!--<![endif]-->
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+	
+	<title>Mylar - ${title}</title>
+	<meta name="description" content="Mylar 'default' interface - made by Elmar Kouwenhoven">
+	<meta name="author" content="Elmar Kouwenhoven">
+	
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	
+	<link rel="apple-touch-icon" href="images/mylarlogo.png">
+	<link rel="stylesheet" href="interfaces/${interface}/css/style.css?v=${mylar.CURRENT_VERSION}"">
+	<link rel="stylesheet" href="interfaces/${interface}/css/jquery-ui.css">
+        <link rel="icon" href="images/favicon.ico" type="image/x-icon">
+        <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+	${next.headIncludes()}
+	
+	<script src="js/libs/modernizr-2.8.3.min.js"></script>
+	<script src="js/libs/jquery-1.7.2.min.js"></script>
+</head>
+<body>
+      	    <div id="container">
+		<header>
+                        <div class="wrapper">
+                     
+			<div id="logo">
+                                <img class="mylarload2" src="images/mylarlogo.png" alt="mylar" height="64" width="64" style="">
+			</div>
+			<ul id="nav">
+				<li>MAINTENANCE MODE</li>
+			</ul>
+                        </div>
+		</header>
+
+		<div id="main" class="main">
+			<div id="subhead">
+				${next.headerIncludes()}
+			</div>
+			${next.body()}
+		</div>
+
+		<footer>
+			<div id="actions">
+				<small>
+                                <a href="shutdown"><span class="ui-button-icon-primary ui-icon ui-icon-power"></span>Shutdown</a> |
+                                <a href="restart"><span class="ui-button-icon-primary ui-icon ui-icon-power"></span>Restart</a> |
+                                %if mylar.CONFIG.AUTHENTICATION > 0:
+                                    <a href="auth/logout"><span class="ui-button-icon-primary ui-icon ui-icon-power"></span>Logout</a></br>
+                                %endif
+                                </small>
+			</div>
+			<div id="version">
+                                Version: <em>
+                                %if mylar.CURRENT_VERSION_NAME:
+                                    ${mylar.CURRENT_VERSION_NAME}
+                                %else:
+                                    ${mylar.CURRENT_VERSION}
+                                %endif
+                                </em>
+				(${mylar.CONFIG.GIT_BRANCH})
+			</div>	
+		</footer>
+		<a href="#main" id="toTop"><span>Back to top</span></a>
+
+	<script src="js/libs/jquery-ui.min.js"></script> 
+        <script src="js/common.js"></script>
+	
+	${next.javascriptIncludes()}
+	
+	<script src="js/plugins.js"></script>
+	<script src="js/script.js"></script>
+	<!--[if lt IE 7 ]>
+	<script src="js/libs/dd_belatedpng.js"></script>
+	<script> DD_belatedPNG.fix('img, .png_bg');</script>
+	<![endif]-->
+        <script>
+        function flippylogo() {
+            $('img.mylarload').addClass('spinny').removeClass('lastgood').removeClass('lastbad');
+        }
+        </script>
+
+</body>
+</html>
+
+<%def name="javascriptIncludes()"></%def>
+<%def name="headIncludes()"></%def>
+<%def name="headerIncludes()"></%def>

--- a/data/interfaces/default/maintenance_mode.html
+++ b/data/interfaces/default/maintenance_mode.html
@@ -1,0 +1,56 @@
+<%inherit file="maintenance_base.html"/>
+
+<%def name="body()">
+        <div class="table_wrapper">
+            <div id="shutdown">
+                <h1>
+                <img class="mylarload" src="images/mylarlogo.png" alt="mylar" height="100" width="100" style=""></br></br>
+<!--
+                <img src="images/spinner.gif" height="100" width="100"/></br></br>
+-->
+                <div style="display:table;position:relative;margin:auto;top:0px;"><span id="progress_percent"></span><div class="progress-container complete"><div id="prog_width"><span class="progressbar-front-text" style="margin:auto;top:-3px;" id="progress" name="progress" value="0%"></span></div></div></div></br>
+                <div id="updatetype"></div></br>
+                </h1>
+                <div id="message"></div></br>
+                <div id="sec_msg"></div>
+            </div>
+        </div>
+</%def>
+
+<%def name="javascriptIncludes()">
+    <script>
+        var UpdateTimer = setInterval(activecheck, 1000);
+        function activecheck() {
+                $.get('check_ActiveMaintenance',
+                    function(data){
+                        if (data.error != undefined) {
+                            alert(data.error);
+                            return;
+                        };
+                        var obj = JSON.parse(data);
+                        var percent = obj['percent'];
+                        var status = obj['status'];
+                        var message = obj['message'];
+                        var sec_msg = obj['secondary_msg'];
+                        var updatetype = obj['updatetype'];
+                        if (status == 'Updating') {
+                            flippylogo();
+                            document.getElementById("prog_width").style.width=percent;
+                            $("#progress").html(percent);
+                            document.getElementById("message").innerHTML = message;
+                            document.getElementById("sec_msg").innerHTML = sec_msg;
+                            document.getElementById("updatetype").innerHTML = updatetype;
+                        }
+                        if (percent == '100%'){
+                            clearInterval(UpdateTimer);
+                            document.getElementById("prog_width").style.width=percent;
+                            $("#progress").html(percent);
+                            document.getElementById("message").innerHTML = message;
+                            document.getElementById("sec_msg").innerHTML = sec_msg;
+                            document.getElementById("updatetype").innerHTML = updatetype;
+                            $("#progress").append('<meta http-equiv="refresh" content="5;url=index">');
+                        }
+                    }
+        )};
+    </script>
+</%def>

--- a/data/interfaces/default/manage.html
+++ b/data/interfaces/default/manage.html
@@ -237,11 +237,11 @@
                            %for j in jobs:
                               <%
                                     if j['status'] == 'Paused':
-                                        grade = '#D9150F'
+                                        grade = '#EC7564'
                                     elif j['status'] == 'Waiting':
-                                        grade = '#0F49D9'
+                                        grade = '#52A9EE'
                                     elif j['status'] == 'Running':
-                                        grade = '#55D90F'
+                                        grade = '#7AEE52'
                                %>
                               <tr>
                                 <td id="job" style="width: 50px;text-align: center;">${j['jobname']}</td>

--- a/data/interfaces/default/weeklypull.html
+++ b/data/interfaces/default/weeklypull.html
@@ -107,9 +107,8 @@
 		<tbody>
 		%for weekly in weeklyresults:
 			<%
-				if weekly['STATUS'] == 'Skipped':
-					grade = 'Z'
-				elif weekly['STATUS'] == 'Wanted':
+                                grade = 'Z'
+				if weekly['STATUS'] == 'Wanted':
 					grade = 'X'
 				elif weekly['STATUS'] == 'Snatched':
 					grade = 'C'
@@ -230,7 +229,7 @@
                                                         %endif
                                                         </a>
                                                      %endif
-                                                     <a href="searchit?name=${weekly['COMIC'] | u}&issue=${weekly['ISSUE']}&mode=pullseries" title="Search for this series to add to your watchlist">
+                                                     <a href="searchit?name=${weekly['COMIC'] | u}&issue=${weekly['ISSUE']}&smode=pullseries" title="Search for this series to add to your watchlist">
                                                      %if mylar.CONFIG.SHOW_ICONS:
                                                          <img style="margin: 0px 5px" src="images/search_add.png" height="25" width="25" class="highqual" />
                                                      %else:
@@ -316,7 +315,7 @@
 </%def>
 
 <%def name="javascriptIncludes()">
-	<script src="js/libs/jquery.dataTables.min.js"></script>
+        <script src="js/libs/jquery.dataTables.1.10.25.min.js"></script>
         <script src="js/libs/selectize.js"></script>
         <script src="js/libs/circular-json.js"></script>
         <script type="text/javascript">

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -97,6 +97,9 @@ DBUPDATE_INTERVAL = 1440 # 24hrs
 DB_BACKFILL = False
 DBLOCK = False
 DB_FILE = None
+MAINTENANCE_UPDATE = []
+MAINTENANCE_DB_TOTAL = 0
+MAINTENANCE_DB_COUNT = 0
 UMASK = None
 WANTED_TAB_OFF = False
 PULLNEW = None
@@ -162,7 +165,6 @@ STATIC_COMICRN_VERSION = "1.01"
 STATIC_APC_VERSION = "2.04"
 ISSUE_EXCEPTIONS = ['AU', 'AI', 'INH', 'NOW', 'BEY', 'MU', 'HU', 'LR', 'A', 'B', 'C', 'X', 'O','SUMMER', 'SPRING', 'FALL', 'WINTER', 'PREVIEW', 'OMEGA', "DIRECTOR'S CUT", "(DC)"]
 SAB_PARAMS = None
-TMP_PROV = None
 EXT_IP = None
 PROVIDER_START_ID=0
 COMICINFO = ()
@@ -195,7 +197,8 @@ def initialize(config_file):
                PROG_DIR, DATA_DIR, CMTAGGER_PATH, DOWNLOAD_APIKEY, LOCAL_IP, STATIC_COMICRN_VERSION, STATIC_APC_VERSION, KEYS_32P, AUTHKEY_32P, FEED_32P, FEEDINFO_32P, \
                MONITOR_STATUS, SEARCH_STATUS, RSS_STATUS, WEEKLY_STATUS, VERSION_STATUS, UPDATER_STATUS, DBUPDATE_INTERVAL, DB_BACKFILL, LOG_LANG, LOG_CHARSET, APILOCK, SEARCHLOCK, DDL_LOCK, LOG_LEVEL, \
                SCHED_RSS_LAST, SCHED_WEEKLY_LAST, SCHED_MONITOR_LAST, SCHED_SEARCH_LAST, SCHED_VERSION_LAST, SCHED_DBUPDATE_LAST, COMICINFO, SEARCH_TIER_DATE, \
-               BACKENDSTATUS_CV, BACKENDSTATUS_WS, PROVIDER_STATUS, TMP_PROV, EXT_IP, ISSUE_EXCEPTIONS, PROVIDER_START_ID, GLOBAL_MESSAGES, CHECK_FOLDER_CACHE, FOLDER_CACHE, SESSION_ID
+               BACKENDSTATUS_CV, BACKENDSTATUS_WS, PROVIDER_STATUS, EXT_IP, ISSUE_EXCEPTIONS, PROVIDER_START_ID, GLOBAL_MESSAGES, CHECK_FOLDER_CACHE, FOLDER_CACHE, SESSION_ID, \
+               MAINTENANCE_UPDATE, MAINTENANCE_DB_COUNT, MAINTENANCE_DB_TOTAL
 
         cc = mylar.config.Config(config_file)
         CONFIG = cc.read(startup=True)
@@ -211,6 +214,20 @@ def initialize(config_file):
             dbcheck()
         except Exception as e:
             logger.error('Cannot connect to the database: %s' % e)
+        else:
+            cc.provider_sequence()
+
+            # quick check here to see if a previous db update failed.
+            chk = maintenance.Maintenance(mode='db update')
+            chk.check_failed_update()
+
+            # check to see if any db updates are required / new.
+            chk.db_update_check()
+
+        #set the flag here whether to start it up in maintenance mode or not.
+        #usually it will be based on if a field is present in the db or not.
+        if mylar.MAINTENANCE_UPDATE:
+            mylar.MAINTENANCE = True
 
         if MAINTENANCE is False:
             #try to get the local IP using socket. Get this on every startup so it's at least current for existing session.
@@ -324,16 +341,14 @@ def initialize(config_file):
             if PUBLISHER_IMPRINTS is not None:
                 logger.info('[IMPRINT_LOADS] Successfully loaded imprints for %s publishers' % (len(PUBLISHER_IMPRINTS['publishers'])))
 
+            logger.info('Remapping the sorting to allow for new additions.')
+            COMICSORT = helpers.ComicSort(sequence='startup')
+
         if CONFIG.LOCMOVE:
             helpers.updateComicLocation()
 
         # make sure the intLatestIssue field is populated with values...
-        helpers.latestissue_update()
-
-        #Ordering comics here
-        if mylar.MAINTENANCE is False:
-            logger.info('Remapping the sorting to allow for new additions.')
-            COMICSORT = helpers.ComicSort(sequence='startup')
+        # ??helpers.latestissue_update()
 
         # Store the original umask
         UMASK = os.umask(0)
@@ -753,7 +768,7 @@ def dbcheck():
             logger.warn('Unable to update readinglist table to new storyarc table format.')
 
     c.execute('CREATE TABLE IF NOT EXISTS comics (ComicID TEXT UNIQUE, ComicName TEXT, ComicSortName TEXT, ComicYear TEXT, DateAdded TEXT, Status TEXT, IncludeExtras INTEGER, Have INTEGER, Total INTEGER, ComicImage TEXT, FirstImageSize INTEGER, ComicPublisher TEXT, PublisherImprint TEXT, ComicLocation TEXT, ComicPublished TEXT, NewPublish TEXT, LatestIssue TEXT, intLatestIssue INT, LatestDate TEXT, Description TEXT, DescriptionEdit TEXT, QUALalt_vers TEXT, QUALtype TEXT, QUALscanner TEXT, QUALquality TEXT, LastUpdated TEXT, AlternateSearch TEXT, UseFuzzy TEXT, ComicVersion TEXT, SortOrder INTEGER, DetailURL TEXT, ForceContinuing INTEGER, ComicName_Filesafe TEXT, AlternateFileName TEXT, ComicImageURL TEXT, ComicImageALTURL TEXT, DynamicComicName TEXT, AllowPacks TEXT, Type TEXT, Corrected_SeriesYear TEXT, Corrected_Type TEXT, TorrentID_32P TEXT, LatestIssueID TEXT, Collects CLOB, IgnoreType INTEGER, AgeRating TEXT, FilesUpdated TEXT, seriesjsonPresent INT, dirlocked INTEGER)')
-    c.execute('CREATE TABLE IF NOT EXISTS issues (IssueID TEXT, ComicName TEXT, IssueName TEXT, Issue_Number TEXT, DateAdded TEXT, Status TEXT, Type TEXT, ComicID TEXT, ArtworkURL Text, ReleaseDate TEXT, Location TEXT, IssueDate TEXT, DigitalDate TEXT, Int_IssueNumber INT, ComicSize TEXT, AltIssueNumber TEXT, IssueDate_Edit TEXT, ImageURL TEXT, ImageURL_ALT TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS issues (IssueID TEXT, ComicName TEXT, IssueName TEXT, Issue_Number TEXT, DateAdded TEXT, Status TEXT, Type TEXT, ComicID TEXT, ArtworkURL Text, ReleaseDate TEXT, Location TEXT, IssueDate TEXT, DigitalDate TEXT, Int_IssueNumber INT, ComicSize TEXT, AltIssueNumber TEXT, IssueDate_Edit TEXT, ImageURL TEXT, ImageURL_ALT TEXT, forced_file INT)')
     c.execute('CREATE TABLE IF NOT EXISTS snatched (IssueID TEXT, ComicName TEXT, Issue_Number TEXT, Size INTEGER, DateAdded TEXT, Status TEXT, FolderName TEXT, ComicID TEXT, Provider TEXT, Hash TEXT, crc TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS upcoming (ComicName TEXT, IssueNumber TEXT, ComicID TEXT, IssueID TEXT, IssueDate TEXT, Status TEXT, DisplayComicName TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS nzblog (IssueID TEXT, NZBName TEXT, SARC TEXT, PROVIDER TEXT, ID TEXT, AltNZBName TEXT, OneOff TEXT)')
@@ -761,7 +776,7 @@ def dbcheck():
     c.execute('CREATE TABLE IF NOT EXISTS importresults (impID TEXT, ComicName TEXT, ComicYear TEXT, Status TEXT, ImportDate TEXT, ComicFilename TEXT, ComicLocation TEXT, WatchMatch TEXT, DisplayName TEXT, SRID TEXT, ComicID TEXT, IssueID TEXT, Volume TEXT, IssueNumber TEXT, DynamicName TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS readlist (IssueID TEXT, ComicName TEXT, Issue_Number TEXT, Status TEXT, DateAdded TEXT, Location TEXT, inCacheDir TEXT, SeriesYear TEXT, ComicID TEXT, StatusChange TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS annuals (IssueID TEXT, Issue_Number TEXT, IssueName TEXT, IssueDate TEXT, Status TEXT, ComicID TEXT, GCDComicID TEXT, Location TEXT, ComicSize TEXT, Int_IssueNumber INT, ComicName TEXT, ReleaseDate TEXT, DigitalDate TEXT, ReleaseComicID TEXT, ReleaseComicName TEXT, IssueDate_Edit TEXT, DateAdded TEXT, Deleted INT DEFAULT 0)')
-    c.execute('CREATE TABLE IF NOT EXISTS rssdb (Title TEXT UNIQUE, Link TEXT, Pubdate TEXT, Site TEXT, Size TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS rssdb (Title TEXT UNIQUE, Link TEXT, Pubdate TEXT, Site TEXT, Size TEXT, Issue_Number TEXT, ComicName TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS futureupcoming (ComicName TEXT, IssueNumber TEXT, ComicID TEXT, IssueID TEXT, IssueDate TEXT, Publisher TEXT, Status TEXT, DisplayComicName TEXT, weeknumber TEXT, year TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS failed (ID TEXT, Status TEXT, ComicID TEXT, IssueID TEXT, Provider TEXT, ComicName TEXT, Issue_Number TEXT, NZBName TEXT, DateFailed TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS searchresults (SRID TEXT, results Numeric, Series TEXT, publisher TEXT, haveit TEXT, name TEXT, deck TEXT, url TEXT, description TEXT, comicid TEXT, comicimage TEXT, issues TEXT, comicyear TEXT, ogcname TEXT)')
@@ -770,10 +785,12 @@ def dbcheck():
     c.execute('CREATE TABLE IF NOT EXISTS jobhistory (JobName TEXT, prev_run_datetime timestamp, prev_run_timestamp REAL, next_run_datetime timestamp, next_run_timestamp REAL, last_run_completed TEXT, successful_completions TEXT, failed_completions TEXT, status TEXT, last_date timestamp)')
     c.execute('CREATE TABLE IF NOT EXISTS manualresults (provider TEXT, id TEXT, kind TEXT, comicname TEXT, volume TEXT, oneoff TEXT, fullprov TEXT, issuenumber TEXT, modcomicname TEXT, name TEXT, link TEXT, size TEXT, pack_numbers TEXT, pack_issuelist TEXT, comicyear TEXT, issuedate TEXT, tmpprov TEXT, pack TEXT, issueid TEXT, comicid TEXT, sarc TEXT, issuearcid TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS storyarcs(StoryArcID TEXT, ComicName TEXT, IssueNumber TEXT, SeriesYear TEXT, IssueYEAR TEXT, StoryArc TEXT, TotalIssues TEXT, Status TEXT, inCacheDir TEXT, Location TEXT, IssueArcID TEXT, ReadingOrder INT, IssueID TEXT, ComicID TEXT, ReleaseDate TEXT, IssueDate TEXT, Publisher TEXT, IssuePublisher TEXT, IssueName TEXT, CV_ArcID TEXT, Int_IssueNumber INT, DynamicComicName TEXT, Volume TEXT, Manual TEXT, DateAdded TEXT, DigitalDate TEXT, Type TEXT, Aliases TEXT, ArcImage TEXT)')
-    c.execute('CREATE TABLE IF NOT EXISTS ddl_info (ID TEXT UNIQUE, series TEXT, year TEXT, filename TEXT, size TEXT, issueid TEXT, comicid TEXT, link TEXT, status TEXT, remote_filesize TEXT, updated_date TEXT, mainlink TEXT, issues TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS ddl_info (ID TEXT UNIQUE, series TEXT, year TEXT, filename TEXT, size TEXT, issueid TEXT, comicid TEXT, link TEXT, status TEXT, remote_filesize TEXT, updated_date TEXT, mainlink TEXT, issues TEXT, site TEXT, submit_date TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS exceptions_log(date TEXT UNIQUE, comicname TEXT, issuenumber TEXT, seriesyear TEXT, issueid TEXT, comicid TEXT, booktype TEXT, searchmode TEXT, error TEXT, error_text TEXT, filename TEXT, line_num TEXT, func_name TEXT, traceback TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS tmp_searches (query_id INTEGER, comicid INTEGER, comicname TEXT, publisher TEXT, publisherimprint TEXT, comicyear TEXT, issues TEXT, volume TEXT, deck TEXT, url TEXT, type TEXT, cvarcid TEXT, arclist TEXT, description TEXT, haveit TEXT, mode TEXT, searchtype TEXT, comicimage TEXT, thumbimage TEXT, PRIMARY KEY (query_id, comicid))')
     c.execute('CREATE TABLE IF NOT EXISTS notifs(session_id INT, date TEXT, event TEXT, comicid TEXT, comicname TEXT, issuenumber TEXT, seriesyear TEXT, status TEXT, message TEXT, PRIMARY KEY (session_id, date))')
+    c.execute('CREATE TABLE IF NOT EXISTS provider_searches(provider TEXT UNIQUE, type TEXT, lastrun INTEGER, active TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS mylar_info(DatabaseVersion INTEGER PRIMARY KEY)')
     conn.commit
     c.close
 
@@ -786,6 +803,19 @@ def dbcheck():
     #c.execute('''PRAGMA journal_mode = WAL''')
 
     #add in the late players to the game....
+
+    # -- mylar info table --
+    try:
+        bdc = c.execute('SELECT DatabaseVersion from mylar_info')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE mylar_info ADD COLUMN DatabaseVersion INTEGER PRIMARY KEY')
+        c.execute("INSERT INTO mylar_info(DatabaseVersion) VALUES(0)")
+    else:
+        bc = bdc.fetchone()
+        if any([not bc, bc is None]):
+            #version is null - set the default version now.
+            c.execute("INSERT INTO mylar_info(DatabaseVersion) VALUES(0)")
+
     # -- Comics Table --
 
     try:
@@ -994,6 +1024,11 @@ def dbcheck():
         c.execute('SELECT DigitalDate from issues')
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE issues ADD COLUMN DigitalDate TEXT')
+
+    try:
+        c.execute('SELECT forced_file from issues')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE issues ADD COLUMN forced_file INT')
 
     ## -- ImportResults Table --
 
@@ -1241,6 +1276,19 @@ def dbcheck():
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE annuals ADD COLUMN Deleted INT DEFAULT 0')
 
+    ## -- rssdb Table --
+    #to_the_rss_update = False
+    #try:
+    #    c.execute('SELECT Issue_Number from rssdb')
+    #except sqlite3.OperationalError:
+    #    c.execute('ALTER TABLE rssdb ADD COLUMN Issue_Number TEXT')
+    #    to_the_rss_update = True
+
+    #try:
+    #    c.execute('SELECT ComicName from rssdb')
+    #except sqlite3.OperationalError:
+    #    c.execute('ALTER TABLE rssdb ADD COLUMN ComicName TEXT')
+
     ## -- Snatched Table --
 
     try:
@@ -1435,6 +1483,16 @@ def dbcheck():
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE ddl_info ADD COLUMN issues TEXT')
 
+    try:
+        c.execute('SELECT site from ddl_info')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE ddl_info ADD COLUMN site TEXT')
+
+    try:
+        c.execute('SELECT submit_date from ddl_info')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE ddl_info ADD COLUMN submit_date TEXT')
+
     #if it's prior to Wednesday, the issue counts will be inflated by one as the online db's everywhere
     #prepare for the next 'new' release of a series. It's caught in updater.py, so let's just store the
     #value in the sql so we can display it in the details screen for everyone to wonder at.
@@ -1482,6 +1540,17 @@ def dbcheck():
     for jh in job_listing:
         job_history.append(jh)
 
+    #update tables here as necessary based on current version of mylar.
+    #this won't be written to the ini until a save of the config after load, but it should be oldconfig_version+1 on load
+    logger.info('[%s]oldconfig_version: %s' % (type(mylar.CONFIG.OLDCONFIG_VERSION), mylar.CONFIG.OLDCONFIG_VERSION))
+    if mylar.CONFIG.OLDCONFIG_VERSION is not None:
+        if int(mylar.CONFIG.OLDCONFIG_VERSION) < 12:
+            logger.info('now updating table data to ensure DDL is properly populated with correct data.')
+            c.execute("UPDATE snatched SET Provider = 'DDL(GetComics)' WHERE Provider = 'ddl'")
+            c.execute("UPDATE nzblog SET PROVIDER = 'DDL(GetComics)' WHERE PROVIDER = 'ddl'")
+            c.execute("UPDATE rssdb SET site = 'DDL(GetComics)' WHERE site = 'DDL'")
+            c.execute("UPDATE ddl_info SET site = 'DDL(GetComics)' WHERE site is NULL")
+
     #logger.fdebug('job_history loaded: %s' % job_history)
     conn.commit()
     c.close()
@@ -1489,6 +1558,11 @@ def dbcheck():
     if dynamic_upgrade is True:
         logger.info('Updating db to include some important changes.')
         helpers.upgrade_dynamic()
+
+    #if to_the_rss_update is True:
+    #    mylar.MAINTENANCE = True
+    #    mylar.MAINTENANCE_DB_TOTAL = 1 # set this to 1 to kick it.
+
 
 def halt():
     global _INITIALIZED, started
@@ -1546,6 +1620,6 @@ def shutdown(restart=False, update=False, maintenance=False):
                 if all([x != 'maintenance', x != '-u']):
                     popen_list += x
         logger.info('Restarting Mylar with ' + str(popen_list))
-        subprocess.Popen(popen_list, cwd=os.getcwd())
+        os.execv(sys.executable, popen_list)
 
     os._exit(0)

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -100,7 +100,7 @@ class Api(object):
                 try:
                     data = '\ndata: {\ndata: "status": "' + results['status'] + '",\ndata: "comicid": "' + results['comicid']+ '",\ndata: "message": "' + results['message'] + '",\ndata: "tables": "' + results['tables'] + '",\ndata: "comicname": "' + results['comicname'] + '",\ndata: "seriesyear": "' + results['seriesyear'] + '"\ndata: }\n\n'
                 except Exception as e:
-                    logger.warn('data_error: %s' % e)
+                    #logger.warn('data_error: %s' % e)
                     data = '\ndata: {\ndata: "status": "' + results['status'] + '",\ndata: "comicid": "' + results['comicid']+ '",\ndata: "message": "' + results['message'] + '",\ndata: "tables": "' + results['tables'] + '"\ndata: }\n\n'
 
             #data = 'retry: 5000\ndata: '+str(results['message'])+'\n\n' # + str(results['message']) + '\n\n'

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -12,7 +12,7 @@ import threading
 import re
 import configparser
 import mylar
-from mylar import logger, helpers, encrypted
+from mylar import logger, helpers, encrypted, filechecker, db
 
 config = configparser.ConfigParser()
 
@@ -20,7 +20,6 @@ _CONFIG_DEFINITIONS = OrderedDict({
      #keyname, type, section, default
     'CONFIG_VERSION': (int, 'General', 6),
     'MINIMAL_INI': (bool, 'General', False),
-    'OLDCONFIG_VERSION': (str, 'General', None),
     'AUTO_UPDATE': (bool, 'General', False),
     'CACHE_DIR': (str, 'General', None),
     'DYNAMIC_UPDATE': (int, 'General', 0),
@@ -328,9 +327,13 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'PUBLIC_VERIFY': (bool, 'Torrents', True),
 
     'ENABLE_DDL': (bool, 'DDL', False),
+    'ENABLE_GETCOMICS': (bool, 'DDL', False),
     'ALLOW_PACKS': (bool, 'DDL', False),
+    'DDL_QUERY_DELAY': (int, 'DDL', 15),
     'DDL_LOCATION': (str, 'DDL', None),
     'DDL_AUTORESUME': (bool, 'DDL', True),
+    'ENABLE_FLARESOLVERR': (bool, 'DDL', False),
+    'FLARESOLVERR_URL': (str, 'DDL', None),
 
     'AUTO_SNATCH': (bool, 'AutoSnatch', False),
     'AUTO_SNATCH_SCRIPT': (str, 'AutoSnatch', None),
@@ -432,7 +435,11 @@ class Config(object):
                 count = sum(1 for line in open(self._config_file))
             else:
                 count = 0
-            self.newconfig = 11
+
+            #this is the current version at this particular point in time.
+            self.newconfig = 12
+
+            OLDCONFIG_VERSION = 0
             if count == 0:
                 CONFIG_VERSION = 0
                 MINIMALINI = False
@@ -440,14 +447,17 @@ class Config(object):
                 # get the config version first, since we need to know.
                 try:
                     CONFIG_VERSION = config.getint('General', 'config_version')
+                    OLDCONFIG_VERSION = CONFIG_VERSION
                 except:
                     CONFIG_VERSION = 0
+                    OLDCONFIG_VERSION = 0
                 try:
                     MINIMALINI = config.getboolean('General', 'minimal_ini')
                 except:
                     MINIMALINI = False
 
         setattr(self, 'CONFIG_VERSION', CONFIG_VERSION)
+        setattr(self, 'OLDCONFIG_VERSION', OLDCONFIG_VERSION)
         setattr(self, 'MINIMAL_INI', MINIMALINI)
 
         config_values = []
@@ -549,6 +559,29 @@ class Config(object):
     def read(self, startup=False):
         self.config_vals()
 
+        if any([self.CONFIG_VERSION == 0, self.CONFIG_VERSION < self.newconfig]):
+            try:
+                shutil.move(self._config_file, os.path.join(mylar.DATA_DIR, 'config.ini.backup'))
+            except:
+                print(('Unable to make proper backup of config file in %s' % os.path.join(mylar.DATA_DIR, 'config.ini.backup')))
+            if self.CONFIG_VERSION < 12:
+                print('Attempting to update configuration..')
+                #8-torznab multiple entries merged into extra_torznabs value
+                #9-remote rtorrent ssl option
+                #10-encryption of all keys/passwords.
+                #11-provider ids
+                #12-ddl seperation into multiple providers, new keys, update tables
+                self.config_update()
+            setattr(self, 'OLDCONFIG_VERSION', str(self.CONFIG_VERSION))
+            #config.set('General', 'OLDCONFIG_VERSION', str(self.CONFIG_VERSION))
+            setattr(self, 'CONFIG_VERSION', self.newconfig)
+            config.set('General', 'CONFIG_VERSION', str(self.newconfig))
+            self.writeconfig()
+        else:
+            if self.OLDCONFIG_VERSION != self.CONFIG_VERSION:
+                setattr(self, 'OLDCONFIG_VERSION', str(self.CONFIG_VERSION))
+                #config.set('General', 'OLDCONFIG_VERSION', str(self.CONFIG_VERSION))
+
         if startup is True:
             if self.LOG_DIR is None:
                 self.LOG_DIR = os.path.join(mylar.DATA_DIR, 'logs')
@@ -587,18 +620,21 @@ class Config(object):
                 shutil.move(self._config_file, os.path.join(mylar.DATA_DIR, 'config.ini.backup'))
             except:
                 logger.warn('Unable to make proper backup of config file in %s' % os.path.join(mylar.DATA_DIR, 'config.ini.backup'))
-            if self.CONFIG_VERSION < 11:
+            if self.CONFIG_VERSION < 12:
                 logger.info('Attempting to update configuration..')
                 #8-torznab multiple entries merged into extra_torznabs value
                 #9-remote rtorrent ssl option
                 #10-encryption of all keys/passwords.
                 #11-provider_ids
+                #12-ddl separation into multiple providers, new keys, update tables
                 self.config_update()
-            setattr(self, 'CONFIG_VERSION', str(self.newconfig))
-            config.set('General', 'CONFIG_VERSION', str(self.newconfig))
+            setattr(self, 'CONFIG_VERSION', self.newconfig)
+            config.set('General', 'CONFIG_VERSION', self.newconfig)
             self.writeconfig()
 
-        self.provider_sequence()
+        if startup is False:
+            # need to do provider sequence AFTER db check
+            self.provider_sequence()
         self.configure(startup=startup)
         if self.WRITE_THE_CONFIG is True:
             self.writeconfig()
@@ -663,6 +699,15 @@ class Config(object):
             #        b_list.append(tuple(tmp_i))
             #        b_cnt +=1
             #setattr(self, 'EXTRA_TORZNABS', b_list)
+
+        if self.newconfig < 12:
+            #change enable_ddl to be a true/false for multiple ddl providers
+            #set enable_getcomics to True by default if that's the case.
+            if self.ENABLE_DDL is True:
+                self.ENABLE_GETCOMICS = True
+                config.set('DDL', 'enable_getcomics', self.ENABLE_GETCOMICS)
+            #tables will be updated by checking the OLDCONFIG_VERSION in __init__
+            logger.info('Successfully updated config to version 12 ( multiple DDL provider option )')
 
         logger.info('Configuration upgraded to version %s' % self.newconfig)
 
@@ -940,7 +985,7 @@ class Config(object):
 
         if self.GIT_TOKEN:
             self.GIT_TOKEN = (self.GIT_TOKEN, 'x-oauth-basic')
-            logger.info('git_token set to %s' % (self.GIT_TOKEN,))
+            #logger.info('git_token set to %s' % (self.GIT_TOKEN,))
 
         try:
             if not any([self.SAB_HOST is None, self.SAB_HOST == '', 'http://' in self.SAB_HOST[:7], 'https://' in self.SAB_HOST[:8]]):
@@ -1185,10 +1230,19 @@ class Config(object):
             setattr(self, 'FOLDER_FORMAT', ann_remove)
             config.set('General', 'folder_format', ann_remove)
 
+        # need to recheck this cause of how enable_ddl and enable_getcomics are now
+        self.ENABLE_GETCOMICS = self.ENABLE_DDL
+        config.set('DDL', 'enable_getcomics', str(self.ENABLE_GETCOMICS))
+
         if not self.DDL_LOCATION:
             self.DDL_LOCATION = self.CACHE_DIR
             if self.ENABLE_DDL is True:
                 logger.info('Setting DDL Location set to : %s' % self.DDL_LOCATION)
+        else:
+            dcreate = filechecker.validateAndCreateDirectory(self.DDL_LOCATION, create=True, dmode='ddl location')
+            if dcreate is False and self.ENABLE_DDL is True:
+                logger.warn('Unable to create ddl_location specified in config: %s. Reverting to default cache location.' % self.DDL_LOCATION)
+                self.DDL_LOCATION = self.CACHE_DIR
 
         if self.MODE_32P is False and self.RSSFEED_32P is not None:
             mylar.KEYS_32P = self.parse_32pfeed(self.RSSFEED_32P)
@@ -1424,10 +1478,11 @@ class Config(object):
             PR_NUM +=1
 
         if self.ENABLE_DDL:
-            PR.append('DDL')
-            PR_NUM +=1
+            if self.ENABLE_GETCOMICS:
+                PR.append('DDL(GetComics)')
+                PR_NUM +=1
 
-        PPR = ['32p', 'nzb.su', 'dognzb', 'Experimental', 'DDL']
+        PPR = ['32p', 'nzb.su', 'dognzb', 'Experimental', 'DDL(GetComics)']
         if self.NEWZNAB:
             for ens in self.EXTRA_NEWZNABS:
                 if str(ens[5]) == '1': # if newznabs are enabled
@@ -1552,6 +1607,8 @@ class Config(object):
         setattr(self, 'PROVIDER_ORDER', PROVIDER_ORDER)
         logger.fdebug('Provider Order is now set : %s ' % self.PROVIDER_ORDER)
 
+        self.write_out_provider_searches()
+
     def write_extras(self, value):
         flattened = []
         for item in value:
@@ -1569,3 +1626,44 @@ class Config(object):
                     ib = i
                 flattened.append(str(ib))
         return flattened
+
+    def write_out_provider_searches(self):
+       # this is needed for rss to work since the provider table isn't written to
+       # until a search is performed
+       myDB = db.DBConnection()
+       chk = myDB.select("SELECT * FROM provider_searches")
+       p_list = {}
+       if chk:
+           for ck in chk:
+               p_list[ck['provider']] = {'active': ck['active'], 'lastrun': ck['lastrun'], 'type': ck['type']}
+
+       for k, v in self.PROVIDER_ORDER.items():
+           if not any(p == v for p, pv in p_list.items()):
+               logger.info('%s was not found in search db. Writing it..' % v)
+               if 'DDL' in v:
+                   t_type = 'DDL'
+               elif 'experimental' in v:
+                   t_type = 'experimental'
+               elif 'dog' in v:
+                   t_type = 'dognzb'
+               elif 'nzbsu' in v:
+                   t_type = 'nzbsu'
+               else:
+                   nnf = False
+                   if self.EXTRA_NEWZNABS:
+                       for n in self.EXTRA_NEWZNABS:
+                           if n[0] == v:
+                               t_type = 'newznab'
+                               nnf = True
+                               break
+                   if nnf is False and self.EXTRA_TORZNABS:
+                       for n in self.EXTRA_TORZNABS:
+                           if n[0] == v:
+                               t_type = 'torznab'
+                               nnf = True
+                               break
+
+               vals = {'active': False, 'lastrun': 0, 'type': t_type}
+               ctrls = {'provider': v}
+               logger.info('writing: keys - %s: vals - %s' % (vals, ctrls))
+               writeout = myDB.upsert("provider_searches", vals, ctrls)

--- a/mylar/cv.py
+++ b/mylar/cv.py
@@ -898,7 +898,8 @@ def GetIssuesInfo(comicid, dom, arcid=None):
                 logger.fdebug('No Issue Number available - Trade Paperbacks, Graphic Novels and Compendiums are not supported as of yet.')
             else:
                 tempissue['Issue_Number'] = tempissue['Issue_Number'].strip()
-
+                if 'Issue #' in tempissue['Issue_Number']:
+                    tempissue['Issue_Number'] = re.sub('Issue #', '', tempissue['Issue_Number']).strip()
             try:
                 tempissue['ComicImage'] = subtrack.getElementsByTagName('small_url')[0].firstChild.wholeText
             except:
@@ -1332,6 +1333,10 @@ def UpdateDates(dom):
         except:
             logger.fdebug('No Issue Number available - Trade Paperbacks, Graphic Novels and Compendiums are not supported as of yet.')
             tempissue['IssueNumber'] = 'None'
+        else:
+            if 'Issue #' in tempissue['IssueNumber']:
+                tempissue['IssueNumber'] = re.sub('Issue #', '', tempissue['IssueNumber']).strip()
+
         try:
             tempissue['date_last_updated'] = dm.getElementsByTagName('date_last_updated')[0].firstChild.wholeText
         except:
@@ -1365,6 +1370,11 @@ def singleIssue(results):
         issue_info['issueid'] = data['id']
         issue_info['image'] = data['image']['medium_url'] #/ ['screen_url'] / ['screen_large_url'] / ['original_url']
         issue_info['issue_number'] = data['issue_number']
+        try:
+            if 'Issue #' in issue_info['issue_number']:
+                issue_info['issue_number'] = re.sub('Issue #', '', issue_info['issue_number']).strip()
+        except Exception:
+            pass
         for x in data['person_credits']:
             issuecredits.append({'role': x['role'], 'name': x['name']})
         issue_info['credits'] = issuecredits
@@ -1408,6 +1418,9 @@ def GetImportList(results):
             tempseries['Issue_Number'] = implist.getElementsByTagName('issue_number')[0].firstChild.wholeText
         except:
             logger.fdebug('No Issue Number available - Trade Paperbacks, Graphic Novels and Compendiums are not supported as of yet.')
+        else:
+            if 'Issue #' in tempseries['Issue_Number']:
+                tempseries['Issue_Number'] = re.sub('Issue #', '', tempseries['Issue_Number']).strip()
 
         logger.info('tempseries:' + str(tempseries))
         serieslist.append({"ComicID":      tempseries['ComicID'],
@@ -1458,7 +1471,7 @@ def drophtml(html):
     else:
         return ''
 
-def get_imprint_volume_and_booktype(series, comicyear, publisher, firstissueid, description, deck):
+def get_imprint_volume_and_booktype(series, comicyear, publisher, firstissueid, description, deck, annual_check=False):
     # this is used to quick_load the imprint, volume and booktype of a specific issue (ie. searchresults editing a result)
     comic = {}
 
@@ -1580,7 +1593,10 @@ def get_imprint_volume_and_booktype(series, comicyear, publisher, firstissueid, 
     desdeck = 0
     #the description field actually holds the Volume# - so let's grab it
     try:
-        comic_desc = drophtml(description)
+        if annual_check is False:
+            comic_desc = drophtml(description)
+        else:
+            comic_desc = description
         desdeck +=1
     except:
         comic_desc = 'None'

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -1011,8 +1011,8 @@ class FileChecker(object):
                     issue_number = issue_year
                     issue_year = None
                 elif len(volume_found) > 0:
-                    logger.fdebug('Possible UNKNOWN TPB/GN/HC detected. Volume assumption is number: %s' % (volume_found))
-                    booktype = 'TPB/GN/HC'
+                    logger.fdebug('Possible UNKNOWN TPB/GN/HC {One-Shot} detected. Volume assumption is number: %s' % (volume_found))
+                    booktype = 'TPB/GN/HC/One-Shot'
                 else:
                     logger.fdebug('No issue number present in filename.')
         else:

--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -113,6 +113,7 @@ class FileHandlers(object):
         publisher = re.sub('!', '', self.comic['ComicPublisher']) # thanks Boom!
         publisher = helpers.filesafe(publisher)
 
+
         if booktype is not None:
             if self.comic['Corrected_Type'] is not None:
                 if self.comic['Corrected_Type'] != booktype:
@@ -133,10 +134,15 @@ class FileHandlers(object):
         else:
             chunk_folder_format = folder_format
 
-        if any([self.comic['ComicVersion'] is None, booktype != 'Print']):
+        if self.comic['ComicVersion'] is None:
             comicVol = 'None'
         else:
-            comicVol = self.comic['ComicVersion']
+            if booktype != 'Print':
+                comicVol = self.comic['ComicVersion']
+            else:
+                comicVol = self.comic['ComicVersion']
+            if comicVol is None:
+                comicVol = 'None'
 
         #if comversion is None, remove it so it doesn't populate with 'None'
         if comicVol == 'None':
@@ -160,6 +166,9 @@ class FileHandlers(object):
             chunk_folder_format = chunk_folder_format[:ccf+1] + chunk_folder_format[ccf+2:]
 
         chunk_folder_format = re.sub(r'\s+', ' ', chunk_folder_format)
+
+        # if the path contains // in linux it will incorrectly parse things out.
+        logger.fdebug('newPath: %s' % re.sub('//', '/', chunk_folder_format).strip())
 
         #do work to generate folder path
         values = {'$Series':        series,

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3186,8 +3186,9 @@ def ddl_downloader(queue):
                    'updated_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M')}
             myDB.upsert('ddl_info', val, ctrlval)
 
-            ddz = getcomics.GC()
-            ddzstat = ddz.downloadit(item['id'], item['link'], item['mainlink'], item['resume'])
+            if item['site'] == 'DDL(GetComics)':
+                ddz = getcomics.GC()
+                ddzstat = ddz.downloadit(item['id'], item['link'], item['mainlink'], item['resume'], item['issueid'])
 
             if ddzstat['success'] is True:
                 tdnow = datetime.datetime.now()
@@ -3607,7 +3608,7 @@ def date_conversion(originaldate):
     hours = (absdiff.days * 24 * 60 * 60 + absdiff.seconds) / 3600.0
     return hours
 
-def job_management(write=False, job=None, last_run_completed=None, current_run=None, status=None):
+def job_management(write=False, job=None, last_run_completed=None, current_run=None, status=None, failure=False):
         jobresults = []
 
         #import db
@@ -3793,7 +3794,12 @@ def job_management(write=False, job=None, last_run_completed=None, current_run=N
                                 jobstore = jbst
                                 break
                             elif job == 'Auto-Search' and 'search' in jb.lower():
-                                nextrun_stamp = utctimestamp() + (mylar.CONFIG.SEARCH_INTERVAL * 60)
+                                if failure is True:
+                                   logger.info('Previous job could not run due to other jobs. Scheduling Auto-Search for 10 minutes from now.')
+                                   s_interval = (10 * 60)
+                                else:
+                                   s_interval = mylar.CONFIG.SEARCH_INTERVAL * 60
+                                nextrun_stamp = utctimestamp() + s_interval
                                 jobstore = jbst
                                 break
                             elif job == 'RSS Feeds' and 'rss' in jb.lower():

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -1632,7 +1632,7 @@ def annual_check(ComicName, SeriesYear, comicid, issuetype, issuechk, annualslis
 
         annualyear = SeriesYear  # no matter what, the year won't be less than this.
         logger.fdebug('[IMPORTER-ANNUAL] - Annual Year:' + str(annualyear))
-        sresults = mb.findComic(annComicName, mode, issue=None)
+        sresults = mb.findComic(annComicName, mode, issue=None, annual_check=True)
         if not sresults:
             return
 
@@ -1643,7 +1643,7 @@ def annual_check(ComicName, SeriesYear, comicid, issuetype, issuechk, annualslis
             num_res = 0
             while (num_res < len(sresults)):
                 sr = sresults[num_res]
-                #logger.fdebug("description:" + sr['description'])
+                #logger.fdebug('description:%s' % sr['description'])
                 for x in annual_types_ignore:
                     if x in sr['description'].lower():
                         test_id_position = sr['description'].find(comicid)
@@ -1743,7 +1743,7 @@ def annual_check(ComicName, SeriesYear, comicid, issuetype, issuechk, annualslis
 
         elif sresults is None or len(sresults) == 0:
             logger.fdebug('[IMPORTER-ANNUAL] - No results, removing the year from the agenda and re-querying.')
-            sresults = mb.findComic(annComicName, mode, issue=None)
+            sresults = mb.findComic(annComicName, mode, issue=None, annual_check=True)
             if not sresults:
                 return
             elif len(sresults) == 1:

--- a/mylar/maintenance.py
+++ b/mylar/maintenance.py
@@ -21,7 +21,7 @@ import sqlite3
 import json
 
 import mylar
-from mylar import logger, importer
+from mylar import logger, importer, filechecker, helpers
 
 class Maintenance(object):
 
@@ -37,6 +37,7 @@ class Maintenance(object):
         self.comiclist = []
         self.maintenance_success = []
         self.maintenance_fail = []
+        self.db_version = 0
 
     def sql_attachmylar(self):
         self.connectmylar = sqlite3.connect(self.dbfile)
@@ -49,11 +50,124 @@ class Maintenance(object):
     def sql_attach(self):
         self.conn = sqlite3.connect(self.maintenance_db)
         self.db = self.conn.cursor()
-        self.db.execute('CREATE TABLE IF NOT EXISTS maintenance (id TEXT, mode TEXT, status TEXT, progress TEXT, total TEXT, current TEXT, last_comicid TEXT, last_series TEXT, last_seriesyear TEXT)')
+        if self.mode == 'db update':
+            self.db.execute('CREATE TABLE IF NOT EXISTS update_db (version INT, mode TEXT PRIMARY KEY, status TEXT, total INT, current INT, last_run TEXT)')
+        else:
+            self.db.execute('CREATE TABLE IF NOT EXISTS maintenance (id TEXT, mode TEXT, status TEXT, progress TEXT, total TEXT, current TEXT, last_comicid TEXT, last_series TEXT, last_seriesyear TEXT)')
+        self.conn.commit()
 
     def sql_close(self):
         self.conn.commit()
         self.db.close()
+
+    def db_version_check(self, display=True):
+        self.db_version = 0
+        tmp_version = 0
+
+        self.sql_attachmylar()
+        self.dbmylar.execute('SELECT DatabaseVersion from mylar_info')
+        tmp_version = self.dbmylar.fetchone()
+        if not tmp_version:
+            self.db_version = 0
+        else:
+            self.db_version = tmp_version[0]
+        self.sql_closemylar()
+
+        #self.sql_attach()
+        #for vchk in self.db.execute('SELECT version, status from update_db'):
+        #    if vchk[1] == 'complete':
+        #        self.db_version = vchk[0]
+        #    elif vchk[1] == 'incomplete':
+        #        self.db_version = tmp_version
+        #    tmp_version = vchk[0]
+        #self.sql_close()
+
+        if display:
+            logger.fdebug('[DB_VERSION_CHECK] Database version is v%s' % (self.db_version))
+
+
+    def db_update_check(self):
+        # this is meant to hold all the updates that are required to be run against the dB at any given time.
+        # if a dbupdate is required of any kind, it will be initiated and controlled from via direct code.
+
+        self.db_version_check()
+
+        if self.db_version < 1:
+
+            # -- rssdb table - ComicName and Issue_Number added.
+            # Values are generated based on existing data
+
+            self.sql_attachmylar()
+            try:
+                self.dbmylar.execute('SELECT Issue_Number from rssdb')
+            except sqlite3.OperationalError:
+                self.dbmylar.execute('ALTER TABLE rssdb ADD COLUMN Issue_Number TEXT')
+                if not any(d.get('mode', None) == 'rss update' for d in mylar.MAINTENANCE_UPDATE):
+                    mylar.MAINTENANCE_UPDATE.append({'mode': 'rss update', 'resume': 0})
+
+            try:
+                self.dbmylar.execute('SELECT ComicName from rssdb')
+            except sqlite3.OperationalError:
+                self.dbmylar.execute('ALTER TABLE rssdb ADD COLUMN ComicName TEXT')
+                if not any(d.get('mode', None) == 'rss update' for d in mylar.MAINTENANCE_UPDATE):
+                    mylar.MAINTENANCE_UPDATE.append({'mode': 'rss update', 'resume': 0})
+
+
+            if not any(d.get('mode', None) == 'rss update' for d in mylar.MAINTENANCE_UPDATE):
+                try:
+                    number_check = self.dbmylar.execute('SELECT rowid from rssdb WHERE Issue_Number is NULL AND ComicName is NULL ORDER BY rowid ASC LIMIT 10')
+                    checked = number_check.fetchall()
+                    if checked:
+                        chk_cnt = 0
+                        resume = []
+                        for ck in checked:
+                            if chk_cnt == 0:
+                                lower = ck[0]
+                                upper = ck[0]
+                                chk_cnt += 1
+                                continue
+                            else:
+                                upper = ck[0]
+                            if lower+1 == upper:
+                                resume.append(lower) # + 1)
+
+                            lower = upper
+                            chk_cnt += 1
+
+                        if len(resume) > 3:
+                            logger.info('[DB-CHECK-UPDATE] Tables are correct, but some data is possibly incorrect. Attempting to resume the RSS Update from record %s' % resume[0])
+                            if not any(d.get('mode', None) == 'rss update' for d in mylar.MAINTENANCE_UPDATE):
+                                mylar.MAINTENANCE_UPDATE.append({'mode': 'rss update', 'resume': resume[0]})
+                    else:
+                        if self.db_version == 0:
+                            logger.info('Updating database to v1 as no data is present to update')
+                            try:
+                                self.dbmylar.execute("UPDATE mylar_info SET DatabaseVersion=? WHERE DatabaseVersion=?", (1, self.db_version))
+                            except Exception as e:
+                                print('error: %s' % e)
+                            else:
+                                self.db_version = 1
+                except Exception as e:
+                   logger.fdebug('[DB-CHECK-UPDATE] Checking DB for sequence containing NULL values did not complete. Ignoring this check.')
+
+            self.sql_closemylar()
+        else:
+            logger.fdebug('[DB-CHECK-UPDATE] Nothing needs updating within dB.')
+
+
+    def check_failed_update(self):
+        self.sql_attach()
+        query = 'SELECT * FROM update_db'
+        check_update = self.db.execute(query)
+        checked = check_update.fetchone()
+        if checked is not None:
+            if checked[2] == 'incomplete':
+                if not any(d.get('mode', None) == checked[1] for d in mylar.MAINTENANCE_UPDATE):
+                    logger.info('[PREVIOUS_UPDATE_CHECK] Previous update of database did not complete. Let\'s do this again! (it is a requirement)')
+                    mylar.MAINTENANCE_UPDATE.append({'mode': checked[1], 'resume': checked[4]})
+        else:
+            logger.info('checked is None')
+        self.sql_close()
 
     def database_import(self):
         self.sql_attachmylar()
@@ -195,3 +309,208 @@ class Maintenance(object):
         except Exception as e:
             logger.warn('[ERROR] %s' % e)
 
+    def db_update_status(self, statusinfo):
+        self.sql_attach()
+
+        #if statusinfo['status'] == 'incomplete':
+        #    query = "DELETE from update_db where status='incomplete'"
+        #    self.db.execute(query)
+        #    query = "INSERT INTO update_db(version, status, total, current, last_run, mode) VALUES (?,?,?,?,?,?)"
+        #else:
+        query = 'INSERT OR REPLACE INTO update_db(mode, version, status, total, current, last_run) VALUES(?,?,?,?,?,?)'
+
+        try:
+            args = (statusinfo['mode'], statusinfo['version'], statusinfo['status'], statusinfo['total'], statusinfo['current'], statusinfo['last_run'])
+            self.db.execute(query, args)
+        except Exception as e :
+            print('error_writing: %s' % e)
+        self.sql_close()
+        if statusinfo['status'] == 'complete':
+            try:
+                self.sql_attachmylar()
+                print('status_version: %s / db_version: %s' % (statusinfo['version'], self.db_version))
+                self.dbmylar.execute("UPDATE mylar_info SET DatabaseVersion=? WHERE DatabaseVersion=?", (statusinfo['version'], self.db_version))
+            except Exception as e:
+                print('error: %s' % e)
+            self.sql_closemylar()
+
+
+    def toggle_logging(self, level):
+        #force set logging to warning level only so the progress indicator can be displayed in console
+        wc = mylar.webserve.WebInterface()
+        wc.toggleVerbose(level=level)
+
+    def update_db(self):
+
+        # mylar.MAINTENANCE_UPDATE will indicate what's being updated in the db
+        if mylar.MAINTENANCE_UPDATE:
+            self.db_version_check(display=False)
+
+            for dmode in mylar.MAINTENANCE_UPDATE:
+                if dmode['mode'] == 'rss update':
+                    logger.info('[MAINTENANCE-MODE][DB-CONVERSION] Updating dB due to RSS table conversion')
+                    if dmode['resume'] > 0:
+                        logger.info('[MAINTENANCE-MODE][DB-CONVERSION][DB-RECOVERY] Attempting to resume conversion from previous run (starting at record: %s)' % dmode['resume'])
+
+                #force set logging to warning level only so the progress indicator can be displayed in console
+                prev_log_level = mylar.LOG_LEVEL
+                self.toggle_logging(level=0)
+
+                if dmode['mode'] == 'rss update':
+                    self.sql_attachmylar()
+
+                    row_cnt = self.dbmylar.execute("SELECT COUNT(rowid) as count FROM rssdb")
+                    rowcnt = row_cnt.fetchone()[0]
+                    mylar.MAINTENANCE_DB_TOTAL = rowcnt
+
+                    if dmode['resume'] > 0:
+                        xt = self.dbmylar.execute("SELECT rowid, Title FROM rssdb WHERE rowid >= ? ORDER BY rowid ASC", [dmode['resume']])
+                    else:
+                        xt = self.dbmylar.execute("SELECT rowid, Title FROM rssdb ORDER BY rowid ASC")
+                    xlist = xt.fetchall()
+
+                    mylar.MAINTENANCE_DB_COUNT = 0
+
+                    if xlist is None:
+                        print('Nothing in the rssdb to update. Ignoring.')
+                        return True
+
+                    try:
+                        if dmode['resume'] > 0 and xlist is not None:
+                            logger.info('resume set at : %s' % (xlist[dmode['resume']],))
+                            #xlist[dmode['resume']:]
+                            mylar.MAINTENANCE_DB_COUNT = dmode['resume']
+                    except Exception as e:
+                        print('[ERROR:%s] - table resume location is not accureate. Starting from start, but this should go quick..' % e)
+                        xt = self.dbmylar.execute("SELECT rowid, Title FROM rssdb ORDER BY rowid ASC")
+                        xlist = xt.fetchall()
+                        dmode['resume'] = 0
+
+                    if xlist:
+                        resultlist = []
+                        for x in self.progressBar(xlist, prefix='Progress', suffix='Complete', length = 50, resume=dmode['resume']):
+
+                            #signal capture here since we can't do it as per normal
+                            if any([mylar.SIGNAL == 'shutdown', mylar.SIGNAL == 'restart']):
+                                try:
+                                    self.dbmylar.executemany("UPDATE rssdb SET Issue_Number=?, ComicName=? WHERE rowid=?", (resultlist))
+                                    self.sql_closemylar()
+                                except Exception as e:
+                                    print('error: %s' % e)
+                                else:
+                                    send_it = {'mode': dmode['mode'],
+                                               'version': self.db_version,
+                                               'status': 'incomplete',
+                                               'total': mylar.MAINTENANCE_DB_TOTAL,
+                                               'current': mylar.MAINTENANCE_DB_COUNT,
+                                               'last_run': helpers.utctimestamp()}
+                                    self.db_update_status(send_it)
+
+                                #toggle back the logging level to what it was originally.
+                                self.toggle_logging(level=prev_log_level)
+
+                                if mylar.SIGNAL == 'shutdown':
+                                    logger.info('[MAINTENANCE-MODE][DB-CONVERSION][SHUTDOWN]Shutting Down...')
+                                    return False
+                                else:
+                                    logger.info('[MAINTENANCE-MODE][DB-CONVERSION][RESTART]Restarting...')
+                                    return True
+
+                            mylar.MAINTENANCE_DB_COUNT +=1
+                            if not x[1]:
+                                continue
+                            flc = filechecker.FileChecker(file=x[1])
+                            filelist = flc.listFiles()
+                            if all([filelist['series_name'] != '', filelist['series_name'] is not None]) and filelist['issue_number'] != '-':
+                                issuenumber = filelist['issue_number']
+                                seriesname = re.sub(r'[\u2014|\u2013|\u2e3a|\u2e3b]', '-', filelist['series_name']).strip()
+                                if seriesname.endswith('-') and '#' in seriesname[-6:]:
+                                    ck1 = seriesname.rfind('#')
+                                    ck2 = seriesname.rfind('-')
+                                    if seriesname[ck1+1:ck2-1].strip().isdigit():
+                                        issuenumber = '%s %s' % (seriesname[ck1:].strip(), issuenumber)
+                                        seriesname = seriesname[:ck1 -1].strip()
+                                        issuenumber.strip()
+                                resultlist.append((issuenumber, seriesname.strip(), x[0]))
+
+                            if len(resultlist) > 500:
+                                # write it out every 5000 records.
+                                try:
+                                    logger.info('resultlist: %s' % (resultlist,))
+                                    self.dbmylar.executemany("UPDATE rssdb SET Issue_Number=?, ComicName=? WHERE rowid=?", (resultlist))
+                                    self.sql_closemylar()
+                                    # update the update_db so if it has to resume it doesn't from the beginning or wrong point ( last 5000th write ).
+                                    send_it = {'mode': dmode['mode'],
+                                               'version': self.db_version,
+                                               'status': 'incomplete',
+                                               'total': mylar.MAINTENANCE_DB_TOTAL,
+                                               'current': mylar.MAINTENANCE_DB_COUNT,
+                                               'last_run': helpers.utctimestamp()}
+                                    self.db_update_status(send_it)
+
+                                except Exception as e:
+                                    print('error: %s' % e)
+                                    return False
+                                else:
+                                    logger.info('reattaching')
+                                    self.sql_attachmylar()
+                                    resultlist = []
+
+                        try:
+                            if len(resultlist) > 0:
+                                self.dbmylar.executemany("UPDATE rssdb SET Issue_Number=?, ComicName=? WHERE rowid=?", (resultlist))
+                                self.sql_closemylar()
+                        except Exception as e:
+                            print('error: %s' % e)
+                            return False
+                        else:
+                            try:
+                                send_it = {'mode': dmode['mode'],
+                                           'version': 1,
+                                           'status': 'complete',
+                                           'total': mylar.MAINTENANCE_DB_TOTAL,
+                                           'current': mylar.MAINTENANCE_DB_COUNT,
+                                           'last_run': helpers.utctimestamp()}
+                            except Exception as e:
+                                print('error_sendit: %s' % e)
+                            else:
+                                self.db_update_status(send_it)
+
+                            #toggle back the logging level to what it was originally.
+                            self.toggle_logging(level=prev_log_level)
+                            logger.info('[MAINTENANCE-MODE][DB-CONVERSION] Updating dB complete! (%s / %s)' % (mylar.MAINTENANCE_DB_COUNT, mylar.MAINTENANCE_DB_TOTAL))
+                            mylar.MAINTENANCE_UPDATE[:] = [x for x in mylar.MAINTENANCE_UPDATE if not ('rss update' == x.get('mode'))]
+
+        else:
+            mylar.MAINTENANCE_DB_COUNT = 0
+            logger.info('[MAINTENANCE-MODE] Update DB set to start - but nothing was provided as to what. Returning to non-maintenance mode')
+        return True
+
+    def progressBar(self, iterable, prefix = '', suffix = '', decimals = 1, length = 100, resume=0, fill = '█', printEnd = "\r"):
+        """
+        Call in a loop to create terminal progress bar
+        @params:
+            iteration   - Required  : current iteration (Int)
+            total       - Required  : total iterations (Int)
+            prefix      - Optional  : prefix string (Str)
+            suffix      - Optional  : suffix string (Str)
+            decimals    - Optional  : positive number of decimals in percent complete (Int)
+            length      - Optional  : character length of bar (Int)
+            fill        - Optional  : bar fill character (Str)
+            printEnd    - Optional  : end character (e.g. "\r", "\r\n") (Str)
+        """
+        total = len(iterable)
+        # Progress Bar Printing Function
+        def printProgressBar (iteration):
+            percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
+            filledLength = int(length * iteration // total)
+            bar = fill * filledLength + '-' * (length - filledLength)
+            print(f'\r{prefix} |{bar}| {percent}% {suffix}', end = printEnd)
+        # Initial Call
+        printProgressBar(0)
+        # Update Progress Bar
+        for i, item in enumerate(iterable):
+            yield item
+            printProgressBar(resume + i + 1)
+        # Print New Line on Complete
+        print()

--- a/mylar/maintenance_webstart.py
+++ b/mylar/maintenance_webstart.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+
+#  This file is part of Mylar.
+#
+#  Mylar is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Mylar is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+import cherrypy
+import portend as portend
+
+import mylar
+from mylar import logger
+from mylar.webserve import WebMaintenance
+from mylar.helpers import create_https_certificates
+
+def initialize(options):
+
+    # HTTPS stuff stolen from sickbeard
+    enable_https = options['enable_https']
+    https_cert = options['https_cert']
+    https_key = options['https_key']
+    https_chain = options['https_chain']
+
+    if enable_https:
+        # If either the HTTPS certificate or key do not exist, try to make
+        # self-signed ones.
+        if not (https_cert and os.path.exists(https_cert)) or not (https_key and os.path.exists(https_key)):
+            if not create_https_certificates(https_cert, https_key):
+                logger.warn("Unable to create certificate and key. Disabling " \
+                    "HTTPS")
+                enable_https = False
+
+        if not (os.path.exists(https_cert) and os.path.exists(https_key)):
+            logger.warn("Disabled HTTPS because of missing certificate and " \
+                "key.")
+            enable_https = False
+
+    options_dict = {
+        'server.socket_port': options['http_port'],
+        'server.socket_host': options['http_host'],
+        'server.thread_pool': 10,
+        'tools.encode.on': True,
+        'tools.encode.encoding': 'utf-8',
+        'tools.encode.text_only': False,
+        'tools.decode.on': True,
+        'log.screen': False,
+        'engine.autoreload.on': False,
+    }
+
+    if enable_https:
+        options_dict['server.ssl_certificate'] = https_cert
+        options_dict['server.ssl_private_key'] = https_key
+        if https_chain:
+            options_dict['server.ssl_certificate_chain'] = https_chain
+        protocol = "https"
+    else:
+        protocol = "http"
+
+    logger.info("[MAINTENANCE-MODE] Starting Mylar in maintenance mode on %s://%s:%d%s" % (protocol,options['http_host'], options['http_port'], options['http_root']))
+    cherrypy.config.update(options_dict)
+
+    conf = {
+        '/': {
+            'tools.staticdir.root': os.path.join(mylar.PROG_DIR, 'data'),
+            'tools.proxy.on': True  # pay attention to X-Forwarded-Proto header
+        },
+        '/interfaces': {
+            'tools.staticdir.on': True,
+            'tools.staticdir.dir': "interfaces"
+        },
+        '/images': {
+            'tools.staticdir.on': True,
+            'tools.staticdir.dir': "images"
+        },
+        '/css': {
+            'tools.staticdir.on': True,
+            'tools.staticdir.dir': "css"
+        },
+        '/js': {
+            'tools.staticdir.on': True,
+            'tools.staticdir.dir': "js"
+        },
+        '/favicon.ico': {
+            'tools.staticfile.on': True,
+            'tools.staticfile.filename': os.path.join(os.path.abspath(os.curdir), 'images' + os.sep + 'favicon.ico')
+        },
+        '/cache': {
+            'tools.staticdir.on': True,
+            'tools.staticdir.dir': mylar.CONFIG.CACHE_DIR
+        }
+    }
+
+    if options['http_password'] is not None:
+        #userpassdict = dict(zip((options['http_username'].encode('utf-8'),), (options['http_password'].encode('utf-8'),)))
+        #get_ha1= cherrypy.lib.auth_digest.get_ha1_dict_plain(userpassdict)
+        if options['authentication'] == 2:
+            # Set up a sessions based login page instead of using basic auth,
+            # using the credentials set for basic auth. Attempting to browse to
+            # a restricted page without a session token will result in a
+            # redirect to the login page. A sucessful login should then redirect
+            # to the originally requested page.
+            #
+            # Login sessions timeout after 43800 minutes (1 month) unless
+            # changed in the config.
+            # Note - the following command doesn't actually work, see update statement 2 lines down
+            # cherrypy.tools.sessions.timeout = options['login_timeout']
+            conf['/'].update({
+                'tools.sessions.on': True,
+                'tools.auth.on': True,
+                'tools.sessions.timeout': options['login_timeout'],
+                'auth.forms_username': options['http_username'],
+                'auth.forms_password': options['http_password'],
+                # Set all pages to require authentication.
+                # You can also set auth requirements on a per-method basis by
+                # using the @require() decorator on the methods in webserve.py
+                'auth.require': []
+            })
+            # exempt api, login page and static elements from authentication requirements
+            for i in ('/api', '/auth/login', '/css', '/images', '/js', 'favicon.ico'):
+                if i in conf:
+                    conf[i].update({'tools.auth.on': False})
+                else:
+                    conf[i] = {'tools.auth.on': False}
+        elif options['authentication'] == 1:
+            conf['/'].update({
+                        'tools.auth_basic.on': True,
+                        'tools.auth_basic.realm': 'Mylar',
+                        'tools.auth_basic.checkpassword':  cherrypy.lib.auth_basic.checkpassword_dict(
+                                {options['http_username']: options['http_password']})
+                    })
+
+    cherrypy.tree.mount(WebMaintenance(), str(options['http_root']), config = conf)
+
+    cherrypy.config.update({'error_page.default': os.path.join(mylar.PROG_DIR, 'data', 'interfaces', 'default', 'maintenance_mode.html')})
+
+    try:
+        portend.Checker().assert_free(options['http_host'], options['http_port'])
+        cherrypy.server.start()
+    except Exception as e:
+        logger.error('[ERROR] %s' % e)
+        print('Failed to start on port: %i. Is something else running?' % (options['http_port']))
+        sys.exit(0)
+
+    cherrypy.server.wait()
+
+def shutdown():
+    cherrypy.engine.exit()
+    cherrypy.config.update({ 'server.shutdown_timeout': 1})

--- a/mylar/mb.py
+++ b/mylar/mb.py
@@ -90,7 +90,7 @@ def pullsearch(comicapi, comicquery, offset, search_type):
     else:
         return dom
 
-def findComic(name, mode, issue, limityear=None, search_type=None):
+def findComic(name, mode, issue, limityear=None, search_type=None, annual_check=False):
 
     #with mb_lock:
     comicResults = None
@@ -387,8 +387,8 @@ def findComic(name, mode, issue, limityear=None, search_type=None):
                             except:
                                 xmldeck = "None"
 
-                            givb = cv.get_imprint_volume_and_booktype(True, xmlYr, xmlpub, xml_firstissueid, xmldesc, xmldeck)
-                            logger.info('givb: %s' % (givb,))
+                            givb = cv.get_imprint_volume_and_booktype(True, xmlYr, xmlpub, xml_firstissueid, xmldesc, xmldeck, annual_check)
+                            logger.fdebug('givb: %s' % (givb,))
                             if givb:
                                 if givb['Type'] == 'None':
                                     xmltype = None

--- a/mylar/readinglist.py
+++ b/mylar/readinglist.py
@@ -49,7 +49,7 @@ class Readinglist(object):
             readlist = myDB.selectone("SELECT * from annuals where IssueID=?", [self.IssueID]).fetchone()
             if readlist is None:
                 logger.error(self.module + ' Cannot locate IssueID - aborting..')
-                return
+                return {'status': 'failure', 'message': 'Unable to locate issue in database. Does it exist?'}
             else:
                 logger.fdebug('%s Successfully found annual for %s' % (self.module, readlist['ComicID']))
                 annualize = True
@@ -57,6 +57,7 @@ class Readinglist(object):
         logger.info(self.module + ' Attempting to add issueid ' + readlist['IssueID'])
         if comicinfo is None:
             logger.info(self.module + ' Issue not located on your current watchlist. I should probably check story-arcs but I do not have that capability just yet.')
+            return {'status': 'failure', 'message': 'Unable to locate issue in your watchlist. Does it exist?'}
         else:
             locpath = None
             if all([mylar.CONFIG.MULTIPLE_DEST_DIRS is not None, mylar.CONFIG.MULTIPLE_DEST_DIRS != 'None']):
@@ -102,7 +103,7 @@ class Readinglist(object):
 
                 myDB.upsert("readlist", newval, ctrlval)
                 logger.info(self.module + ' Added ' + dspinfo + ' to the Reading list.')
-        return
+        return {'status': 'success', 'message': 'Successfully added %s to your reading list' % dspinfo}
 
     def markasRead(self, IssueID=None, IssueArcID=None):
         myDB = db.DBConnection()

--- a/mylar/rsscheck.py
+++ b/mylar/rsscheck.py
@@ -29,7 +29,7 @@ from io import StringIO
 from pkg_resources import parse_version
 
 import mylar
-from mylar import db, logger, ftpsshup, helpers, auth32p, utorrent, helpers
+from mylar import db, logger, ftpsshup, helpers, auth32p, utorrent, helpers, filechecker
 from mylar.torrent.clients import transmission
 from mylar.torrent.clients import  deluge as deluge
 from mylar.torrent.clients import qbittorrent as qbittorrent
@@ -395,8 +395,9 @@ def ddl(forcerss=False):
     headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1'}
     ddl_feed = 'https://getcomics.info/feed/'
     try:
-        r = requests.get(ddl_feed, verify=True, headers=headers)
+        r = requests.get(ddl_feed, verify=True, headers=headers, timeout=30)
     except Exception as e:
+        #need to handle timeouts / downtime here
         logger.warn('Error fetching RSS Feed Data from DDL: %s' % (e))
         return False
     else:
@@ -408,58 +409,59 @@ def ddl(forcerss=False):
                 logger.warn('[ERROR] Status code returned: %s' % r.status_code)
             return False
 
-        feedme = feedparser.parse(r.content)
-        results = []
-        for entry in feedme.entries:
-            soup = BeautifulSoup(entry.summary, 'html.parser')
-            orig_find = soup.find("p", {"style": "text-align: center;"})
-            i = 0
-            option_find = orig_find
-            while True: #i <= 10:
-                prev_option = option_find
-                option_find = option_find.findNext(text=True)
-                if 'Year' in option_find:
-                    year = option_find.findNext(text=True)
-                    year = re.sub('\|', '', year).strip()
-                else:
-                   if 'Size' in prev_option:
-                        size = option_find #.findNext(text=True)
-                        if '- MB' in size: size = '0 MB'
-                        possible_more = orig_find.next_sibling
-                        break
-            i+=1
+    feedme = feedparser.parse(r.content)
+    results = []
+    for entry in feedme.entries:
+        soup = BeautifulSoup(entry.summary, 'html.parser')
+        orig_find = soup.find("p", {"style": "text-align: center;"})
+        i = 0
+        option_find = orig_find
+        while True: #i <= 10:
+            prev_option = option_find
+            option_find = option_find.findNext(text=True)
+            if 'Year' in option_find:
+                year = option_find.findNext(text=True)
+                year = re.sub('\|', '', year).strip()
+            else:
+               if 'Size' in prev_option:
+                   size = option_find #.findNext(text=True)
+                   if '- MB' in size: size = '0 MB'
+                   possible_more = orig_find.next_sibling
+                   break
+        i+=1
 
-            link = entry.link
-            title = entry.title
-            updated = entry.updated
-            if updated.endswith('+0000'):
-                updated = updated[:-5].strip()
-            tmpid = entry.id
-            id = tmpid[tmpid.find('=')+1:]
-            if 'KB' in size:
-                szform = 'KB'
-                sz = 'K'
-            elif 'GB' in size:
-                szform = 'GB'
-                sz = 'G'
-            elif 'MB' in size:
-                szform = 'MB'
-                sz = 'M'
-            elif 'TB' in size:
-                szform = 'TB'
-                sz = 'T'
-            tsize = helpers.human2bytes(re.sub('[^0-9]', '', size).strip() + sz)
+        link = entry.link
+        title = entry.title
+        updated = entry.updated
+        if updated.endswith('+0000'):
+            updated = updated[:-5].strip()
+        tmpid = entry.id
+        id = tmpid[tmpid.find('=')+1:]
+        if 'KB' in size:
+            szform = 'KB'
+            sz = 'K'
+        elif 'GB' in size:
+            szform = 'GB'
+            sz = 'G'
+        elif 'MB' in size:
+            szform = 'MB'
+            sz = 'M'
+        elif 'TB' in size:
+            szform = 'TB'
+            sz = 'T'
+        tsize = helpers.human2bytes(re.sub('[^0-9]', '', size).strip() + sz)
 
-            #link can be referenced with the ?p=id url
-            results.append({'Title':   title,
-                            'Size':    tsize,
-                            'Link':    id,
-                            'Site':    'DDL',
-                            'Pubdate': updated})
+        #link can be referenced with the ?p=id url
+        results.append({'Title':   title,
+                        'Size':    tsize,
+                        'Link':    id,
+                        'Site':    'DDL(GetComics)',
+                        'Pubdate': updated})
 
-        if len(results) >0:
-            logger.info('[RSS][DDL] %s entries have been indexed and are now going to be stored for caching.' % len(results))
-            rssdbupdate(results, len(results), 'ddl')
+    logger.info('[DDL][RSS-RESULTS] %s' % (results,))
+    if len(results) >0:
+        logger.info('[RSS][DDL] %s entries have been indexed and are now going to be stored for caching.' % len(results))
+        rssdbupdate(results, len(results), 'ddl')
 
     return
 
@@ -630,19 +632,39 @@ def rssdbupdate(feeddata, i, type):
         if type == 'torrent':
             #we just store the torrent ID's now.
 
-            newVal = {"Link":      dataval['link'],
-                      "Pubdate":   dataval['pubdate'],
-                      "Site":      dataval['site'],
-                      "Size":      dataval['size']}
-            ctrlVal = {"Title":    dataval['title']}
+            newVal = {"Link": dataval['link'],
+                      "Pubdate": dataval['pubdate'],
+                      "Site": dataval['site'],
+                      "Size": dataval['size']}
+            ctrlVal = {"Title": dataval['title']}
+            tmp_title = dataval['title']
 
         else:
             newlink = dataval['Link']
-            newVal = {"Link":      newlink,
-                      "Pubdate":   dataval['Pubdate'],
-                      "Site":      dataval['Site'],
-                      "Size":      dataval['Size']}
-            ctrlVal = {"Title":    dataval['Title']}
+            newVal = {"Link": newlink,
+                      "Pubdate": dataval['Pubdate'],
+                      "Site": dataval['Site'],
+                      "Size": dataval['Size']}
+            ctrlVal = {"Title": dataval['Title']}
+            tmp_title = dataval['Title']
+
+        seriesname = None
+        issuenumber = None
+        flc = filechecker.FileChecker(file=tmp_title)
+        filelist = flc.listFiles()
+        if all([filelist['series_name'] != '', filelist['series_name'] is not None]) and filelist['issue_number'] != '-':
+            issuenumber = filelist['issue_number']
+            seriesname = re.sub(r'[\u2014|\u2013|\u2e3a|\u2e3b]', '-', filelist['series_name']).strip()
+            if seriesname.endswith('-') and '#' in seriesname[-6:]:
+                ck1 = seriesname.rfind('#')
+                ck2 = seriesname.rfind('-')
+                if seriesname[ck1+1:ck2-1].strip().isdigit():
+                    issuenumber = '%s %s' % (seriesname[ck1:].strip(), issuenumber)
+                    seriesname = seriesname[:ck1 -1].strip()
+                    issuenumber.strip()
+
+        newVal['ComicName'] = seriesname
+        newVal['Issue_Number'] = issuenumber
 
         myDB.upsert("rssdb", newVal, ctrlVal)
 
@@ -668,7 +690,7 @@ def ddl_dbsearch(seriesname, issue, comicid=None, nzbprov=None, oneoff=False):
     dsearch_removed = re.sub('\s+', ' ', dsearch_rem2)
     dsearch_seriesname = re.sub('[\'\!\@\#\$\%\:\-\;\/\\=\?\&\.\s\,]', '%', dsearch_removed)
     dsearch = '%' + dsearch_seriesname + '%'
-    dresults = myDB.select("SELECT * FROM rssdb WHERE Title like ? AND Site='DDL'", [dsearch])
+    dresults = myDB.select('SELECT * FROM rssdb WHERE ComicName like ? COLLATE NOCASE AND Site="DDL(GetComics)"', [dsearch])
     ddltheinfo = []
     ddlinfo = {}
     if not dresults:
@@ -682,9 +704,8 @@ def ddl_dbsearch(seriesname, issue, comicid=None, nzbprov=None, oneoff=False):
                           'site':    dl['Site'],
                           'length':  dl['Size']
                           })
-
+    logger.fdebug('[DDL][RSS][DB-QUERY] results: %s' % (ddltheinfo,))
     ddlinfo['entries'] = ddltheinfo
-
     return ddlinfo
 
 def torrentdbsearch(seriesname, issue, comicid=None, nzbprov=None, oneoff=False):
@@ -848,13 +869,16 @@ def torrentdbsearch(seriesname, issue, comicid=None, nzbprov=None, oneoff=False)
                           })
 
     torinfo['entries'] = tortheinfo
-
     return torinfo
 
-def nzbdbsearch(seriesname, issue, comicid=None, nzbprov=None, searchYear=None, ComicVersion=None, oneoff=False):
+def nzbdbsearch(seriesname, issue, comicid=None, nzbprov=None, searchYear=None, ComicVersion=None, oneoff=False, rsslist=None, provider_list=None):
+    extensions = ('cbr', 'cbz')
+    nzbtheinfo = []
+    nzbinfo = {}
+
     myDB = db.DBConnection()
     seriesname_alt = None
-    if any([comicid is None, comicid == 'None', oneoff is True]):
+    if any([comicid is None, comicid == 'None', oneoff is True ,rsslist is not None]):
         pass
     else:
         snm = myDB.selectone("SELECT * FROM comics WHERE comicid=?", [comicid]).fetchone()
@@ -865,104 +889,219 @@ def nzbdbsearch(seriesname, issue, comicid=None, nzbprov=None, searchYear=None, 
             seriesname = snm['ComicName']
             seriesname_alt = snm['AlternateSearch']
 
-    nsearch_seriesname = re.sub('[\'\!\@\#\$\%\:\;\/\\=\?\.\-\s]', '%', seriesname)
-    formatrem_seriesname = re.sub('[\'\!\@\#\$\%\:\;\/\\=\?\.]', '', seriesname)
-
-    nsearch = '%' + nsearch_seriesname + "%"
-
-    nresults = myDB.select("SELECT * FROM rssdb WHERE Title like ? AND Site=?", [nsearch, nzbprov])
-    if nresults is None:
-        logger.fdebug('nzb search returned no results for ' + seriesname)
-        if seriesname_alt is None:
-            logger.fdebug('no nzb Alternate name given. Aborting search.')
-            return "no results"
+    if rsslist is not None:
+        conn = mylar.sql_db()
+        cur = conn.cursor()
+        logger.info('cur returned. db attached.')
+        try:
+            # if the VariableTable doesn't exist yet, this will fail. Let's go.
+            cur.execute('DROP TABLE VariableTable')
+        except Exception:
+            pass
         else:
-            chkthealt = seriesname_alt.split('##')
-            if chkthealt == 0:
-                AS_Alternate = AlternateSearch
-            for calt in chkthealt:
-                AS_Alternate = re.sub('##', '', calt)
-                AS_Alternate = '%' + AS_Alternate + "%"
-                nresults += myDB.select("SELECT * FROM rssdb WHERE Title like ? AND Site=?", [AS_Alternate, nzbprov])
-            if nresults is None:
-                logger.fdebug('nzb alternate name search returned no results.')
+            logger.info('dropped previous rss dataset to ensure we have a clean slate.')
+        cur.execute("CREATE TABLE IF NOT EXISTS VariableTable (ComicName TEXT, SQLquery_name TEXT collate nocase, Issue_Number TEXT, ComicYear TEXT, SeriesYear TEXT, Publisher TEXT, IssueDate TEXT, StoreDate TEXT, IssueID TEXT NOT NULL UNIQUE, AlternateSearch TEXT collate nocase, UseFuzzy TEXT, ComicVersion TEXT, SARC TEXT, IssueArcID TEXT, searchmode TEXT, RSS TEXT, ComicID TEXT, ComicName_Filesafe TEXT, AllowPacks TEXT, OneOff INT, TorrentID_32P TEXT, DigitalDate TEXT, BookType TEXT, Ignore_Booktype TEXT)")
+        #logger.info('rsslist: %s' % (rsslist))
+
+        #curline = "INSERT INTO VariableTable (Variable) VALUES ({seq})".format(seq=','.join(['?'] *(len(rsslist))))
+        try:
+            cur.executemany("INSERT OR IGNORE INTO VariableTable (ComicName, SQLquery_name, Issue_Number, ComicYear, SeriesYear, Publisher, IssueDate, StoreDate, IssueID, AlternateSearch, UseFuzzy, ComicVersion, SARC, IssueArcID, searchmode, RSS, ComicID, ComicName_Filesafe, AllowPacks, OneOff, TorrentID_32P, DigitalDate, booktype, ignore_booktype) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", rsslist)
+            #cur.executemany(curline, rsslist)
+            conn.commit()
+            cur.close()
+        except Exception as e:
+            logger.warn('error: %s' % e)
+            cur.close()
+        else:
+            logger.info('executed insert...now attempting to select')
+
+        tcnt = myDB.select("SELECT COUNT(*) as count FROM rssdb")
+        totalcnt = tcnt[0][0]
+        cnt = 0
+        for nzb in myDB.select("SELECT DISTINCT r.ComicName as RSS_ComicName, r.Issue_Number as RSS_IssueNumber, r.Title, r.Link, r.Pubdate, r.Size, r.Site, v.* FROM rssdb r join VariableTable v on r.Title like '%' || v.SQLQuery_name || '%' WHERE (r.ComicName like '%' || v.SQLQuery_name || '%' and v.SQLQuery_name is not NULL) AND v.Issue_Number = r.Issue_Number"):
+            cnt+=1
+            nzbTITLE = re.sub('&amp;', '&', nzb['Title']).strip()
+            nzbTITLE = re.sub('&#39;', '\'', nzbTITLE).strip()
+            #logger.info('tor[Title]: %s' % tor['Title'])
+            if mylar.CONFIG.PREFERRED_QUALITY == 1:
+                if 'cbr' not in nzbTITLE:
+                    #logger.fdebug('Quality restriction enforced [ cbr only ]. Rejecting result.')
+                    continue
+            elif mylar.CONFIG.PREFERRED_QUALITY == 2:
+                if 'cbz' not in nzbTITLE:
+                    #logger.fdebug('Quality restriction enforced [ cbz only ]. Rejecting result.')
+                    continue
+            i=0
+            if provider_list is not None:
+                if not any(nzb['Site'] in olist for olist in provider_list['prov_order']) or helpers.block_provider_check(nzb['Site']):
+                    continue
+
+            else:
+                if nzbprov is not None:
+                    if nzbprov != nzb['Site'] or not mylar.CONFIG.ENABLE_NEWZNABS:
+                        #logger.fdebug('this is a result from ' + str(tor['Site']) + ', not the site I am looking for of ' + str(nzbprov))
+                        continue
+
+            #0 holds the title/issue and format-type.
+            fmod = mylar.filechecker.FileChecker()
+            formatrem_seriesname = fmod.dynamic_replace(nzb['ComicName'])['mod_seriesname']
+            formatrem_nzbsplit = fmod.dynamic_replace(nzbTITLE)['mod_seriesname']
+            if formatrem_seriesname.lower() in formatrem_nzbsplit.lower(): # or any(x.lower() in formatrem_torsplit.lower() for x in AS_Alt):
+                #logger.fdebug('matched to : %s' % nzbTITLE)
+                #logger.fdebug('matched on series title: %s' % nzb['ComicName'])
+                titleend = formatrem_nzbsplit[len(formatrem_seriesname):]
+                titleend = re.sub('\-', '', titleend)   #remove the '-' which is unnecessary
+                #remove extensions
+                titleend = re.sub('cbr', '', titleend)
+                titleend = re.sub('cbz', '', titleend)
+                titleend = re.sub('none', '', titleend)
+                #logger.fdebug('titleend: ' + titleend)
+
+                sptitle = titleend.split()
+                extra = ''
+
+                issues = None
+                pack = False
+                if nzb['Site'] == 'DDL(GetComics)':
+                    # see if it's a pack type
+                    ddl_check = ddlrss_pack_detect(nzbTITLE, nzb['Link'])
+                    if ddl_check is not None:
+                        nzbTITLE = ddl_check['title']
+                        issues = ddl_check['issues']
+                        pack = ddl_check['pack']
+
+                nzbtheinfo.append({
+                              'title':   nzbTITLE, #cttitle,
+                              'link':    nzb['Link'],
+                              'pubdate': nzb['Pubdate'],
+                              'site':    nzb['Site'],
+                              'length':  nzb['Size'],
+                              'issues':  issues,
+                              'pack':    pack,
+                              'info':    {'ComicName': nzb['ComicName'],
+                                          'Issue_Number': nzb['Issue_Number'],
+                                          'ComicYear': nzb['ComicYear'],
+                                          'SeriesYear': nzb['SeriesYear'],
+                                          'Publisher': nzb['Publisher'],
+                                          'IssueDate': nzb['IssueDate'],
+                                          'StoreDate': nzb['StoreDate'],
+                                          'IssueID': nzb['IssueID'],
+                                          'AlternateSearch': nzb['AlternateSearch'],
+                                          'UseFuzzy': nzb['UseFuzzy'],
+                                          'ComicVersion': nzb['ComicVersion'],
+                                          'SARC': nzb['SARC'],
+                                          'IssueArcID': nzb['IssueARCID'],
+                                          'searchmode': nzb['searchmode'],
+                                          'RSS': nzb['RSS'],
+                                          'ComicID': nzb['ComicID'],
+                                          'ComicName_Filesafe': nzb['ComicName_Filesafe'],
+                                          'AllowPacks': bool(nzb['AllowPacks']),
+                                          'OneOff': bool(nzb['OneOff']),
+                                          'TorrentID_32P': nzb['TorrentID_32P'],
+                                          'DigitalDate': nzb['DigitalDate'],
+                                          'booktype': nzb['booktype'],
+                                          'ignore_booktype': bool(nzb['ignore_booktype'])},
+                              })
+        #logger.info('nzbinfo: %s' % nzbtheinfo)
+        logger.info('[RSS-QUERY] Searched through RSSDB looking for %s Wanted items in %s RSS entries. Rough matching to %s items.' % (len(rsslist), totalcnt, len(nzbtheinfo)))
+    else:
+        nsearch_seriesname = re.sub('[\'\!\@\#\$\%\:\;\/\\=\?\.\-\s]', '%', seriesname)
+        formatrem_seriesname = re.sub('[\'\!\@\#\$\%\:\;\/\\=\?\.]', '', seriesname)
+
+        nsearch = '%' + nsearch_seriesname + "%"
+
+        nresults = myDB.select("SELECT * FROM rssdb WHERE Title like ? AND Site=?", [nsearch, nzbprov])
+        if nresults is None:
+            logger.fdebug('nzb search returned no results for ' + seriesname)
+            if seriesname_alt is None:
+                logger.fdebug('no nzb Alternate name given. Aborting search.')
                 return "no results"
+            else:
+                chkthealt = seriesname_alt.split('##')
+                if chkthealt == 0:
+                    AS_Alternate = AlternateSearch
+                for calt in chkthealt:
+                    AS_Alternate = re.sub('##', '', calt)
+                    AS_Alternate = '%' + AS_Alternate + "%"
+                    nresults += myDB.select("SELECT * FROM rssdb WHERE Title like ? AND Site=?", [AS_Alternate, nzbprov])
+                if nresults is None:
+                    logger.fdebug('nzb alternate name search returned no results.')
+                    return "no results"
 
-    nzbtheinfo = []
-    nzbinfo = {}
+        nzbtheinfo = []
+        nzbinfo = {}
 
-    if nzbprov == 'experimental':
-        except_list=['releases', 'gold line', 'distribution', '0-day', '0 day']
+        if nzbprov == 'experimental':
+            except_list=['releases', 'gold line', 'distribution', '0-day', '0 day']
 
-        if ComicVersion:
-            ComVersChk = re.sub("[^0-9]", "", ComicVersion)
-            if ComVersChk == '':
-                ComVersChk = 0
+            if ComicVersion:
+                ComVersChk = re.sub("[^0-9]", "", ComicVersion)
+                if ComVersChk == '':
+                    ComVersChk = 0
+                else:
+                    ComVersChk = 0
             else:
                 ComVersChk = 0
-        else:
-            ComVersChk = 0
 
-        filetype = None
-        if mylar.CONFIG.PREFERRED_QUALITY == 1: filetype = 'cbr'
-        elif mylar.CONFIG.PREFERRED_QUALITY == 2: filetype = 'cbz'
+            filetype = None
+            if mylar.CONFIG.PREFERRED_QUALITY == 1: filetype = 'cbr'
+            elif mylar.CONFIG.PREFERRED_QUALITY == 2: filetype = 'cbz'
 
-        for results in nresults:
-            title = results['Title']
-            #logger.fdebug("titlesplit: " + str(title.split("\"")))
-            splitTitle = title.split("\"")
-            noYear = 'False'
-            _digits = re.compile('\d')
-            for subs in splitTitle:
-                #logger.fdebug(subs)
-                if len(subs) >= len(seriesname) and not any(d in subs.lower() for d in except_list) and bool(_digits.search(subs)) is True:
-                    if subs.lower().startswith('for'):
-                         # need to filter down alternate names in here at some point...
-                        if seriesname.lower().startswith('for'):
-                            pass
-                        else:
-                            #this is the crap we ignore. Continue
-                            logger.fdebug('this starts with FOR : ' + str(subs) + '. This is not present in the series - ignoring.')
-                            continue
-
-                    if ComVersChk == 0:
-                        noYear = 'False'
-
-                    if ComVersChk != 0 and searchYear not in subs:
-                        noYear = 'True'
-                        noYearline = subs
-
-                    if searchYear in subs and noYear == 'True':
-                        #this would occur on the next check in the line, if year exists and
-                        #the noYear check in the first check came back valid append it
-                        subs = noYearline + ' (' + searchYear + ')'
-                        noYear = 'False'
-
-                    if noYear == 'False':
-
-                        if filetype is not None:
-                            if filetype not in subs.lower():
+            for results in nresults:
+                title = results['Title']
+                #logger.fdebug("titlesplit: " + str(title.split("\"")))
+                splitTitle = title.split("\"")
+                noYear = 'False'
+                _digits = re.compile('\d')
+                for subs in splitTitle:
+                    #logger.fdebug(subs)
+                    if len(subs) >= len(seriesname) and not any(d in subs.lower() for d in except_list) and bool(_digits.search(subs)) is True:
+                        if subs.lower().startswith('for'):
+                             # need to filter down alternate names in here at some point...
+                            if seriesname.lower().startswith('for'):
+                                pass
+                            else:
+                                #this is the crap we ignore. Continue
+                                logger.fdebug('this starts with FOR : ' + str(subs) + '. This is not present in the series - ignoring.')
                                 continue
 
-                        nzbtheinfo.append({
-                                  'title':   subs,
-                                  'link':    re.sub('\/release\/', '/download/', results['Link']),
-                                  'pubdate': str(results['PubDate']),
-                                  'site':    str(results['Site']),
-                                  'length':  str(results['Size'])})
+                        if ComVersChk == 0:
+                            noYear = 'False'
 
-    else:
-        for nzb in nresults:
-            # no need to parse here, just compile and throw it back ....
-            nzbtheinfo.append({
-                             'title':   nzb['Title'],
-                             'link':    nzb['Link'],
-                             'pubdate': nzb['Pubdate'],
-                             'site':    nzb['Site'],
-                             'length':    nzb['Size']
-                             })
-            #logger.fdebug("entered info for " + nzb['Title'])
+                        if ComVersChk != 0 and searchYear not in subs:
+                            noYear = 'True'
+                            noYearline = subs
 
+                        if searchYear in subs and noYear == 'True':
+                            #this would occur on the next check in the line, if year exists and
+                            #the noYear check in the first check came back valid append it
+                            subs = noYearline + ' (' + searchYear + ')'
+                            noYear = 'False'
+
+                        if noYear == 'False':
+
+                            if filetype is not None:
+                                if filetype not in subs.lower():
+                                    continue
+
+                            nzbtheinfo.append({
+                                      'title':   subs,
+                                      'link':    re.sub('\/release\/', '/download/', results['Link']),
+                                      'pubdate': str(results['PubDate']),
+                                      'site':    str(results['Site']),
+                                      'length':  str(results['Size'])})
+
+        else:
+            for nzb in nresults:
+                # no need to parse here, just compile and throw it back ....
+                nzbtheinfo.append({
+                                 'title':   nzb['Title'],
+                                 'link':    nzb['Link'],
+                                 'pubdate': nzb['Pubdate'],
+                                 'site':    nzb['Site'],
+                                 'length':    nzb['Size']
+                                 })
+                #logger.fdebug("entered info for " + nzb['Title'])
 
     nzbinfo['entries'] = nzbtheinfo
     return nzbinfo
@@ -1317,3 +1456,69 @@ if __name__ == '__main__':
     #torrents(sys.argv[1])
     #torrentdbsearch(sys.argv[1], sys.argv[2], sys.argv[3])
     nzbs(provider=sys.argv[1])
+
+def ddlrss_pack_detect(title, link):
+    issues = None
+    pack = False
+    issfind_st = title.find('#')
+    issfind_en = title.find('-', issfind_st)
+    if issfind_en != -1:
+        if all([title[issfind_en + 1] == ' ', title[issfind_en + 2].isdigit()]):
+            iss_en = title.find(' ', issfind_en + 2)
+            if iss_en != -1:
+                 issues = title[issfind_st + 1 : iss_en]
+                 pack = True
+        if title[issfind_en + 1].isdigit():
+            iss_en = title.find(' ', issfind_en + 1)
+            if iss_en != -1:
+                issues = title[issfind_st + 1 : iss_en]
+                pack = True
+
+    # to handle packs that are denoted without a # sign being present.
+    # if there's a dash, check to see if both sides of the dash are numeric.
+    if pack is False and title.find('-') != -1:
+        issfind_en = title.find('-')
+        if all(
+            [
+                title[issfind_en + 1] == ' ',
+                title[issfind_en + 2].isdigit(),
+            ]
+        ) and all(
+            [
+                title[issfind_en -1] == ' ',
+            ]
+        ):
+            spaces = [m.start() for m in re.finditer(' ', title)]
+            dashfind = title.find('-')
+            space_beforedash = title.find(' ', dashfind - 1)
+            space_afterdash = title.find(' ', dashfind + 1)
+            if not title[space_afterdash+1].isdigit():
+                pass
+            else:
+                iss_end = title.find(' ', space_afterdash + 1)
+                if iss_end == -1:
+                    iss_end = len(title)
+                set_sp = None
+                for sp in spaces:
+                    if sp < space_beforedash:
+                        prior_sp = sp
+                    else:
+                        set_sp = prior_sp
+                        break
+
+                if title[set_sp:space_beforedash].strip().isdigit():
+                    issues = title[set_sp:iss_end].strip()
+                    pack = True
+
+    # if it's a pack - remove the issue-range and the possible issue years
+    # (cause it most likely will span) and pass thru as separate items
+    if pack is True:
+        title = re.sub(issues, '', title).strip()
+        # kill any brackets in the issue line here.
+        issues = re.sub(r'[\(\)\[\]]', '', issues).strip()
+        if title.endswith('#'):
+            title = title[:-1].strip()
+
+        return {'title': title, 'issues': issues, 'pack': pack, 'link': link}
+    else:
+        return

--- a/mylar/rsscheckit.py
+++ b/mylar/rsscheckit.py
@@ -107,7 +107,7 @@ class tehMain():
             logger.info('[RSS-FEEDS] RSS Feed Check/Update Complete')
             logger.info('[RSS-FEEDS] Watchlist Check for new Releases')
             rss_start = datetime.datetime.now()
-            mylar.search.searchforissue(rsscheck='yes')
+            mylar.search.searchforissue(rsschecker='yes')
             logger.fdebug('[RSS-FEEDS] RSS dbsearch/matching took: %s' % (datetime.datetime.now() - rss_start))
             logger.info('[RSS-FEEDS] Watchlist Check complete.')
             if forcerss:

--- a/mylar/search_filer.py
+++ b/mylar/search_filer.py
@@ -1,0 +1,1047 @@
+
+import re
+import email.utils
+import datetime
+import time
+from wsgiref.handlers import format_date_time
+
+import mylar
+from mylar import logger, filechecker, helpers, search
+
+
+class search_check(object):
+
+    def __init__(self):
+        pass
+
+
+    def checker(self, entries, is_info=None):
+        mylar.COMICINFO = []
+        hold_the_matches = []
+        if is_info:
+            ComicName = is_info['ComicName']
+            nzbprov = is_info['nzbprov']
+            RSS = is_info['RSS']
+            UseFuzzy = is_info['UseFuzzy']
+            StoreDate = is_info['StoreDate']
+            IssueDate = is_info['IssueDate']
+            digitaldate = is_info['digitaldate']
+            booktype = is_info['booktype']
+            ignore_booktype = is_info['ignore_booktype']
+            SeriesYear = is_info['SeriesYear']
+            ComicVersion = is_info['ComicVersion']
+            IssDateFix = is_info['IssDateFix']
+            ComicYear = comyear = is_info['ComicYear']
+            IssueID = is_info['IssueID']
+            ComicID = is_info['ComicID']
+            IssueNumber = is_info['IssueNumber']
+            manual = is_info['manual']
+            newznab_host = is_info['newznab_host']
+            torznab_host = is_info['torznab_host']
+            oneoff = is_info['oneoff']
+            tmpprov = is_info['tmpprov']
+            SARC = is_info['SARC']
+            IssueArcID = is_info['IssueArcID']
+            cmloopit = is_info['cmloopit']
+            findcomiciss = is_info['findcomiciss']
+            intIss = is_info['intIss']
+            chktpb = is_info['chktpb']
+            provider_stat = is_info['provider_stat']
+
+        #logger.fdebug('entries: %s' % (entries,))
+        for entry in entries['entries']:
+                alt_match = False
+                logger.fdebug('entry: %s' % (entry,))
+                # brief match here against 32p since it returns the direct issue number
+
+                logger.fdebug("checking search result: %s" % entry['title'])
+                # some nzbsites feel that comics don't deserve a nice regex to strip
+                # the crap from the header, the end result is that we're dealing with
+                # the actual raw header which causes incorrect matches below. This is a
+                # temporary cut from the experimental search option (findcomicfeed) as
+                # it does this part well usually.
+                except_list = [
+                    'releases',
+                    'gold line',
+                    'distribution',
+                    '0-day',
+                    '0 day',
+                ]
+                splitTitle = entry['title'].split("\"")
+                _digits = re.compile(r'\d')
+
+                ComicTitle = entry['title']
+                for subs in splitTitle:
+                    logger.fdebug('sub: %s' % subs)
+                    try:
+                        if (
+                            len(subs) >= len(ComicName.split())
+                            and not any(d in subs.lower() for d in except_list)
+                            and bool(_digits.search(subs)) is True
+                        ):
+                            if subs.lower().startswith('for'):
+                                if ComicName.lower().startswith('for'):
+                                    pass
+                                else:
+                                    # this is the crap we ignore. Continue
+                                    continue
+                                logger.fdebug(
+                                    'Detected crap within header. Ignoring this portion'
+                                    ' of the result in order to see if it\'s a valid'
+                                    ' match.'
+                                )
+                            ComicTitle = subs
+                            break
+                    except Exception:
+                        break
+
+                comsize_m = 0
+                if nzbprov != "dognzb":
+                    # rss for experimental doesn't have the size constraints embedded.
+                    # So we do it here.
+                    if RSS == "yes":
+                        comsize_b = entry['length']
+                    else:
+                        # Experimental already has size constraints done.
+                        if nzbprov == 'experimental':
+                            # we only want the size from the rss as
+                            # the search/api has it already.
+                            comsize_b = entry['length']
+                        else:
+                            try:
+                                if entry['site'] == 'DDL(GetComics)':
+                                    comsize_b = entry['size']
+                                    if comsize_b is not None:
+                                        cb2 = re.sub(r'[^0-9]', '', comsize_b).strip()
+                                        if cb2 == '':
+                                            logger.warn(
+                                                'Invalid filesize encountered. Ignoring'
+                                            )
+                                            comsize_b = None
+                                        else:
+                                            comsize_b = helpers.human2bytes(entry['size'])
+                            except Exception:
+                                tmpsz = entry.enclosures[0]
+                                comsize_b = tmpsz['length']
+
+                    logger.fdebug('comsize_b: %s' % comsize_b)
+                    # file restriction limitation here
+                    # Experimental (has it embeded in search and rss checks)
+
+                    if comsize_b is None or comsize_b == '0':
+                        logger.fdebug(
+                            'Size of file cannot be retrieved.'
+                            ' Ignoring size-comparison and continuing.'
+                        )
+                        # comsize_b = 0
+                    else:
+                        if entry['title'][:17] != '0-Day Comics Pack':
+                            comsize_m = helpers.human_size(comsize_b)
+                            logger.fdebug('size given as: %s' % comsize_m)
+                            # ----size constraints.
+                            # if it's not within size constaints - dump it now.
+                            if mylar.CONFIG.USE_MINSIZE:
+                                conv_minsize = helpers.human2bytes(
+                                    mylar.CONFIG.MINSIZE + "M"
+                                )
+                                logger.fdebug(
+                                    'comparing Min threshold %s .. to .. nzb %s'
+                                    % (conv_minsize, comsize_b)
+                                )
+                                if int(conv_minsize) > int(comsize_b):
+                                    logger.fdebug(
+                                        'Failure to meet the Minimum size threshold'
+                                        ' - skipping'
+                                    )
+                                    continue
+                            if mylar.CONFIG.USE_MAXSIZE:
+                                conv_maxsize = helpers.human2bytes(
+                                    mylar.CONFIG.MAXSIZE + "M"
+                                )
+                                logger.fdebug(
+                                    'comparing Max threshold %s .. to .. nzb %s'
+                                    % (conv_maxsize, comsize_b)
+                                )
+                                if int(comsize_b) > int(conv_maxsize):
+                                    logger.fdebug(
+                                        'Failure to meet the Maximium size threshold'
+                                        ' - skipping'
+                                    )
+                                    continue
+
+                if mylar.CONFIG.IGNORE_COVERS is True:
+                    cvrchk = re.sub(r'[\s\s+\_\.]', '', entry['title']).lower()
+                    if any(['coversonly' in cvrchk, 'coveronly' in cvrchk]):
+                        logger.fdebug('Cover(s) only detected. Ignoring result.')
+                        continue
+
+                # ---- date constaints.
+                # if the posting date is prior to the publication date,
+                # dump it and save the time.
+                # logger.fdebug('entry: %s' % entry)
+                if nzbprov == 'experimental':
+                    pubdate = entry['pubdate']
+                else:
+                    try:
+                        pubdate = entry['updated']
+                    except Exception:
+                        try:
+                            pubdate = entry['pubdate']
+                        except Exception as e:
+                            logger.fdebug(
+                                'Invalid date found. Unable to continue'
+                                ' - skipping result. Error returned: %s' % e
+                            )
+                            continue
+
+                if UseFuzzy == "1":
+                    logger.fdebug(
+                        'Year has been fuzzied for this series,'
+                        ' ignoring store date comparison entirely.'
+                    )
+                    postdate_int = None
+                    issuedate_int = None
+                else:
+                    # use store date instead of publication date for comparisons since
+                    # publication date is usually +2 months
+                    if StoreDate is None or StoreDate == '0000-00-00':
+                        if IssueDate is None or IssueDate == '0000-00-00':
+                            logger.fdebug(
+                                'Invalid store date & issue date detected - you'
+                                ' probably should refresh the series or wait for CV'
+                                ' to correct the data'
+                            )
+                            continue
+                        else:
+                            stdate = IssueDate
+                        logger.fdebug('issue date used is : %s' % stdate)
+                    else:
+                        stdate = StoreDate
+                        logger.fdebug('store date used is : %s' % stdate)
+                    logger.fdebug('date used is : %s' % stdate)
+
+                    postdate_int = None
+                    if all(['DDL' in nzbprov, len(pubdate) == 10]):
+                        postdate_int = pubdate
+                        logger.fdebug(
+                            '[%s] postdate_int (%s): %s'
+                            % (nzbprov, type(postdate_int), postdate_int)
+                        )
+                    if any(
+                        [postdate_int is None, type(postdate_int) != int]
+                    ) or not RSS == 'no':
+                        # convert it to a tuple
+                        dateconv = email.utils.parsedate_tz(pubdate)
+
+                        try:
+                            dateconv2 = datetime.datetime(*dateconv[:6])
+                        except TypeError as e:
+                            logger.warn(
+                                'Unable to convert timestamp from : %s [%s]'
+                                % ((dateconv,), e)
+                            )
+                        try:
+                            # convert it to a numeric time, then subtract the
+                            # timezone difference (+/- GMT)
+                            if dateconv[-1] is not None:
+                                postdate_int = (
+                                    time.mktime(dateconv[: len(dateconv) - 1])
+                                    - dateconv[-1]
+                                )
+                            else:
+                                postdate_int = time.mktime(
+                                    dateconv[: len(dateconv) - 1]
+                                )
+                        except Exception as e:
+                            logger.warn(
+                                'Unable to parse posting date from provider result set'
+                                ' for : %s. Error returned: %s' % (entry['title'], e)
+                            )
+                            continue
+
+                    if all([digitaldate != '0000-00-00', digitaldate is not None]):
+                        i = 0
+                    else:
+                        digitaldate_int = '00000000'
+                        i = 1
+
+                    while i <= 1:
+                        if i == 0:
+                            usedate = digitaldate
+                        else:
+                            usedate = stdate
+                        logger.fdebug('usedate: %s' % usedate)
+                        # convert it to a Thu, 06 Feb 2014 00:00:00 format
+                        issue_converted = datetime.datetime.strptime(
+                            usedate.rstrip(), '%Y-%m-%d'
+                        )
+                        issue_convert = issue_converted + datetime.timedelta(days=-1)
+                        # to get past different locale's os-dependent dates, let's
+                        # convert it to a generic datetime format
+                        try:
+                            stamp = time.mktime(issue_convert.timetuple())
+                            issconv = format_date_time(stamp)
+                        except OverflowError as e:
+                            logger.fdebug(
+                                'Error converting the timestamp into a generic format:'
+                                ' %s' % e
+                            )
+                            issconv = issue_convert.strftime('%a, %d %b %Y %H:%M:%S')
+                        # convert it to a tuple
+                        econv = email.utils.parsedate_tz(issconv)
+                        econv2 = datetime.datetime(*econv[:6])
+                        # convert it to a numeric and drop the GMT/Timezone
+                        try:
+                            usedate_int = time.mktime(econv[: len(econv) - 1])
+                        except OverflowError:
+                            logger.fdebug(
+                                'Unable to convert timestamp to integer format.'
+                                ' Forcing things through.'
+                            )
+                            isyear = econv[1]
+                            epochyr = '1970'
+                            if int(isyear) <= int(epochyr):
+                                tm = datetime.datetime(1970, 1, 1)
+                                try:
+                                    usedate_int = int(time.mktime(tm.timetuple()))
+                                except Exception as e:
+                                    logger.warn(
+                                        '[%s] Failed to convert tm of [%s]' % (e,tm)
+                                    )
+                                    logger.fdebug('issconv: %s' % issconv)
+                                    diff = issue_convert - tm
+                                    logger.fdebug('diff: %s' % diff)
+                                    usedate_int = diff.total_seconds()
+                            else:
+                                continue
+                        if i == 0:
+                            digitaldate_int = usedate_int
+                            digconv2 = econv2
+                        else:
+                            issuedate_int = usedate_int
+                            issconv2 = econv2
+                        i += 1
+
+                    try:
+                        # try new method to get around issues populating in a diff
+                        # timezone thereby putting them in a different day.
+                        # logger.info('digitaldate: %s' % digitaldate)
+                        # logger.info('dateconv2: %s' % dateconv2.date())
+                        # logger.info('digconv2: %s' % digconv2.date())
+                        if (
+                            digitaldate != '0000-00-00'
+                            and dateconv2.date() >= digconv2.date()
+                        ):
+                            logger.fdebug(
+                                '%s is after DIGITAL store date of %s'
+                                % (pubdate, digitaldate)
+                            )
+                        elif dateconv2.date() < issconv2.date():
+                            logger.fdebug(
+                                '[CONV] pubdate: %s  < storedate: %s'
+                                % (dateconv2.date(), issconv2.date())
+                            )
+                            logger.fdebug(
+                                '%s is before store date of %s. Ignoring search result'
+                                ' as this is not the right issue.'
+                                % (pubdate, stdate)
+                            )
+                            continue
+                        else:
+                            logger.fdebug(
+                                '[CONV] %s is after store date of %s'
+                                % (pubdate, stdate)
+                            )
+                    except Exception:
+                        # if the above fails, drop down to the integer compare method
+                        # as a failsafe.
+                        if (
+                            digitaldate != '0000-00-00'
+                            and postdate_int >= digitaldate_int
+                        ):
+                            logger.fdebug(
+                                '%s is after DIGITAL store date of %s'
+                                % (pubdate, digitaldate)
+                            )
+                        elif postdate_int < issuedate_int:
+                            logger.fdebug(
+                                '[INT]pubdate: %s  < storedate: %s'
+                                % (postdate_int, issuedate_int)
+                            )
+                            logger.fdebug(
+                                '%s is before store date of %s. Ignoring search result'
+                                ' as this is not the right issue.'
+                                % (pubdate, stdate)
+                            )
+                            continue
+                        else:
+                            logger.fdebug(
+                                '[INT] %s is after store date of %s' % (pubdate, stdate)
+                            )
+                # -- end size constaints.
+                if '(digital first)' in ComicTitle.lower():
+                    dig_moving = re.sub(
+                        r'\(digital first\)', '', ComicTitle.lower()
+                    ).strip()
+                    dig_moving = re.sub(r'[\s+]', ' ', dig_moving)
+                    dig_mov_end = '%s (Digital First)' % dig_moving
+                    thisentry = dig_mov_end
+                else:
+                    thisentry = ComicTitle
+
+                logger.fdebug('Entry: %s' % thisentry)
+                cleantitle = thisentry
+
+                if 'mixed format' in cleantitle.lower():
+                    cleantitle = re.sub('mixed format', '', cleantitle).strip()
+                    logger.fdebug(
+                        'removed extra information after issue # that'
+                        ' is not necessary: %s' % cleantitle
+                    )
+
+                # send it to the parser here.
+                p_comic = filechecker.FileChecker(file=ComicTitle, watchcomic=ComicName)
+                parsed_comic = p_comic.listFiles()
+
+                logger.fdebug('parsed_info: %s' % parsed_comic)
+                logger.fdebug(
+                    'booktype: %s / parsed_booktype: %s [ignore_booktype: %s]'
+                    % (booktype, parsed_comic['booktype'], ignore_booktype)
+                )
+                if parsed_comic['parse_status'] == 'success' and (
+                    all([booktype is None, parsed_comic['booktype'] == 'issue'])
+                    or all([booktype == 'Print', parsed_comic['booktype'] == 'issue'])
+                    or all(
+                        [booktype == 'One-Shot', any(
+                            [parsed_comic['booktype'] == 'issue',
+                            'One-Shot' in parsed_comic['booktype']
+                             ]
+                        )
+                        ]
+                    )
+                    or all(
+                        [booktype != parsed_comic['booktype'], ignore_booktype is True]
+                    )
+                    or booktype in parsed_comic['booktype']
+                ):
+                    try:
+                        fcomic = filechecker.FileChecker(watchcomic=ComicName)
+                        filecomic = fcomic.matchIT(parsed_comic)
+                    except Exception as e:
+                        logger.error('[PARSE-ERROR]: %s' % e)
+                        continue
+                    else:
+                        logger.fdebug('match_check: %s' % filecomic)
+                        if filecomic['process_status'] == 'fail':
+                            logger.fdebug(
+                                '%s was not a match to %s (%s)'
+                                % (cleantitle, ComicName, SeriesYear)
+                            )
+                            continue
+                        elif filecomic['process_status'] == 'alt_match':
+                            # if it's an alternate series match, we'll retain each value
+                            # until the search has compeletely run, compiling matches.
+                            # If at any point it's a standard match (ie. non-alternate
+                            # series) that will be accepted as the one match and
+                            # ignore the alts. Once all the search options have been
+                            # exhausted and no matches aside from alternate series then
+                            # we go get the best result from that list
+                            logger.fdebug(
+                                '%s was a match due to alternate matching.  Continuing'
+                                ' to search, but retaining this result just in case.'
+                                % ComicTitle
+                            )
+                            alt_match = True
+                elif booktype != parsed_comic['booktype'] and ignore_booktype is False:
+                    logger.fdebug(
+                        'Booktypes do not match. Looking for %s, this is a %s.'
+                        ' Ignoring this result.' % (booktype, parsed_comic['booktype'])
+                    )
+                    continue
+                else:
+                    logger.fdebug(
+                        'Unable to parse name properly: %s. Ignoring this result'
+                        % parsed_comic
+                    )
+                    continue
+
+                # adjust for covers only by removing them entirely...
+                vers4year = "no"
+                vers4vol = "no"
+                versionfound = "no"
+
+                if ComicVersion:
+                    ComVersChk = re.sub("[^0-9]", "", ComicVersion)
+                    if ComVersChk == '' or ComVersChk == '1':
+                        ComVersChk = 0
+                else:
+                    ComVersChk = 0
+
+                fndcomicversion = None
+
+                if parsed_comic['series_volume'] is not None:
+                    versionfound = "yes"
+                    if len(parsed_comic['series_volume'][1:]) == 4 and (
+                        parsed_comic['series_volume'][1:].isdigit()
+                    ):  # v2013
+                        logger.fdebug(
+                            "[Vxxxx] Version detected as %s"
+                            % (parsed_comic['series_volume'])
+                        )
+                        vers4year = "yes"
+                        fndcomicversion = parsed_comic['series_volume']
+                    elif len(parsed_comic['series_volume'][1:]) == 1 and (
+                        parsed_comic['series_volume'][1:].isdigit()
+                    ):  # v2
+                        logger.fdebug(
+                            "[Vx] Version detected as %s"
+                            % parsed_comic['series_volume']
+                        )
+                        vers4vol = parsed_comic['series_volume']
+                        fndcomicversion = parsed_comic['series_volume']
+                    elif (
+                        parsed_comic['series_volume'][1:].isdigit()
+                        and len(parsed_comic['series_volume']) < 4
+                    ):
+                        logger.fdebug(
+                            '[Vxxx] Version detected as %s'
+                            % parsed_comic['series_volume']
+                        )
+                        vers4vol = parsed_comic['series_volume']
+                        fndcomicversion = parsed_comic['series_volume']
+                    elif (
+                        parsed_comic['series_volume'].isdigit()
+                        and len(parsed_comic['series_volume']) <= 4
+                    ):
+                        # this stuff is necessary for 32P volume manipulation
+                        if len(parsed_comic['series_volume']) == 4:
+                            vers4year = "yes"
+                            fndcomicversion = parsed_comic['series_volume']
+                        elif len(parsed_comic['series_volume']) == 1:
+                            vers4vol = parsed_comic['series_volume']
+                            fndcomicversion = parsed_comic['series_volume']
+                        elif len(parsed_comic['series_volume']) < 4:
+                            vers4vol = parsed_comic['series_volume']
+                            fndcomicversion = parsed_comic['series_volume']
+                        else:
+                            logger.fdebug(
+                                "error - unknown length for : %s"
+                                % parsed_comic['series_volume']
+                            )
+
+                yearmatch = False
+                #logger.fdebug('UseFuzzy: %s / ComVersChk: %s / IssDateFix: %s' % (UseFuzzy, ComVersChk, IssDateFix))
+                if vers4vol != "no" or vers4year != "no":
+                    logger.fdebug(
+                        'Series Year not provided but Series Volume detected of %s.'
+                        ' Bypassing Year Match.'
+                        % fndcomicversion
+                    )
+                    yearmatch = True
+                elif ComVersChk == 0 and parsed_comic['issue_year'] is None:
+                    logger.fdebug(
+                        'Series version detected as V1 (only series in existance with'
+                        ' that title). Bypassing Year/Volume check'
+                    )
+                    yearmatch = True
+                elif (
+                    any(
+                        [
+                            UseFuzzy == "0",
+                            UseFuzzy == "2",
+                            UseFuzzy is None,
+                            IssDateFix != "no",
+                        ]
+                    )
+                    and parsed_comic['issue_year'] is not None
+                ):
+                    if any(
+                        [
+                            parsed_comic['issue_year'][:-2] == '19',
+                            parsed_comic['issue_year'][:-2] == '20',
+                        ]
+                    ):
+                        if str(comyear) == parsed_comic['issue_year']:
+                            logger.fdebug('%s - right years match baby!' % comyear)
+                            yearmatch = True
+                        else:
+                            logger.fdebug(
+                                '%s - not right - years do not match' % comyear
+                            )
+                            yearmatch = False
+                            if UseFuzzy == "2":
+                                # Fuzzy the year +1 and -1
+                                ComUp = int(ComicYear) + 1
+                                ComDwn = int(ComicYear) - 1
+                                if (
+                                    str(ComUp) in parsed_comic['issue_year']
+                                    or str(ComDwn) in parsed_comic['issue_year']
+                                ):
+                                    logger.fdebug(
+                                        'Fuzzy Logicd the Year and matched to a year'
+                                        ' of %s' % parsed_comic['issue_year']
+                                    )
+                                    yearmatch = True
+                                else:
+                                    logger.fdebug(
+                                        '%s Fuzzy logicd the Year and year still did'
+                                        ' not match.' % comyear
+                                    )
+                            # let's do this here and save a few extra loops ;)
+                            # fix for issue dates between Nov-Dec/Jan
+                            if IssDateFix != "no" and UseFuzzy != "2":
+                                if (
+                                    IssDateFix == "01"
+                                    or IssDateFix == "02"
+                                    or IssDateFix == "03"
+                                ):
+                                    ComicYearFix = int(ComicYear) - 1
+                                    if str(ComicYearFix) in parsed_comic['issue_year']:
+                                        logger.fdebug(
+                                            'Further analysis reveals this was'
+                                            ' published inbetween Nov-Jan, decreasing'
+                                            ' year to %s has resulted in a match!'
+                                            % ComicYearFix
+                                        )
+                                        yearmatch = True
+                                    else:
+                                        logger.fdebug(
+                                            '%s- not the right year.' % comyear
+                                        )
+                                else:
+                                    ComicYearFix = int(ComicYear) + 1
+                                    if str(ComicYearFix) in parsed_comic['issue_year']:
+                                        logger.fdebug(
+                                            'Further analysis reveals this was'
+                                            ' published inbetween Nov-Jan, incrementing'
+                                            ' year to %s has resulted in a match!'
+                                            % ComicYearFix
+                                        )
+                                        yearmatch = True
+                                    else:
+                                        logger.fdebug(
+                                            '%s - not the right year.' % comyear
+                                        )
+                elif UseFuzzy == "1":
+                    yearmatch = True
+
+                if yearmatch is False:
+                    continue
+
+                annualize = "false"
+                if 'annual' in ComicName.lower():
+                    logger.fdebug(
+                        "IssueID of : %s This is an annual...let's adjust." % IssueID
+                    )
+                    annualize = "true"
+
+                F_ComicVersion = None
+
+                if versionfound == "yes":
+                    logger.fdebug("volume detection commencing - adjusting length.")
+                    logger.fdebug("watch comicversion is %s" % ComicVersion)
+                    logger.fdebug("version found: %s" % fndcomicversion)
+                    logger.fdebug("vers4year: %s" % vers4year)
+                    logger.fdebug("vers4vol: %s" % vers4vol)
+
+                    if vers4year != "no" or vers4vol != "no":
+                        # if the volume is None, assume it's a V1 to increase % hits
+                        if ComVersChk == 0:
+                            D_ComicVersion = 1
+                        else:
+                            D_ComicVersion = ComVersChk
+
+                    # if this is a one-off, SeriesYear will be None and cause errors.
+                    if SeriesYear is None:
+                        S_ComicVersion = 0
+                    else:
+                        S_ComicVersion = str(SeriesYear)
+
+                    F_ComicVersion = re.sub("[^0-9]", "", fndcomicversion)
+                    # if found volume is a vol.0, up it to vol.1 (since there is no V0)
+                    if F_ComicVersion == '0':
+                        # need to convert dates to just be yyyy-mm-dd and do comparison,
+                        # time operator in the below calc
+                        F_ComicVersion = '1'
+
+                    logger.fdebug('FCVersion: %s' % F_ComicVersion)
+                    logger.fdebug('DCVersion: %s' % D_ComicVersion)
+                    logger.fdebug('SCVersion: %s' % S_ComicVersion)
+
+                    # here's the catch, sometimes annuals get posted as the Pub Year
+                    # instead of the Series they belong to (V2012 vs V2013)
+                    if annualize == "true" and int(ComicYear) == int(F_ComicVersion):
+                        logger.fdebug(
+                            "We matched on versions for annuals %s" % fndcomicversion
+                        )
+                    elif all(
+                            [
+                                 booktype != 'TPB',
+                                 booktype != 'HC',
+                                 booktype != 'GN',
+                            ]
+                        ) and (
+                            int(F_ComicVersion) == int(D_ComicVersion)
+                            or int(F_ComicVersion) == int(S_ComicVersion)
+                    ):
+                        logger.fdebug("We matched on versions...%s" % fndcomicversion)
+                    else:
+                        if any(
+                               [
+                                   booktype == 'TPB',
+                                   booktype == 'HC',
+                                   booktype == 'GN',
+                               ]
+                            ) and (
+                                int(F_ComicVersion) == int(findcomiciss)
+                                and filecomic['justthedigits'] is None
+                        ):
+                            logger.fdebug(
+                                '%s detected - reassigning volume %s to match as the'
+                                ' issue number based on Volume'
+                                % (booktype, fndcomicversion)
+                            )
+                        elif all(
+                                 [
+                                     booktype == 'TPB',
+                                     booktype == 'HC',
+                                     booktype == 'GN',
+                                 ]
+                            ) and all(
+                            [
+                                int(F_ComicVersion) == int(findcomiciss),
+                                fndcomicversion is not None,
+                                booktype in filecomic['booktype'],
+                                filecomic['justthedigits'] is None,
+                            ]
+                        ):
+                            logger.fdebug(
+                                '%s detected - reassigning volume %s to match as the issue number'
+                                % (booktype, fndcomicversion)
+                            )
+                        else:
+                            logger.fdebug("Versions wrong. Ignoring possible match.")
+                            continue
+
+                downloadit = False
+
+                try:
+                    pack_test = entry['pack']
+                except Exception:
+                    pack_test = False
+
+
+                if all(['DDL' in nzbprov, pack_test is True]):
+                    logger.fdebug(
+                        '[PACK-QUEUE] %s Pack detected for %s.'
+                        % (nzbprov, entry['filename'])
+                    )
+
+                    # find the pack range.
+                    pack_issuelist = None
+                    issueid_info = None
+                    try:
+                        if not entry['title'].startswith('0-Day Comics Pack'):
+                            pack_issuelist = entry['issues']
+                            issueid_info = helpers.issue_find_ids(
+                                ComicName, ComicID, pack_issuelist, IssueNumber
+                            )
+                            if issueid_info['valid'] is True:
+                                logger.info(
+                                    'Issue Number %s exists within pack. Continuing.'
+                                    % IssueNumber
+                                )
+                            else:
+                                logger.fdebug(
+                                    'Issue Number %s does NOT exist within this pack.'
+                                    ' Skipping' % IssueNumber
+                                )
+                                continue
+                    except Exception as e:
+                        logger.error(
+                            'Unable to identify pack range for %s. Error returned: %s'
+                            % (entry['title'], e)
+                        )
+                        continue
+                    # pack support.
+                    nowrite = False
+                    if 'DDL' in nzbprov:
+                        if 'getcomics' in entry['link']:
+                            nzbid = entry['id']
+                    else:
+                        nzbid = search.generate_id(provider_stat, entry['link'])
+                    if all([manual is not True, alt_match is False]):
+                        downloadit = True
+                    else:
+                        for x in mylar.COMICINFO:
+                            if (
+                                all(
+                                    [
+                                        x['link'] == entry['link'],
+                                        x['tmpprov'] == tmpprov,
+                                    ]
+                                )
+                                or all(
+                                    [x['nzbid'] == nzbid, x['newznab'] == newznab_host]
+                                )
+                                or all(
+                                    [x['nzbid'] == nzbid, x['torznab'] == torznab_host]
+                                )
+                            ):
+                                nowrite = True
+                                break
+
+                    if nowrite is False:
+                        if any(
+                            [
+                                nzbprov == 'dognzb',
+                                nzbprov == 'nzb.su',
+                                nzbprov == 'experimental',
+                                'newznab' in nzbprov,
+                            ]
+                        ):
+                            tprov = nzbprov
+                            kind = 'usenet'
+                            if newznab_host is not None:
+                                tprov = newznab_host[0]
+                        else:
+                            tprov = nzbprov
+                            kind = 'torrent'
+                            if torznab_host is not None:
+                                tprov = torznab_host[0]
+
+                        search_values = {
+                            "ComicName": ComicName,
+                            "ComicID": ComicID,
+                            "IssueID": IssueID,
+                            "ComicVolume": ComicVersion,
+                            "IssueNumber": IssueNumber,
+                            "IssueDate": IssueDate,
+                            "comyear": comyear,
+                            "pack": True,
+                            "pack_numbers": pack_issuelist,
+                            "pack_issuelist": issueid_info,
+                            "modcomicname": entry['title'],
+                            "oneoff": oneoff,
+                            "nzbprov": nzbprov,
+                            "nzbtitle": entry['title'],
+                            "nzbid": nzbid,
+                            "provider": tprov,
+                            "link": entry['link'],
+                            "pubdate": pubdate,
+                            "size": comsize_m,
+                            "tmpprov": tmpprov,
+                            "kind": kind,
+                            "SARC": SARC,
+                            "booktype": booktype,
+                            "IssueArcID": IssueArcID,
+                            "newznab": newznab_host,
+                            "torznab": torznab_host,
+                            "downloadit": downloadit,
+                            "ComicTitle": ComicTitle,
+                            "entry": entry,
+                            "provider_stat": provider_stat,
+                        }
+
+                        mylar.COMICINFO.append(search_values)
+
+                        hold_the_matches.append(search_values)
+
+                else:
+                    if filecomic['process_status'] == 'match':
+                        if cmloopit != 4:
+                            logger.fdebug(
+                                "issue we are looking for is : %s" % findcomiciss
+                            )
+                            logger.fdebug(
+                                "integer value of issue we are looking for : %s"
+                                % intIss
+                            )
+                        else:
+                            if intIss is None and all(
+                                [
+                                    booktype == 'One-Shot',
+                                    helpers.issuedigits(parsed_comic['issue_number'])
+                                    == 1000,
+                                ]
+                            ):
+                                intIss = 1000
+                            else:
+                                intIss = 9999999999
+                        if filecomic['justthedigits'] is not None:
+                            logger.fdebug(
+                                "issue we found for is : %s"
+                                % filecomic['justthedigits']
+                            )
+                            comintIss = helpers.issuedigits(filecomic['justthedigits'])
+                            logger.fdebug(
+                                "integer value of issue we have found : %s" % comintIss
+                            )
+                        else:
+                            comintIss = 11111111111
+
+                        # do this so that we don't touch the actual value but just
+                        # use it for comparisons
+                        if filecomic['justthedigits'] is None:
+                            pc_in = None
+                        else:
+                            pc_in = helpers.issuedigits(filecomic['justthedigits'])
+                        # issue comparison now as well
+                        if (
+                            all([intIss is not None, comintIss is not None])
+                            and int(intIss) == int(comintIss)
+                            or (any(
+                                [
+                                    filecomic['booktype'] == 'TPB',
+                                    filecomic['booktype'] == 'GN',
+                                    filecomic['booktype'] == 'HC',
+                                    filecomic['booktype'] == 'TPB/GN/HC',
+                                ]
+                                ) and all(
+                                    [
+                                        chktpb != 0,
+                                        pc_in is None,
+                                        helpers.issuedigits(F_ComicVersion) == intIss,
+                                    ]
+                            ))
+                            or (any(
+                                [
+                                    filecomic['booktype'] == 'TPB',
+                                    filecomic['booktype'] == 'GN',
+                                    filecomic['booktype'] == 'HC',
+                                    filecomic['booktype'] == 'TPB/GN/HC',
+                                ]
+                                )  and all(
+                                    [
+                                        chktpb == 2,
+                                        pc_in is None,
+                                        cmloopit == 1,
+                                    ]
+                            ))
+                            or all([cmloopit == 4, findcomiciss is None, pc_in is None])
+                            or all([cmloopit == 4, findcomiciss is None, pc_in == 1])
+                        ):
+                            nowrite = False
+                            logger.info('[nzbprov:%s] provider_stat: %s' % (nzbprov, provider_stat,))
+                            if nzbprov == 'torznab' or provider_stat['type'] == 'torznab':
+                                nzbid = search.generate_id(provider_stat, entry['id'])
+                            elif 'DDL' in nzbprov:
+                                if 'GetComics' in nzbprov:
+                                    if RSS == "yes":
+                                        entry['id'] = entry['link']
+                                        entry['link'] = 'https://getcomics.info/?p=' + str(
+                                            entry['id']
+                                        )
+                                        entry['filename'] = entry['title']
+                                    else:
+                                        nzbid = entry['id']
+                                    if '/cat/' in entry['link']:
+                                        entry['link'] = 'https://getcomics.info/?p=%s' % entry['id']
+                                entry['title'] = entry['filename']
+                                nzbid = entry['id']
+                            else:
+                                nzbid = search.generate_id(provider_stat, entry['link'])
+                                #try:
+                                #    entry['link'] = entry.enclosures[0]['url']
+                                #except Exception:
+                                #    pass
+                            if all([manual is not True, alt_match is False]):
+                                downloadit = True
+                            else:
+                                for x in mylar.COMICINFO:
+                                    if (
+                                        all(
+                                            [
+                                                x['link'] == entry['link'],
+                                                x['tmpprov'] == tmpprov,
+                                            ]
+                                        )
+                                        or all(
+                                            [
+                                                x['nzbid'] == nzbid,
+                                                x['newznab'] == newznab_host,
+                                            ]
+                                        )
+                                        or all(
+                                            [
+                                                x['nzbid'] == nzbid,
+                                                x['torznab'] == torznab_host,
+                                            ]
+                                        )
+                                    ):
+                                        nowrite = True
+                                        break
+
+                            # modify the name for annualization to be displayed properly
+                            if annualize is True:
+                                modcomicname = '%s Annual' % ComicName
+                            else:
+                                modcomicname = ComicName
+
+                            if IssueID is None:
+                                cyear = ComicYear
+                            else:
+                                cyear = comyear
+
+                            if nowrite is False:
+                                if any(
+                                    [
+                                        nzbprov == 'dognzb',
+                                        nzbprov == 'nzb.su',
+                                        nzbprov == 'experimental',
+                                        'newznab' in nzbprov,
+                                    ]
+                                ):
+                                    tprov = nzbprov
+                                    kind = 'usenet'
+                                    if newznab_host is not None:
+                                        tprov = newznab_host[0]
+                                else:
+                                    kind = 'torrent'
+                                    tprov = nzbprov
+                                    if torznab_host is not None:
+                                        tprov = torznab_host[0]
+
+                                search_values = {
+                                    "ComicName": ComicName,
+                                    "ComicID": ComicID,
+                                    "IssueID": IssueID,
+                                    "ComicVolume": ComicVersion,
+                                    "IssueNumber": IssueNumber,
+                                    "IssueDate": IssueDate,
+                                    "comyear": cyear,
+                                    "pack": False,
+                                    "pack_numbers": None,
+                                    "pack_issuelist": None,
+                                    "modcomicname": modcomicname,
+                                    "oneoff": oneoff,
+                                    "nzbprov": nzbprov,
+                                    "provider": tprov,
+                                    "nzbtitle": entry['title'],
+                                    "nzbid": nzbid,
+                                    "link": entry['link'],
+                                    "pubdate": pubdate,
+                                    "size": comsize_m,
+                                    "tmpprov": tmpprov,
+                                    "kind": kind,
+                                    "booktype": booktype,
+                                    "SARC": SARC,
+                                    "IssueArcID": IssueArcID,
+                                    "newznab": newznab_host,
+                                    "torznab": torznab_host,
+                                    "downloadit": downloadit,
+                                    "ComicTitle": ComicTitle,
+                                    "entry": entry,
+                                    "provider_stat": provider_stat,
+                                }
+
+                                mylar.COMICINFO.append(search_values)
+
+                                hold_the_matches.append(search_values)
+
+                        else:
+                            #log2file = log2file + "issues don't match.." + "\n"
+                            downloadit = False
+                            #foundc['status'] = False
+        logger.info('returning hold_the_matches: %s' % (hold_the_matches,))
+        return hold_the_matches

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -23,6 +23,7 @@ import cherrypy
 import requests
 import datetime
 from datetime import timedelta, date
+from collections import OrderedDict
 import re
 import json
 import copy
@@ -105,8 +106,60 @@ def serve_template(templatename, **kwargs):
         try:
             template = _hplookup.get_template(templatename)
             return template.render(http_root=mylar.CONFIG.HTTP_ROOT, interface=mylar.CONFIG.INTERFACE, icons=icons, gl_messages=mylar.GLOBAL_MESSAGES, sse_key=mylar.SSE_KEY, **kwargs)
-        except:
+        except Exception:
             return exceptions.html_error_template().render()
+
+
+class WebMaintenance(object):
+
+    auth = AuthController()
+
+    def default(self, attr='abc'):
+        raise cherrypy.HTTPRedirect("maintenance_mode")
+    default.exposed = True
+
+    def maintenance_mode(self):
+        return serve_template(templatename='maintenance_mode.html', title='Maintenance Mode!')
+    maintenance_mode.exposed = True
+
+    def check_ActiveMaintenance(self):
+        if mylar.MAINTENANCE_DB_COUNT >= mylar.MAINTENANCE_DB_TOTAL:
+            status = 'Completed!'
+            message = 'completed.'
+            updatetype = '.:[RSS table update]:.'
+            percent = 0
+        else:
+            updatetype = '.:[RSS table update]:.'
+            status = 'Updating'
+            message = 'Currently updating database'
+            secondary_msg = '( %s / %s )' % (mylar.MAINTENANCE_DB_COUNT, mylar.MAINTENANCE_DB_TOTAL)
+            m_math = int( (mylar.MAINTENANCE_DB_COUNT *100) / (mylar.MAINTENANCE_DB_TOTAL *100) * 100 )
+            percent = '%s%s' % (m_math, '%')
+        return json.dumps(
+                     {
+                         'status': status,
+                         'percent': percent,
+                         'message': message,
+                         'secondary_msg': secondary_msg,
+                         'updatetype': updatetype
+                     }
+        )
+    check_ActiveMaintenance.exposed = True
+
+    def restart(self):
+        logger.info('[RESTART] Now Restarting Mylar...')
+        mylar.SIGNAL = 'restart'
+        message = 'Restarting...'
+        return serve_template(templatename="shutdown.html", title="Restarting", message=message, timer=5)
+    restart.exposed = True
+
+    def shutdown(self):
+        logger.info('[SHUTDOWN] Now Shutting down Mylar...')
+        mylar.SIGNAL = 'shutdown'
+        message = 'Shutting Down...'
+        return serve_template(templatename="shutdown.html", title="Shutting Down", message=message, timer=5)
+    shutdown.exposed = True
+
 
 class WebInterface(object):
 
@@ -118,6 +171,19 @@ class WebInterface(object):
         else:
             raise cherrypy.HTTPRedirect("home")
     index.exposed=True
+
+    def check_ActiveMaintenance(self):
+        # this is just here to return 100% on completion so the reload can occur properly.
+        return json.dumps(
+                     {
+                           'status': 'Completed!',
+                           'percent': '100%',
+                           'message': 'RSS Update completed!',
+                           'secondary_msg': 'Please wait...</br>Disabling Maintenance mode',
+                           'updatetype': '.:[RSS table update]:.'
+                     }
+        )
+    check_ActiveMaintenance.exposed = True
 
     def home(self, **kwargs):
         if mylar.CONFIG.ALPHAINDEX == True:
@@ -802,7 +868,11 @@ class WebInterface(object):
                 results = mb.findComic(name, mode, issue=None)
             except TypeError:
                 logger.error('Unable to perform required search for : [name: ' + name + '][mode: ' + mode + ']')
-                return
+                return json.dumps({
+                    'iTotalDisplayRecords': 0,
+                    'iTotalRecords': 0,
+                    'aaData': [],
+                })
         else:
             results = []
             for rt in db_results:
@@ -1764,7 +1834,11 @@ class WebInterface(object):
                         logger.warn('Unable to remove directory as it does not exist in : ' + seriesdir)
                 else:
                     logger.warn('Unable to remove directory as it does not exist in : ' + seriesdir)
-            logger.info('Successful deletion of %s %s (%s) from your watchlist' % (ComicName, seriesvol, seriesyear))
+            if seriesvol is None:
+                dspline = '%s (%s)' % (ComicName, seriesyear)
+            else:
+                dspline = '%s %s (%s)' % (ComicName, seriesvol, seriesyear)
+            logger.info('Successful deletion of %s from your watchlist' % (dspline))
             helpers.ComicSort(sequence='update')
         raise cherrypy.HTTPRedirect("home")
     deleteSeries.exposed = True
@@ -3074,7 +3148,7 @@ class WebInterface(object):
             filters = json.loads(kwargs.get('filters'))
         except Exception as e:
             filters = []
-        logger.info('filters: %s' % (filters,))
+        #logger.fdebug('filters: %s' % (filters,))
 
         myDB = db.DBConnection()
         if sSortDir_0 == 'desc':
@@ -3234,9 +3308,9 @@ class WebInterface(object):
                 if matched is True:
                     filtered.append([ark['comicname'], ark['issuenumber'], ark['releasedate'], key, tier, ark['comicid'], ark['status'], ark['storyarc'], ark['storyarcid'], ark['issuearcid'], "oneoff"])
 
-        logger.info('[%s] one-off arcs: %s' % (len(arcs), arcs,))
+        #logger.fdebug('[%s] one-off arcs: %s' % (len(arcs), arcs,))
 
-        logger.info('sort_column: %s: sort_directioN: %s' % (iSortCol_0,sSortDir_0))
+        logger.fdebug('sort_column: %s: sort_directioN: %s' % (iSortCol_0,sSortDir_0))
         sortcolumn = 2 #'releasedate'
         if iSortCol_0 == '1':
             sortcolumn = 0 #'comicame'
@@ -3287,7 +3361,7 @@ class WebInterface(object):
         if missinglist:
             threading.Thread(target=search.searchIssueIDList, args=[missinglist]).start()
             logger.info('[SEARCH-FOR-MISSING] Queued up %s issues to seach for' % (len(missinglist)))
-            mylar.GLOBAL_MESSAGES = {'status': 'success', 'comicname': comicname, 'seriesyear': comicyear, 'comicid': ComicID, 'tables': None, 'message': 'Successfully queued up %s issues of %s (%s)to search for' % (len(missinglist), comicname, comicyear)}
+            mylar.GLOBAL_MESSAGES = {'status': 'success', 'comicname': comicname, 'seriesyear': comicyear, 'comicid': ComicID, 'tables': 'None', 'message': 'Successfully queued up %s issues of %s (%s)to search for' % (len(missinglist), comicname, comicyear)}
         else:
             logger.info('[SEARCH-FOR-MISSING] Nothing to queue up')
             mylar.GLOBAL_MESSAGES = {'status': 'success', 'comicname': None, 'seriesyear': None, 'comicid': ComicID, 'tables': 'None', 'message': 'Nothing to queue up'}
@@ -3297,23 +3371,34 @@ class WebInterface(object):
     def skipped2wanted(self, comicid, fromupdate=None):
         # change all issues for a given ComicID that are Skipped, into Wanted.
         issuestowanted = []
-        issuesnumwant = []
+        issuesnumwant = 0
+        annsnumwant = 0
+        mvvalues = {"Status": "Wanted"}
         myDB = db.DBConnection()
-        skipped2 = myDB.select("SELECT * from issues WHERE ComicID=? AND Status='Skipped'", [comicid])
+        skipped2 = myDB.select("SELECT issueid, 0 as type from issues WHERE ComicID=? AND Status='Skipped'", [comicid])
+        if mylar.CONFIG.ANNUALS_ON:
+            skipped2 += myDB.select("SELECT issueid, 1 as type from annuals WHERE ComicID=? AND Status='Skipped'", [comicid])
         for skippy in skipped2:
-            mvcontroldict = {"IssueID":    skippy['IssueID']}
-            mvvalues = {"Status":         "Wanted"}
-            myDB.upsert("issues", mvvalues, mvcontroldict)
-            issuestowanted.append(skippy['IssueID'])
-            issuesnumwant.append(skippy['Issue_Number'])
-        if len(issuestowanted) > 0:
+            mvcontroldict = {"IssueID": skippy['IssueID']}
+            if skippy['type'] == 1:
+                skip_table = 'annuals'
+                issuesnumwant +=1
+            else:
+                skip_table = 'issues'
+                annsnumwant +=1
+            myDB.upsert(skip_table, mvvalues, mvcontroldict)
+            issuestowanted.append(skippy['issueid'])
+        if issuesnumwant > 0:
+            num_line = '%s issues' % issuesnumwant
+            if annsnumwant > 0:
+                num_line += ' and %s annauls' % annsnumwant
             if fromupdate is None:
-                logger.info("Marking issues: %s as Wanted" % issuesnumwant)
+                logger.info("Marking %s as Wanted" % num_line)
                 threading.Thread(target=search.searchIssueIDList, args=[issuestowanted]).start()
-                line_message = 'Successfully changed %s issues from Skipped 2 Wanted' % len(issuestowanted)
+                line_message = 'Successfully changed %s from Skipped 2 Wanted' % num_line
                 line_status = 'success'
             else:
-                logger.info('Marking issues: %s as Wanted' & issuesnumwant)
+                logger.info('Marking %s as Wanted' % num_line)
                 logger.info('These will be searched for on next Search Scan / Force Check')
                 return
         else:
@@ -3336,7 +3421,8 @@ class WebInterface(object):
 
     annualDelete.exposed = True
 
-    def ddl_requeue(self, mode, id=None):
+    def ddl_requeue(self, mode, id=None, issueid=None):
+        logger.info('id: %s / mode: %s / issueid: %s' % (id, mode, issueid))
         myDB = db.DBConnection()
         if mode == 'clear_queue':
             chk = myDB.selectone("SELECT count(*) AS count FROM ddl_info WHERE status = 'Queued'").fetchone()
@@ -3383,6 +3469,7 @@ class WebInterface(object):
                                      'size':     item['size'],
                                      'comicid':  item['comicid'],
                                      'issueid':  item['issueid'],
+                                     'site':     item['site'],
                                      'id':       item['id'],
                                      'resume':   resume})
 
@@ -3409,7 +3496,7 @@ class WebInterface(object):
 
         resultlist = 'There are currently no items waiting in the Direct Download (DDL) Queue for processing.'
         s_info = myDB.select("SELECT a.ComicName, a.ComicVersion, a.ComicID, a.ComicYear, b.Issue_Number, b.IssueID, c.size, c.status, c.id, c.updated_date, c.issues, c.year FROM comics as a INNER JOIN issues as b ON a.ComicID = b.ComicID INNER JOIN ddl_info as c ON b.IssueID = c.IssueID") # WHERE c.status != 'Downloading'")
-        o_info = myDB.select("Select a.ComicName, b.Issue_Number, a.IssueID, a.ComicID, c.size, c.status, c.id, c.updated_date, c.issues, c.year from oneoffhistory a join snatched b on a.issueid=b.issueid join ddl_info c on b.issueid=c.issueid where b.provider = 'ddl'")
+        o_info = myDB.select("Select a.ComicName, b.Issue_Number, a.IssueID, a.ComicID, c.size, c.status, c.id, c.updated_date, c.issues, c.year from oneoffhistory a join snatched b on a.issueid=b.issueid join ddl_info c on b.issueid=c.issueid where b.provider like 'DDL%'")
         if s_info:
             resultlist = []
             for si in s_info:
@@ -3480,7 +3567,7 @@ class WebInterface(object):
         myDB = db.DBConnection()
         resultlist = 'There are currently no items waiting in the Direct Download (DDL) Queue for processing.'
         s_info = myDB.select("SELECT a.ComicName, a.ComicVersion, a.ComicID, a.ComicYear, b.Issue_Number, b.IssueID, c.size, c.status, c.id, c.updated_date, c.issues, c.year FROM comics as a INNER JOIN issues as b ON a.ComicID = b.ComicID INNER JOIN ddl_info as c ON b.IssueID = c.IssueID") # WHERE c.status != 'Downloading'")
-        o_info = myDB.select("Select a.ComicName, b.Issue_Number, a.IssueID, a.ComicID, c.size, c.status, c.id, c.updated_date, c.issues, c.year from oneoffhistory a join snatched b on a.issueid=b.issueid join ddl_info c on b.issueid=c.issueid where b.provider = 'ddl'")
+        o_info = myDB.select("Select a.ComicName, b.Issue_Number, a.IssueID, a.ComicID, c.size, c.status, c.id, c.updated_date, c.issues, c.year from oneoffhistory a join snatched b on a.issueid=b.issueid join ddl_info c on b.issueid=c.issueid where b.provider like 'DDL%'")
         if s_info:
             resultlist = []
             for si in s_info:
@@ -3577,7 +3664,7 @@ class WebInterface(object):
             rows = filtered[iDisplayStart:(iDisplayStart + iDisplayLength)]
         else:
             rows = filtered
-        rows = [[row['comicid'], row['series'], row['size'], row['progress'], row['status'], row['updated_date'], row['queueid']] for row in rows]
+        rows = [[row['comicid'], row['series'], row['size'], row['progress'], row['status'], row['updated_date'], row['queueid'], row['issueid']] for row in rows]
         #rows = [{'comicid': row['comicid'], 'series': row['series'], 'size': row['size'], 'progress': row['progress'], 'status': row['status'], 'updated_date': row['updated_date']} for row in rows]
         #logger.info('rows: %s' % rows)
         return json.dumps({
@@ -4600,8 +4687,11 @@ class WebInterface(object):
 
     def addtoreadlist(self, IssueID):
         read = readinglist.Readinglist(IssueID=IssueID)
-        read.addtoreadlist()
-        return
+        chkreturn = read.addtoreadlist()
+        if chkreturn is not None:
+            return json.dumps({'status': chkreturn['status'], 'message': chkreturn['message']})
+        else:
+            return
         #raise cherrypy.HTTPRedirect("comicDetails?ComicID=%s" % readlist['ComicID'])
     addtoreadlist.exposed = True
 
@@ -5335,20 +5425,28 @@ class WebInterface(object):
         raise cherrypy.HTTPRedirect("logs")
     clearLogs.exposed = True
 
-    def toggleVerbose(self):
-        if mylar.LOG_LEVEL != 2:
-            mylar.LOG_LEVEL = 2
+    def toggleVerbose(self, level=None):
+        if level is None:
+            if mylar.LOG_LEVEL != 2:
+                mylar.LOG_LEVEL = 2
+            else:
+                mylar.LOG_LEVEL = 1
         else:
-            mylar.LOG_LEVEL = 1
+            mylar.LOG_LEVEL = level
+
         if logger.LOG_LANG.startswith('en'):
-            logger.initLogger(console=not mylar.QUIET, log_dir=mylar.CONFIG.LOG_DIR, max_logsize=mylar.CONFIG.MAX_LOGSIZE, max_logfiles=mylar.CONFIG.MAX_LOGFILES, loglevel=mylar.LOG_LEVEL)
+            if level == 0:
+                logger.initLogger(console=mylar.QUIET, log_dir=mylar.CONFIG.LOG_DIR, max_logsize=mylar.CONFIG.MAX_LOGSIZE, max_logfiles=mylar.CONFIG.MAX_LOGFILES, loglevel=level)
+            else:
+                logger.initLogger(console=not mylar.QUIET, log_dir=mylar.CONFIG.LOG_DIR, max_logsize=mylar.CONFIG.MAX_LOGSIZE, max_logfiles=mylar.CONFIG.MAX_LOGFILES, loglevel=mylar.LOG_LEVEL)
         else:
             logger.mylar_log.stopLogger()
             logger.mylar_log.initLogger(loglevel=mylar.LOG_LEVEL, log_dir=mylar.CONFIG.LOG_DIR, max_logsize=mylar.CONFIG.MAX_LOGSIZE, max_logfiles=mylar.CONFIG.MAX_LOGFILES)
-        #mylar.VERBOSE = not mylar.VERBOSE
-        #logger.initLogger(console=not mylar.QUIET,
-        #    log_dir=mylar.CONFIG.LOG_DIR, verbose=mylar.VERBOSE)
-        if mylar.LOG_LEVEL == 2:
+
+        if level is not None:
+            # this is for maintenance mode so that it returns without notice.
+            return
+        elif mylar.LOG_LEVEL == 2:
             logger.info("Verbose (DEBUG) logging is enabled")
             logger.debug("If you can read this message, debug logging is now working")
         else:
@@ -6357,6 +6455,7 @@ class WebInterface(object):
                     "newznab": helpers.checked(mylar.CONFIG.NEWZNAB),
                     "extra_newznabs": sorted(mylar.CONFIG.EXTRA_NEWZNABS, key=itemgetter(5), reverse=True),
                     "enable_ddl": helpers.checked(mylar.CONFIG.ENABLE_DDL),
+                    "enable_getcomics": helpers.checked(mylar.CONFIG.ENABLE_GETCOMICS),
                     "enable_rss": helpers.checked(mylar.CONFIG.ENABLE_RSS),
                     "rss_checkinterval": mylar.CONFIG.RSS_CHECKINTERVAL,
                     "rss_last": rss_sclast,
@@ -6808,7 +6907,8 @@ class WebInterface(object):
                            'lowercase_filenames', 'autowant_upcoming', 'autowant_all', 'comic_cover_local', 'cover_folder_local', 'series_metadata_local', 'alternate_latest_series_covers', 'cvinfo', 'snatchedtorrent_notify',
                            'prowl_enabled', 'prowl_onsnatch', 'pushover_enabled', 'pushover_onsnatch', 'pushover_image', 'boxcar_enabled',
                            'boxcar_onsnatch', 'pushbullet_enabled', 'pushbullet_onsnatch', 'telegram_enabled', 'telegram_onsnatch', 'telegram_image', 'discord_enabled', 'discord_onsnatch', 'slack_enabled', 'slack_onsnatch',
-                           'email_enabled', 'email_enc', 'email_ongrab', 'email_onpost', 'opds_enable', 'opds_authentication', 'opds_metainfo', 'opds_pagesize', 'enable_ddl', 'deluge_pause'] #enable_public
+                           'email_enabled', 'email_enc', 'email_ongrab', 'email_onpost', 'opds_enable', 'opds_authentication', 'opds_metainfo', 'opds_pagesize', 'enable_ddl',
+                           'enable_getcomics', 'deluge_pause'] #enable_public
 
         for checked_config in checked_configs:
             if checked_config not in kwargs:
@@ -7136,12 +7236,38 @@ class WebInterface(object):
 
     opds.exposed = True
 
-    def downloadthis(self, pathfile=None):
-        #pathfile should be escaped via the |u tag from within the html call already.
-        logger.fdebug('filepath to retrieve file from is : ' + pathfile)
-        from cherrypy.lib.static import serve_download
-        return serve_download(pathfile)
+    def downloadthis(self, issueid):
+        myDB = db.DBConnection()
+        issue = myDB.selectone('SELECT a.ComicLocation, b.* FROM comics a LEFT JOIN issues b ON a.comicid = b.comicid WHERE b.issueid=?', [issueid]).fetchone()
+        if issue:
+            secondary_folders = None
+            if mylar.CONFIG.MULTIPLE_DEST_DIRS:
+                try:
+                    if os.path.exists(os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(issue['ComicLocation']))):
+                        secondary_folders = os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(issue['ComicLocation']))
+                    else:
+                        # when loading a new series initially the publisher value might not be written out the db yet.
+                        # pass this all on the initial load if it's not  - it'll catch it when the page finishes loading.
+                        ff = mylar.filers.FileHandlers(ComicID=issue['ComicID'])
+                        secondary_folders = ff.secondary_folders(issue['ComicLocation'])
+                except Exception:
+                    pass
+        else:
+            return json.dumps({'status': 'failure', 'message': 'Unable to locate selected issue in database'})
 
+        pathfile = None
+        if all([issue['Location'] is not None, issue['ComicLocation'] is not None]):
+            if os.path.exists(os.path.join(issue['ComicLocation'], issue['Location'])):
+                pathfile = os.path.join(issue['ComicLocation'], issue['Location'])
+            elif secondary_folders is not None:
+                if os.path.exists(os.path.join(secondary_folders, issue['Location'])):
+                    pathfile = os.path.join(secondary_folders, issue['Location'])
+
+        if pathfile is None:
+            return json.dumps({'status': 'failure', 'message': 'Unable to find issue - you might want to ReCheck Files'})
+        else:
+            dspline = 'Now downloading issue #%s of %s' % (issue['Issue_Number'], issue['ComicName'])
+            return cherrypy.lib.static.serve_download( pathfile )
     downloadthis.exposed = True
 
     def IssueInfo(self, issueid): #filelocation, comicname=None, issue=None, date=None, title=None, issueid=None):
@@ -7985,8 +8111,10 @@ class WebInterface(object):
                                 'a_year':  None,
                                 'a_filename':  None,
                                 'a_size':  None,
-                                'a_id':  None})
+                                'a_id':  None,
+                                'a_issueid': None})
          else:
+             filelocation = None
              if active['filename'] is not None:
                  filelocation = os.path.join(mylar.CONFIG.DDL_LOCATION, active['filename'])
                  #logger.fdebug('checking file existance: %s' % filelocation)
@@ -8674,10 +8802,16 @@ class WebInterface(object):
         else:
             comicImage = "data:image/gif;base64,%s" % mylar.getimage.load_image(os.path.join(mylar.PROG_DIR, 'data', 'images', 'blank.gif'),263)
 
+        dir_exists = ''
+        if comlocation is not None:
+            if os.path.exists(comlocation):
+                dir_exists = 'false'
+            else:
+                dir_exists = 'true'
         #logger.info('comlocation: %s' % comlocation)
         #if all([location is not None, comlocation != location]):
         #    comlocation = location
         #    logger.fdebug('location preset from editor as : %s' % (comlocation))
-
-        return json.dumps({'status': 'success', 'image': comicImage, 'booktype': booktype, 'comicname': results['ComicName'], 'publisher': results['ComicPublisher'], 'comicyear': results['ComicYear'], 'issues': results['ComicIssues'], 'description': results['ComicDescription'], 'comlocation': comlocation})
+        logger.info('[%s] comlocation: %s' % (dir_exists,comlocation))
+        return json.dumps({'status': 'success', 'image': comicImage, 'booktype': booktype, 'comicname': results['ComicName'], 'publisher': results['ComicPublisher'], 'comicyear': results['ComicYear'], 'issues': results['ComicIssues'], 'description': results['ComicDescription'], 'comlocation': comlocation, 'dir_exists': dir_exists})
     editDetails.exposed = True


### PR DESCRIPTION
IMP: vast improvement in RSS searching time (refactored)
IMP: maintenance-mode GUI mode with progress indicators, resume and isolated web GUI during upgrade path when upgrading db (as well as progress in CLI)
IMP: DDL downloads will get the ``[__ISSUEID__]`` attached temporarily to filename to lessen chance of problems with naming problems
IMP: Break out search matching functionality from search module into it's own module
IMP: (refactor) Breaking out allows DDL items to be verified for matches during queries saving hits & time
IMP: Priority Alternate Search Name added - use !! instead of ## to denote priority vs normal
IMP: Provider-search delay (global setting) is now honoured on a per provider basis and is persistent across restarts.
IMP: Skipped2Wanted will now take both issues & annuals into account for a series
IMP: Break out DDL into DDL(GetComics) to allow for future additions (config auto-update to v12)
IMP: Force Enable DDL to mirror DDL(GetComics) when enabling/disabling via GUI since only option available atm
IMP: Flaresolverr support added (specifically for GC usage only)
IMP: Cookie receipts when using GC
IMP: Extra loop for tpb/gn/one-shot/annual inclusion when using DDL to account for issues with no issue number
IMP: ``ddl_query_delay`` available to delay search queries to GC (default 15s) and only affects search queries
IMP:  DDL downloads will now temporarily append the issueid to the filename after downloading to improve post-processing
FIX: Annual integration broken and not auto-adding annuals outside of manually integrating them
FIX: Error when post-processing issues with the ``[__ISSUEID__]`` included in the filename for direct issue processing.
FIX: ``Add to Readinglist`` and ``Download`` icons & functionality restored to series detail page
FIX: Deleting series in GUI via seriesdetail page would sometimes throw a 500 error
FIX: Make sure to return a null dataset instead of just null when no searchresults returned
FIX: Remove some extra logging lines needed during testing
FIX: Search-4-missing would not throw a popup after queue submission
FIX: Forgot to include One-Shot as part of the TPB/GN/HC json return to show possibility of having no issue numbers
FIX: Status colours on Scheduler Management page
FIX: Extra spacing at bottom of Edit Settings tab on series detail page causing tab size to be bigger than necessary
FIX: Try to adjust Folder Name creation to retain $VolumeN when series is a non-print edition