### PR TITLE
FIX: couple traceback errors w/ experimental & GC, FIX: GC file already exists error

### DIFF
--- a/mylar/Failed.py
+++ b/mylar/Failed.py
@@ -143,7 +143,7 @@ class FailedProcessor(object):
             nzbname = nzbiss['NZBName']
 
         if all([self.id == nzbiss['ID'], self.prov == nzbiss['PROVIDER']]):
-            logger.info('ID %s for provider %s already exists as a Failed item. Continuing the search...')
+            logger.info('ID %s for provider %s already exists as a Failed item. Continuing the search...' % (nzbiss['ID'], nzbiss['Provider']))
             return
 
         if self.prov is None:

--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -549,10 +549,10 @@ class PostProcessor(object):
                                     else:
                                         tpath = os.path.join(self.nzb_folder, fl['sub'], fl['comicfilename'])
                                     cloct = pathlib.Path(tpath).with_name(nfilename)
-                                    clocation = str(pathlib.Path(tpath).rename(cloct))
+                                    clocation = str(pathlib.Path(tpath).replace(cloct))
                                 else:
                                     cloct = pathlib.Path(tpath).with_name(nfilename)
-                                    clocation = str(pathlib.Path(tpath).rename(cloct))
+                                    clocation = str(pathlib.Path(tpath).replace(cloct))
 
                                 logger.fdebug('path with the issueid removed: %s' % clocation)
 

--- a/mylar/findcomicfeed.py
+++ b/mylar/findcomicfeed.py
@@ -42,8 +42,10 @@ def Startit(searchName, searchIssue, searchYear, ComicVersion, IssDateFix, bookt
     tmpsearchIssue = searchIssue
 
     if any([booktype == 'One-Shot', booktype == 'TPB']):
-        tmpsearchIssue = '1'
-        loop = 4
+            tmpsearchIssue = '1'
+            loop = 4
+    elif searchIssue is None:
+        loop = 1
     elif len(searchIssue) == 1:
         loop = 3
     elif len(searchIssue) == 2:


### PR DESCRIPTION
- FIX: Experimental search would throw traceback on searching for print versions of issues with no file name
- FIX: If file already exists when DDL goes to download and resume isn't enabled, would cause traceback
- FIX: Variables not formatted in a logger line within the failed module
- FIX: If file already exists during post-processing without the ``[__ISSUEID__]`` (but has it within the original filename) in the same location (ie. DDL) - would throw a FileExistsError and halt post-processing queue 