### PR TITLE
IMP: Add unwatched series from Arc to watchlist, FIX: logging error on non-EN systems during maintenance

### DIFF
--- a/Mylar.py
+++ b/Mylar.py
@@ -251,7 +251,7 @@ def main():
     #    raise SystemExit('FATAL ERROR')
 
     if mylar.MAINTENANCE is False:
-        filechecker.validateAndCreateDirectory(mylar.DATA_DIR, True)
+        filechecker.validateAndCreateDirectory(mylar.DATA_DIR, True, dmode='DATA')
 
         # Make sure the DATA_DIR is writeable
         if not os.access(mylar.DATA_DIR, os.W_OK):

--- a/data/interfaces/default/storyarc_detail.html
+++ b/data/interfaces/default/storyarc_detail.html
@@ -12,8 +12,7 @@
                         %if mylar.CONFIG.TAB_ENABLE:
   			    <a id="menu_link_delete" onclick="doAjaxCall('syncfiles',$(this),'table')" data-success="Successfully sent issues to your device">Sync</a>
                         %endif
-			<a id="menu_link_delete" href="#">Remove Read</a>
-			<a id="menu_link_delete" href="#">Clear File Cache</a>
+                        <a id="menu_link_refresh" href="#" title="Add series that are in this arc, but not currently on your watchlist into your watchlist" onclick="doAjaxCall('addMissingSeriesFromArc?storyarcid=${storyarcid}',$(this),'table')" data-success="Submitted adding missing series for ${storyarcname}">Add Unwatched Series to Watchlist</a>
                         <a id="menu_link_refresh" onclick="doAjaxCall('SearchArcIssues?StoryArcID=${storyarcid}',$(this),'table')" data-success="Now searching for Missing StoryArc Issues">Search for Missing</a>
                         <a id="menu_link_refresh" onclick="doAjaxCall('ArcWatchlist?StoryArcID=${storyarcid}',$(this),'table')" data-success="Now searching for matches on Watchlist & Rechecking files">Search for Watchlist matches/Recheck Files</a>
                         %if cvarcid:

--- a/data/interfaces/default/storyarc_detail.poster.html
+++ b/data/interfaces/default/storyarc_detail.poster.html
@@ -12,8 +12,7 @@
                         %if mylar.CONFIG.TAB_ENABLE:
   			    <a id="menu_link_delete" onclick="doAjaxCall('syncfiles',$(this),'table')" data-success="Successfully sent issues to your device">Sync</a>
                         %endif
-			<a id="menu_link_delete" href="#">Remove Read</a>
-			<a id="menu_link_delete" href="#">Clear File Cache</a>
+			<a id="menu_link_refresh" href="#" title="Add series that are in this arc, but not currently on your watchlist into your watchlist" onclick="doAjaxCall('addMissingSeriesFromArc?storyarcid=${storyarcid}',$(this),'table')" data-success="Submitted adding missing series for ${storyarcname}">Add Unwatched Series to Watchlist</a>
                         <a id="menu_link_refresh" onclick="doAjaxCall('SearchArcIssues?StoryArcID=${storyarcid}',$(this),'table')" data-success="Now searching for Missing StoryArc Issues">Search for Missing</a>
                         <a id="menu_link_refresh" onclick="doAjaxCall('ArcWatchlist?StoryArcID=${storyarcid}',$(this),'table')" data-success="Now searching for matches on Watchlist">Search for Watchlist matches</a>
                         %if cvarcid:

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -560,35 +560,6 @@ class Config(object):
     def read(self, startup=False):
         self.config_vals()
 
