### PR TITLE
FIX: DBUpdate notification/logging variable incorrect, FIX: remove unnecessary logging 

### DIFF
--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -472,7 +472,7 @@ class FileChecker(object):
         ignore_mod_position = -1
         if year_check:
             ignore_mod_position = self.char_file_position(modfilename, year_check[0], modfilename.index(year_check[0]))
-            logger.info('[%s] year_check: %s' % (ignore_mod_position,year_check,))
+            #logger.fdebug('[%s] year_check: %s' % (ignore_mod_position,year_check,))
 
         for sf in split_file:
             current_pos +=1

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -1869,7 +1869,7 @@ class WebInterface(object):
             watch.append({"comicid": ComicID, "comicname": chkdb['ComicName'], "seriesyear": chkdb['ComicYear']})
 
         if len(watch) > 0:
-            logger.info('[SHIZZLE-WHIZZLE] Now queueing to refresh %s %s' % (chkdb['ComicName'], chkdb['ComicYear']))
+            logger.info('[SHIZZLE-WHIZZLE] Now queueing to refresh %s (%s)' % (chkdb['ComicName'], chkdb['ComicYear']))
             try:
                 importer.refresh_thread(watch)
             except Exception:

--- a/mylar/weeklypull.py
+++ b/mylar/weeklypull.py
@@ -1015,7 +1015,7 @@ def new_pullcheck(weeknumber, pullyear, comic1off_name=None, comic1off_id=None, 
         if not comic1off_id:
             logger.fdebug("[WALKSOFTLY] You are watching for: " + str(len(weeklylist)) + " comics")
 
-        weekly = myDB.select('SELECT * from(SELECT a.comicid,IFNULL(a.Comic, b.ComicName) as ComicName,a.rowid,a.issue,a.issueid,NULL as ComicPublisher,a.weeknumber,a.shipdate,a.dynamicname,a.annuallink,a.format FROM weekly as a INNER JOIN annuals as b ON b.releasecomicid = a.comicid WHERE weeknumber = ? AND year = ? UNION SELECT a.comicid,IFNULL(a.Comic, c.ComicName) as ComicName,a.rowid,a.issue,a.issueid,c.ComicPublisher,a.weeknumber,a.shipdate,a.dynamicname,a.annuallink,a.format FROM weekly as a INNER JOIN comics as c ON c.comicid = a.comicid OR c.DynamicComicName = a.dynamicname OR a.annuallink = c.comicid WHERE weeknumber = ? AND year = ?  ) GROUP BY dynamicname', [int(weeknumber),pullyear,int(weeknumber),pullyear])
+        weekly = myDB.select('SELECT * from(SELECT a.comicid,IFNULL(a.Comic, b.ComicName) as ComicName,NULL as SeriesYear,a.rowid,a.issue,a.issueid,NULL as ComicPublisher,a.weeknumber,a.shipdate,a.dynamicname,a.annuallink,a.format FROM weekly as a INNER JOIN annuals as b ON b.releasecomicid = a.comicid WHERE weeknumber = ? AND year = ? UNION SELECT a.comicid,IFNULL(a.Comic, c.ComicName) as ComicName,c.ComicYear as SeriesYear,a.rowid,a.issue,a.issueid,c.ComicPublisher,a.weeknumber,a.shipdate,a.dynamicname,a.annuallink,a.format FROM weekly as a INNER JOIN comics as c ON c.comicid = a.comicid OR c.DynamicComicName = a.dynamicname OR a.annuallink = c.comicid WHERE weeknumber = ? AND year = ?  ) GROUP BY dynamicname', [int(weeknumber),pullyear,int(weeknumber),pullyear])
         if mylar.CONFIG.ANNUALS_ON is True:
             #Need to loop over the weekly section and check the name of the title against the ComicName in the annuals table
             # this is to pick up new #1 annuals that don't exist in the db yet, and won't until a refresh of the series happens.
@@ -1273,6 +1273,7 @@ def new_pullcheck(weeknumber, pullyear, comic1off_name=None, comic1off_id=None, 
                         else:
                             isschk = myDB.selectone('SELECT * FROM issues where IssueID=?', [issueid]).fetchone()
 
+
                         if isschk is None:
                             isschk = myDB.selectone('SELECT * FROM annuals where IssueID=? AND NOT Deleted', [issueid]).fetchone()
                             if isschk is None:
@@ -1281,7 +1282,7 @@ def new_pullcheck(weeknumber, pullyear, comic1off_name=None, comic1off_id=None, 
                                     comicid = release_the_id
                                 logger.fdebug('[WEEKLY-PULL] Forcing a refresh of the series to ensure it is current [' + str(comicid) +'].')
                                 anncid = None
-                                seriesyear = None
+                                seriesyear = week['SeriesYear']
                                 try:
                                     logger.fdebug('week[comicid]: %s' % week['comicid'])
                                     logger.fdebug('week[comicid]: %s' % annualidmatch[0]['AnnualIDs'][0]['ComicID'])


### PR DESCRIPTION
- FIX: SSE display during DBUpdate would have a None for year
- FIX: Remove ``year_check`` logging during file scanning