### PR TITLE
scheduler fixes

### DIFF
--- a/mylar/searchit.py
+++ b/mylar/searchit.py
@@ -30,5 +30,5 @@ class CurrentSearcher():
         mylar.SEARCH_STATUS = 'Running'
         mylar.search.searchforissue()
         helpers.job_management(write=True, job='Auto-Search', last_run_completed=helpers.utctimestamp(), status='Waiting')
-        mylar.SEARCH_STATUS = 'Waiting'
+        #mylar.SEARCH_STATUS = 'Waiting'
         #mylar.SCHED_SEARCH_LAST = helpers.now()

--- a/mylar/versioncheckit.py
+++ b/mylar/versioncheckit.py
@@ -29,4 +29,3 @@ class CheckVersion():
         mylar.VERSION_STATUS = 'Running'
         versioncheck.checkGithub()
         helpers.job_management(write=True, job='Check Version', last_run_completed=helpers.utctimestamp(), status='Waiting')
-        mylar.VERSION_STATUS = 'Waiting'

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -3932,16 +3932,22 @@ class WebInterface(object):
                 logger.info('[%s] Now force submitting job for jobid %s' % (jb, jobid))
                 if any([jobid == 'rss', jobid == 'weekly', jobid =='search', jobid == 'version', jobid == 'updater', jobid == 'monitor']):
                     if jobid == 'rss':
+                        mylar.FORCE_STATUS['rss'] = mylar.RSS_STATUS
                         mylar.RSS_STATUS = 'Running'
                     elif jobid == 'weekly':
+                        mylar.FORCE_STATUS['weekly'] = mylar.WEEKLY_STATUS
                         mylar.WEEKLY_STATUS = 'Running'
                     elif jobid == 'search':
+                        mylar.FORCE_STATUS['search'] = mylar.SEARCH_STATUS
                         mylar.SEARCH_STATUS = 'Running'
                     elif jobid == 'version':
+                        mylar.FORCE_STATUS['version'] = mylar.VERSION_STATUS
                         mylar.VERSION_STATUS = 'Running'
                     elif jobid == 'updater':
+                        mylar.FORCE_STATUS['updater'] = mylar.UPDATER_STATUS
                         mylar.UPDATER_STATUS = 'Running'
                     elif jobid == 'monitor':
+                        mylar.FORCE_STATUS['monitor'] = mylar.MONITOR_STATUS
                         mylar.MONITOR_STATUS = 'Running'
                     jb.modify(next_run_time=datetime.datetime.utcnow())
                     break

--- a/mylar/weeklypullit.py
+++ b/mylar/weeklypullit.py
@@ -30,5 +30,5 @@ class Weekly():
         weeklypull.pullit()
         weeklypull.future_check()
         helpers.job_management(write=True, job='Weekly Pullist', last_run_completed=helpers.utctimestamp(), status='Waiting')
-        mylar.WEEKLY_STATUS = 'Waiting'
+        #mylar.WEEKLY_STATUS = 'Waiting'
 


### PR DESCRIPTION
- FIX: Schedulers would run even though config settings would have them disabled
- FIX: Loading previous states from db would not take into account status' prior to the update
- FIX: monitor_scheduler was mislabelled as folder_scheduler which probably caused some problems
- FIX: When folder monitor was run (whether enabled or not) and no folder was set, would traceback error and lock up the thread
- FIX: If job is in a Paused status, there is no Next Runtime displayed in the GUI
- FIX: Force job will now only run the job once instead of inadvertently making it a scheduled job (even if it was Paused prior to the Force job) 