-        if any([self.CONFIG_VERSION == 0, self.CONFIG_VERSION < self.newconfig]):
-            if not self.BACKUP_LOCATION:
-                # this is needed here since the configuration hasn't run to check the location value yet.
-                self.BACKUP_LOCATION = os.path.join(mylar.DATA_DIR, 'backup')
-
-            backupinfo = {'location': self.BACKUP_LOCATION,
-                          'config_version': self.CONFIG_VERSION,
-                          'backup_retention': self.BACKUP_RETENTION}
-            cc = maintenance.Maintenance('backup')
-            bcheck = cc.backup_files(cfg=True, dbs=False, backupinfo=backupinfo)
-
-            if self.CONFIG_VERSION < 12:
-                print('Attempting to update configuration..')
-                #8-torznab multiple entries merged into extra_torznabs value
-                #9-remote rtorrent ssl option
-                #10-encryption of all keys/passwords.
-                #11-provider ids
-                #12-ddl seperation into multiple providers, new keys, update tables
-                self.config_update()
-            setattr(self, 'OLDCONFIG_VERSION', str(self.CONFIG_VERSION))
-            #config.set('General', 'OLDCONFIG_VERSION', str(self.CONFIG_VERSION))
-            setattr(self, 'CONFIG_VERSION', self.newconfig)
-            config.set('General', 'CONFIG_VERSION', str(self.newconfig))
-            self.writeconfig(startup=startup)
-        else:
-            if self.OLDCONFIG_VERSION != self.CONFIG_VERSION:
-                setattr(self, 'OLDCONFIG_VERSION', str(self.CONFIG_VERSION))
-                #config.set('General', 'OLDCONFIG_VERSION', str(self.CONFIG_VERSION))
-
         if startup is True:
             if self.LOG_DIR is None:
                 self.LOG_DIR = os.path.join(mylar.DATA_DIR, 'logs')
@@ -616,6 +587,33 @@ class Config(object):
                 logger.initLogger(console=not mylar.QUIET, log_dir=self.LOG_DIR, max_logsize=self.MAX_LOGSIZE, max_logfiles=self.MAX_LOGFILES, loglevel=log_level)
             else:
                 logger.mylar_log.initLogger(loglevel=log_level, log_dir=self.LOG_DIR, max_logsize=self.MAX_LOGSIZE, max_logfiles=self.MAX_LOGFILES)
+
+        if any([self.CONFIG_VERSION == 0, self.CONFIG_VERSION < self.newconfig]):
+            if not self.BACKUP_LOCATION:
+                # this is needed here since the configuration hasn't run to check the location value yet.
+                self.BACKUP_LOCATION = os.path.join(mylar.DATA_DIR, 'backup')
+
+            backupinfo = {'location': self.BACKUP_LOCATION,
+                          'config_version': self.CONFIG_VERSION,
+                          'backup_retention': self.BACKUP_RETENTION}
+            cc = maintenance.Maintenance('backup')
+            bcheck = cc.backup_files(cfg=True, dbs=False, backupinfo=backupinfo)
+
+            if self.CONFIG_VERSION < 12:
+                print('Attempting to update configuration..')
+                #8-torznab multiple entries merged into extra_torznabs value
+                #9-remote rtorrent ssl option
+                #10-encryption of all keys/passwords.
+                #11-provider ids
+                #12-ddl seperation into multiple providers, new keys, update tables
+                self.config_update()
+            setattr(self, 'OLDCONFIG_VERSION', str(self.CONFIG_VERSION))
+            setattr(self, 'CONFIG_VERSION', self.newconfig)
+            config.set('General', 'CONFIG_VERSION', str(self.newconfig))
+            self.writeconfig(startup=startup)
+        else:
+            if self.OLDCONFIG_VERSION != self.CONFIG_VERSION:
+                setattr(self, 'OLDCONFIG_VERSION', str(self.CONFIG_VERSION))
 
         extra_newznabs, extra_torznabs = self.get_extras()
         setattr(self, 'EXTRA_NEWZNABS', extra_newznabs)

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -1809,7 +1809,7 @@ def image_it(comicid, latestissueid, comlocation, ComicImage):
 
 def importer_thread(serieslist):
     # importer thread to queue up series to be added to the watchlist
-    # serieslist = [{'comicid': '2828991', 'series': 'Some Comic'}]
+    # serieslist = [{'comicid': '2828991', 'series': 'Some Comic', 'seriesyear': 1999}]
 
     if type(serieslist) != list:
         serieslist  = [(serieslist)]


### PR DESCRIPTION
- IMP: Add unwatched series from Arc to watchlist
- FIX: logging error on non-EN systems during maintenance resultling in non-operational bootup
- FIX: Remove ``Read Sync`` and ``Clear File Cache`` from StoryArc detail pages as they're non-working
- FIX: indicate Data directory check on startup, instead of saying comic directory (misleading)