### PR TITLE
FIX:(#1011) Experimental provider error on startup, IMP: Changed how ini & db files are backed up

### DIFF
--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -168,7 +168,7 @@ class FileHandlers(object):
         chunk_folder_format = re.sub(r'\s+', ' ', chunk_folder_format)
 
         # if the path contains // in linux it will incorrectly parse things out.
-        logger.fdebug('newPath: %s' % re.sub('//', '/', chunk_folder_format).strip())
+        #logger.fdebug('newPath: %s' % re.sub('//', '/', chunk_folder_format).strip())
 
         #do work to generate folder path
         values = {'$Series':        series,

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -374,7 +374,7 @@ def search_init(
                         searchprov['DDL(GetComics)']['active'] = True
                 elif prov_order[prov_count] == '32p' and not provider_blocked:
                     searchprov['32P'] = ({'type': 'torrent', 'lastrun': 0, 'active': True})
-                elif prov_order[prov_count] == 'Experimental' and not provider_blocked and 'experimental' not in checked_once:
+                elif prov_order[prov_count] == 'experimental' and not provider_blocked and 'experimental' not in checked_once:
                     if 'experimental' not in searchprov.keys():
                         prov_order[prov_count] = 'experimental'  # cause it's Experimental for display
                         logger.info('resetting searchprov - last run here..')


### PR DESCRIPTION
- FIX: (#1011) If Experimental provider was enabled, Mylar would fail to start.
- IMP: Added ``backup_location`` and ``backup_retention`` as config.ini values to better control where & how much backup files are retained.
- IMP: Backups are now rolling backups based on the ``backup_retention`` value (default of 4 files). Will only keep the X most recent files of each in the ``backup_location`` if specified (if not will be in the root of the mylar installation).
- IMP: Altered the ``-b`` switch to allow for ``-b ini`` or ``-b db`` for ini and db only backups respectively. Just using ``-b`` by itself will back up both.
- IMP: Backup of config.ini will occur when config schema is updated. Backup of mylar.db will occur when db schema change is required or database data needs altering.
- FIX: Removed some unnecessary logging lines.