### PR TITLE
FIX: Storyarc detail options fix, FIX: Post-Processing DDL problems, 

### DIFF
--- a/data/interfaces/default/storyarc_detail.html
+++ b/data/interfaces/default/storyarc_detail.html
@@ -212,9 +212,9 @@
                 </td>
                 <td id="options">
                  %if any([item['Status'] is None, item['Status'] == None, item['Status'] == 'Skipped']):
-                     <a href="#" onclick="doAjaxCall('queueit?ComicName=${item['ComicName'] | u}&ComicIssue=${item['IssueNumber']}&ComicYear=${issuedate}&mode=readlist&SARC=${item['StoryArc']}&IssueArcID=${item['IssueArcID']}&SeriesYear=${item['SeriesYear']}',$(this),'table')" data-success="Now searching for ${item['ComicName']} #${item['IssueNumber']}"><span class="ui-icon ui-icon-plus"></span>Grab</a>
+                     <a href="#" onclick="doAjaxCall('queueit?ComicName=${item['ComicName'] | u}&ComicIssue=${item['IssueNumber']}&ComicYear=${issuedate}&mode=readlist&SARC=${item['StoryArc'] |u}&IssueArcID=${item['IssueArcID']}&SeriesYear=${item['SeriesYear']}',$(this),'table')" data-success="Now searching for ${item['ComicName']} #${item['IssueNumber']}"><span class="ui-icon ui-icon-plus"></span>Grab</a>
                  %elif item['Status'] == 'Snatched':
-                     <a href="#" onclick="doAjaxCall('queueit?ComicName=${item['ComicName'] | u}&ComicIssue=${item['IssueNumber']}&ComicYear=${issuedate}&mode=readlist&SARC=${item['StoryArc']}&IssueArcID=${item['IssueArcID']}&SeriesYear=${item['SeriesYear']}',$(this),'table')" data-success="Trying to search again for issue"><span class="ui-icon ui-icon-plus"></span>Retry</a>
+                     <a href="#" onclick="doAjaxCall('queueit?ComicName=${item['ComicName'] | u}&ComicIssue=${item['IssueNumber']}&ComicYear=${issuedate}&mode=readlist&SARC=${item['StoryArc'] |u}&IssueArcID=${item['IssueArcID']}&SeriesYear=${item['SeriesYear']}',$(this),'table')" data-success="Trying to search again for issue"><span class="ui-icon ui-icon-plus"></span>Retry</a>
                  %elif item['Status'] == 'Downloaded' and item['Location'] is not None:
                      <a href="downloadthis?pathfile=${item['Location'] |u}"><span class="ui-icon ui-icon-plus"></span>Download</a>
                  %endif

--- a/data/interfaces/default/storyarc_detail.poster.html
+++ b/data/interfaces/default/storyarc_detail.poster.html
@@ -215,9 +215,9 @@
                 </td>
                 <td id="options">
                  %if any([item['Status'] is None, item['Status'] == None, item['Status'] == 'Skipped']):
-                     <a href="#" onclick="doAjaxCall('queueit?ComicName=${item['ComicName'] | u}&ComicIssue=${item['IssueNumber']}&ComicYear=${issuedate}&mode=readlist&SARC=${item['StoryArc']}&IssueArcID=${item['IssueArcID']}&SeriesYear=${item['SeriesYear']}',$(this),'table')" data-success="Now searching for ${item['ComicName']} #${item['IssueNumber']}"><span class="ui-icon ui-icon-plus"></span>Grab</a>
+                     <a href="#" onclick="doAjaxCall('queueit?ComicName=${item['ComicName'] | u}&ComicIssue=${item['IssueNumber']}&ComicYear=${issuedate}&mode=readlist&SARC=${item['StoryArc'] |u}&IssueArcID=${item['IssueArcID']}&SeriesYear=${item['SeriesYear']}',$(this),'table')" data-success="Now searching for ${item['ComicName']} #${item['IssueNumber']}"><span class="ui-icon ui-icon-plus"></span>Grab</a>
                  %elif item['Status'] == 'Snatched':
-                     <a href="#" onclick="doAjaxCall('queueit?ComicName=${item['ComicName'] | u}&ComicIssue=${item['IssueNumber']}&ComicYear=${issuedate}&mode=readlist&SARC=${item['StoryArc']}&IssueArcID=${item['IssueArcID']}&SeriesYear=${item['SeriesYear']}',$(this),'table')" data-success="Trying to search again for issue"><span class="ui-icon ui-icon-plus"></span>Retry</a>
+                     <a href="#" onclick="doAjaxCall('queueit?ComicName=${item['ComicName'] | u}&ComicIssue=${item['IssueNumber']}&ComicYear=${issuedate}&mode=readlist&SARC=${item['StoryArc'] |u}&IssueArcID=${item['IssueArcID']}&SeriesYear=${item['SeriesYear']}',$(this),'table')" data-success="Trying to search again for issue"><span class="ui-icon ui-icon-plus"></span>Retry</a>
                  %elif item['Status'] == 'Downloaded' and item['Location'] is not None:
                      <a href="downloadthis?pathfile=${item['Location'] |u}"><span class="ui-icon ui-icon-plus"></span>Download</a>
                  %endif

--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -350,8 +350,8 @@ class PostProcessor(object):
                     self._log('Failed to remove temporary directory: %s' % odir)
                     logger.error('%s %s not empty. Skipping removal of temporary cache directory - this will either be caught in further post-processing or have to be manually deleted.' % (self.module, odir))
 
-        except (OSError, IOError):
-            logger.fdebug('%s Failed to remove directory - Processing will continue, but manual removal is necessary' % self.module)
+        except (OSError, IOError) as e:
+            logger.fdebug('%s[%s] Failed to remove directory - Processing will continue, but manual removal is necessary' % (self.module,e))
             self._log('Failed to remove temporary directory')
 
 
@@ -511,76 +511,185 @@ class PostProcessor(object):
                         comicseries = myDB.select('SELECT * FROM comics WHERE ComicID=?', [self.comicid])
                     else:
                         if fl['issueid'] is not None:
+                            story_the_arcs = False
+                            annchk = 'no'
+                            tmp_the_arc = {}
+                            tmp_manual_list = {}
+                            tmp_oneoff = {}
                             logger.info('issueid detected in filename: %s' % fl['issueid'])
+                            ssi = myDB.selectone('SELECT ComicID, IssueID, IssueArcID, IssueNumber, ComicName, SeriesYear, StoryArc, StoryArcID, Publisher, ReadingOrder FROM storyarcs WHERE IssueID=?', [fl['issueid']]).fetchone()
+                            if ssi is not None:
+                                story_the_arcs = True
+                                tmp_the_arc= {"ComicID":         ssi['ComicID'],
+                                              "IssueID":         ssi['IssueID'],
+                                              "IssueNumber":     ssi['IssueNumber'],
+                                              "StoryArc":        ssi['StoryArc'],
+                                              "StoryArcID":      ssi['StoryArcID'],
+                                              "IssueArcID":      ssi['IssueArcID'],
+                                              "SeriesYear":      ssi['SeriesYear'],
+                                              "Publisher":       ssi['Publisher'],
+                                              "ReadingOrder":    ssi['ReadingOrder'],
+                                              "ComicName":       ssi['ComicName']}
+
                             csi = myDB.selectone('SELECT i.ComicID, i.IssueID, i.Issue_Number, c.ComicName, c.ComicYear, c.AgeRating FROM comics as c JOIN issues as i ON c.ComicID = i.ComicID WHERE i.IssueID=?', [fl['issueid']]).fetchone()
                             if csi is None:
                                 csi = myDB.selectone('SELECT a.ComicID as comicid, a.IssueID, a.Issue_Number, a.ReleaseComicName, c.ComicName, c.ComicYear, c.AgeRating FROM comics as c JOIN annuals as a ON c.ComicID = a.ComicID WHERE a.IssueID=? AND NOT a.Deleted', [fl['issueid']]).fetchone()
                                 if csi is not None:
                                     annchk = 'yes'
-                                else:
-                                    continue
-                            else:
-                                annchk = 'no'
 
-                            if self.nzb_name == 'Manual Run':
-                                tname = str(pathlib.Path(fl['comicfilename']))
-                            else:
-                                tname = str(pathlib.Path(fl['comiclocation']).name)
-                                tpath = fl['comiclocation']
-                            xyb = tname.find('[__')
-                            if xyb != -1:
-                                yyb = tname.find('__]', xyb)
-                                if yyb != -1:
-                                    rem_issueid = tname[xyb+3:yyb]
-                                    logger.fdebug('issueid: %s' % rem_issueid)
-                                    two_add = re.sub(r'\s+', '', tname[yyb+3:]).strip()
-                                    if any([two_add == '', two_add == ' ']):
-                                        nfilename = '%s' % tname[:xyb].strip()
-                                    else:
-                                        nfilename = '%s%s' % (tname[:xyb].strip(), two_add)
-                                    logger.fdebug('issueid information [%s] removed successfully: %s' % (rem_issueid, nfilename))
+                            osi = None
+                            if all([csi is None, ssi is None]):
+                                osi = myDB.selectone('select s.Issue_Number, s.ComicName, s.IssueID, s.ComicID, w.seriesyear FROM snatched AS s INNER JOIN nzblog AS n ON s.IssueID = n.IssueID INNER JOIN weekly AS w ON s.IssueID = w.IssueID WHERE s.IssueID = ? AND n.OneOff = 1 AND s.ComicName IS NOT NULL', [fl['issueid']]).fetchone()
+                                if osi is not None:
+                                    tmp_oneoff = {"ComicID":         osi['ComicID'],
+                                                  "IssueID":         osi['IssueID'],
+                                                  "IssueNumber":     osi['Issue_Number'],
+                                                  "ComicName":       osi['ComicName'],
+                                                  "SeriesYear":      osi['seriesyear'],
+                                                  "One-Off":         True}
+                                    self.oneoffinlist = True
 
+                            if any([csi is not None, ssi is not None, osi is not None]):
                                 if self.nzb_name == 'Manual Run':
-                                    if fl['sub'] is None:
-                                        tpath = os.path.join(self.nzb_folder, fl['comicfilename'])
-                                    else:
-                                        tpath = os.path.join(self.nzb_folder, fl['sub'], fl['comicfilename'])
-                                    cloct = pathlib.Path(tpath).with_name(nfilename)
-                                    clocation = str(pathlib.Path(tpath).replace(cloct))
+                                    tname = str(pathlib.Path(fl['comicfilename']))
                                 else:
-                                    cloct = pathlib.Path(tpath).with_name(nfilename)
-                                    clocation = str(pathlib.Path(tpath).replace(cloct))
+                                    if os.path.isfile(fl['comiclocation']):
+                                        t_mp = pathlib.Path(fl['comiclocation'])
+                                        tpath = str(t_mp.parents[0])
+                                        tname = str(pathlib.Path(fl['comiclocation']).name)
+                                    else:
+                                        tname = str(pathlib.Path(fl['comiclocation']).name)
+                                        tpath = fl['comiclocation']
+                                xyb = tname.find('[__')
+                                if xyb != -1:
+                                    yyb = tname.find('__]', xyb)
+                                    if yyb != -1:
+                                        rem_issueid = tname[xyb+3:yyb]
+                                        two_add = re.sub(r'\s+', '', tname[yyb+3:]).strip()
+                                        if any([two_add == '', two_add == ' ']):
+                                            nfilename = '%s' % tname[:xyb].strip()
+                                        else:
+                                            nfilename = '%s%s' % (tname[:xyb].strip(), two_add)
+                                        logger.fdebug('issueid information [%s] removed successfully: %s' % (rem_issueid, nfilename))
 
-                                logger.fdebug('path with the issueid removed: %s' % clocation)
+                                    path_failure = False
+                                    if self.nzb_name == 'Manual Run':
+                                        if fl['sub'] is None:
+                                            tpath = os.path.join(self.nzb_folder, fl['comicfilename'])
+                                        else:
+                                            tpath = os.path.join(self.nzb_folder, fl['sub'], fl['comicfilename'])
+                                        if pathlib.Path(tpath).is_file():
+                                            try:
+                                                cloct = pathlib.Path(tpath).with_name(nfilename)
+                                                clocation = str(pathlib.Path(tpath).replace(cloct))
+                                            except Exception as e:
+                                                try:
+                                                    tt = str(pathlib.Path(tpath))
+                                                    clocation = str(pathlib.Path(tpath).with_name(nfilename))
+                                                    helpers.file_ops(tt, cloctation)
+                                                except Exception as e:
+                                                    logger.warn('[%s] Skipping this file due to path conversion error [path: %s]/[name: %s]' % (e, tpath, tname))
+                                                    path_failure = True
+                                        else:
+                                            logger.warn('[%s] Skipping this file due to path conversion error [path: %s]/[name: %s]' % (e, tpath, tname))
+                                            path_failure = True
+                                    else:
+                                        if pathlib.Path(tpath).joinpath(tname).is_file():
+                                            try:
+                                                cloct = pathlib.Path(tpath).joinpath(tname).with_name(nfilename)
+                                                clocation = str(pathlib.Path(tpath).joinpath(tname).replace(cloct))
+                                            except Exception as e:
+                                                try:
+                                                    tt = str(pathlib.Path(tpath).joinpath(tname))
+                                                    clocation = str(pathlib.Path(tpath).joinpath(tname).with_name(nfilename))
+                                                    helpers.file_ops(tt, cloctation)
+                                                except Exception as e:
+                                                    logger.warn('[%s] Skipping this file due to path conversion error [path: %s]/[name: %s]' % (e, tpath, tname))
+                                                    path_failure = True
+                                                else:
+                                                    self.nzb_folder = clocation   # this is needed in order to delete after moving.
+                                            else:
+                                               self.nzb_folder = clocation   # this is needed in order to delete after moving.
+                                        else:
+                                            try:
+                                                if all([pathlib.Path(tpath) != pathlib.Path(mylar.CACHE_DIR), pathlib.Path(tpath) != pathlib.Path(mylar.CONFIG.DDL_LOCATION)]):
+                                                   if pathlib.Path(tpath).is_file():
+                                                        try:
+                                                            cloct = pathlib.Path(tpath).with_name(nfilename)
+                                                            clocation = str(pathlib.Path(tpath).replace(cloct))
+                                                        except Exception as e:
+                                                            try:
+                                                                tt = str(pathlib.Path(tpath).joinpath(tname))
+                                                                clocation = str(pathlib.Path(tpath).joinpath(tname).with_name(nfilename))
+                                                                helpers.file_ops(tt, cloctation)
+                                                            except Exception as e:
+                                                                logger.warn('[%s] Skipping this file due to path conversion error [path: %s]/[name: %s]' % (e, tpath, tname))
+                                                                path_failure = True
+                                                            else:
+                                                                self.nzb_folder = clocation   # this is needed in order to delete after moving.
+                                                        else:
+                                                            self.nzb_folder = clocation   # this is needed in order to delete after moving.
+                                                   else:
+                                                       logger.warn('[%s] Skipping this file due to path conversion error [path: %s]/[name: %s]' % (e, tpath, tname))
+                                                       path_failure = True
+                                                else:
+                                                    logger.warn('[%s] Skipping this file due to path conversion error [path: %s]/[name: %s]' % (e, tpath, tname))
+                                                    path_failure = True
+                                            except Exception as e:
+                                                logger.warn('[%s] Skipping this file due to path conversion error [path: %s]/[name: %s]' % (e, tpath, tname))
+                                                path_failure = True
 
-                            annualtype = None
-                            if annchk == 'yes':
-                                if 'Annual' in csi['ReleaseComicName']:
-                                    annualtype = 'Annual'
-                                elif 'Special' in csi['ReleaseComicName']:
-                                    annualtype = 'Special'
-                            else:
-                                if 'Annual' in csi['ComicName']:
-                                    annualtype = 'Annual'
-                                elif 'Special' in csi['ComicName']:
-                                    annualtype = 'Special'
-                            manual_list.append({"ComicLocation":   clocation,
-                                                "ComicID":         csi['ComicID'],
-                                                "IssueID":         csi['IssueID'],
-                                                "IssueNumber":     csi['Issue_Number'],
-                                                "AnnualType":      annualtype,
-                                                "ComicName":       csi['ComicName'],
-                                                "AgeRating":       csi['AgeRating'],
-                                                "Series":          fl['series_name'],
-                                                "SeriesYear":      csi['ComicYear'],
-                                                "AltSeries":       fl['alt_series'],
-                                                "One-Off":         False,
-                                                "ForcedMatch":     True})
-                            logger.info('manual_list: %s' % manual_list)
+                                    if path_failure is True:
+                                        continue
+
+                                    logger.fdebug('path with the issueid removed: %s' % clocation)
+
+                                    if csi is not None:
+                                        annualtype = None
+                                        if annchk == 'yes':
+                                            if 'Annual' in csi['ReleaseComicName']:
+                                                annualtype = 'Annual'
+                                            elif 'Special' in csi['ReleaseComicName']:
+                                                annualtype = 'Special'
+                                        else:
+                                            if 'Annual' in csi['ComicName']:
+                                                annualtype = 'Annual'
+                                            elif 'Special' in csi['ComicName']:
+                                                annualtype = 'Special'
+
+                                        tmp_manual_list = {"ComicLocation":   clocation,
+                                                           "ComicID":         csi['ComicID'],
+                                                           "IssueID":         csi['IssueID'],
+                                                           "IssueNumber":     csi['Issue_Number'],
+                                                           "AnnualType":      annualtype,
+                                                           "ComicName":       csi['ComicName'],
+                                                           "AgeRating":       csi['AgeRating'],
+                                                           "Series":          fl['series_name'],
+                                                           "SeriesYear":      csi['ComicYear'],
+                                                           "AltSeries":       fl['alt_series'],
+                                                           "One-Off":         False,
+                                                           "ForcedMatch":     True}
+
+                                    if story_the_arcs is True:
+                                        if tmp_manual_list:
+                                            if tmp_manual_list['IssueID'] == tmp_the_arc['IssueID']:
+                                                tmp_manual_list['IssueArcID'] = ssi['IssueArcID']
+                                        else:
+                                            tmp_the_arc["ComicLocation"] = clocation
+                                            tmp_the_arc["Filename"] = nfilename
+                                    if tmp_oneoff is not None:
+                                        tmp_oneoff['ComicLocation'] = clocation
+
+                            if tmp_manual_list:
+                                manual_list.append(tmp_manual_list)
+                            elif tmp_the_arc:
+                                manual_arclist.append(tmp_the_arc)
+                            elif tmp_oneoff:
+                                oneoff_issuelist.append(tmp_oneoff)
                             continue
-                        else:
-                            tmpsql = "SELECT * FROM comics WHERE DynamicComicName IN ({seq}) COLLATE NOCASE".format(seq=','.join('?' * len(loopchk)))
-                            comicseries = myDB.select(tmpsql, tuple(loopchk))
+
+                        tmpsql = "SELECT * FROM comics WHERE DynamicComicName IN ({seq}) COLLATE NOCASE".format(seq=','.join('?' * len(loopchk)))
+                        comicseries = myDB.select(tmpsql, tuple(loopchk))
 
                     if not comicseries or orig_seriesname != mod_seriesname:
                         if any(['special' in orig_seriesname.lower(), 'annual' in orig_seriesname.lower()]) and all([mylar.CONFIG.ANNUALS_ON, orig_seriesname != mod_seriesname]):
@@ -1734,7 +1843,7 @@ class PostProcessor(object):
 
                             #tidyup old path
                             if any([mylar.CONFIG.FILE_OPTS == 'move', mylar.CONFIG.FILE_OPTS == 'copy']):
-                                self.tidyup(src_location, True, filename=orig_filename)
+                                self.tidyup(src_location, True, filename=os.path.basename(orig_filename))
 
                             #delete entry from nzblog table
                             #if it was downloaded via mylar from the storyarc section, it will have an 'S' in the nzblog
@@ -2278,7 +2387,7 @@ class PostProcessor(object):
 
                     #tidyup old path
                     if any([mylar.CONFIG.FILE_OPTS == 'move', mylar.CONFIG.FILE_OPTS == 'copy']):
-                        self.tidyup(src_location, True, filename=orig_filename)
+                        self.tidyup(src_location, True, filename=os.path.basename(orig_filename))
 
                     #delete entry from nzblog table
                     myDB.action('DELETE from nzblog WHERE issueid=?', [issueid])
@@ -2965,7 +3074,7 @@ class PostProcessor(object):
 
                 #tidyup old path
                 if any([mylar.CONFIG.FILE_OPTS == 'move', mylar.CONFIG.FILE_OPTS == 'copy']):
-                    self.tidyup(odir, True, filename=orig_filename)
+                    self.tidyup(odir, True, filename=os.path.basename(orig_filename))
 
             else:
                 #downtype = for use with updater on history table to set status to 'Post-Processed'
@@ -2999,7 +3108,7 @@ class PostProcessor(object):
                 logger.info('%s %s successful to : %s' % (module, mylar.CONFIG.FILE_OPTS, dst))
 
                 if any([mylar.CONFIG.FILE_OPTS == 'move', mylar.CONFIG.FILE_OPTS == 'copy']):
-                    self.tidyup(odir, True, subpath, filename=orig_filename)
+                    self.tidyup(odir, True, subpath, filename=os.path.basename(orig_filename))
 
             #Hopefully set permissions on downloaded file
             if mylar.CONFIG.ENFORCE_PERMS:

--- a/mylar/rsscheck.py
+++ b/mylar/rsscheck.py
@@ -526,7 +526,7 @@ def nzbs(provider=None, forcerss=False):
                       'g[]': 85}
             check = _parse_feed('experimental', 'https://nzbindex.nl/search/rss', True, params)
             if check == 'disable':
-                helpers.disable_provider(site)
+                helpers.disable_provider('experimental')
 
         if mylar.CONFIG.NZBSU is True:
             num_items = "&num=100" if forcerss else ""  # default is 25

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -2183,7 +2183,7 @@ def watchlist_updater(calledfrom=None, sched=False):
         #to_check.extend(prev_failed_updates)
     else:
         logger.info(
-            '[BACKFILL-UPDATE] No updates to watchlisted items checked against %s items'
+            '[BACKFILL-UPDATE] No previous failures on updates detected (checked against %s items)'
             % (cntr)
         )
 

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -3947,22 +3947,22 @@ class WebInterface(object):
                 if any([jobid == 'rss', jobid == 'weekly', jobid =='search', jobid == 'version', jobid == 'updater', jobid == 'monitor']):
                     if jobid == 'rss':
                         mylar.FORCE_STATUS['rss'] = mylar.RSS_STATUS
-                        mylar.RSS_STATUS = 'Running'
+                        #mylar.RSS_STATUS = 'Running'
                     elif jobid == 'weekly':
                         mylar.FORCE_STATUS['weekly'] = mylar.WEEKLY_STATUS
-                        mylar.WEEKLY_STATUS = 'Running'
+                        #mylar.WEEKLY_STATUS = 'Running'
                     elif jobid == 'search':
                         mylar.FORCE_STATUS['search'] = mylar.SEARCH_STATUS
-                        mylar.SEARCH_STATUS = 'Running'
+                        #mylar.SEARCH_STATUS = 'Running'
                     elif jobid == 'version':
                         mylar.FORCE_STATUS['version'] = mylar.VERSION_STATUS
-                        mylar.VERSION_STATUS = 'Running'
+                        #mylar.VERSION_STATUS = 'Running'
                     elif jobid == 'updater':
                         mylar.FORCE_STATUS['updater'] = mylar.UPDATER_STATUS
-                        mylar.UPDATER_STATUS = 'Running'
+                        #mylar.UPDATER_STATUS = 'Running'
                     elif jobid == 'monitor':
                         mylar.FORCE_STATUS['monitor'] = mylar.MONITOR_STATUS
-                        mylar.MONITOR_STATUS = 'Running'
+                        #mylar.MONITOR_STATUS = 'Running'
                     jb.modify(next_run_time=datetime.datetime.utcnow())
                     break
     schedulerForceCheck.exposed = True
@@ -4477,7 +4477,7 @@ class WebInterface(object):
            #                else:
            #                    #for actual banner width (ie. 960x280)
            #                    storyarcbanner += 'H' + str(bannerheight)
-            logger.info('storyarcbanner: %s' % (storyarcbanner,))
+            #logger.fdebug('storyarcbanner: %s' % (storyarcbanner,))
             if filepath is not None:
                 fname = os.path.basename(filepath)
                 if any(['H' in fname, 'W' in fname]):


### PR DESCRIPTION
- FIX: Storyarc detail options (``grab`` and ``retry``) would not work with story arcs with an ``'`` in the title
- FIX: (Post-Processing) Fixed DDL (or files tagged with the ``[__issueid__]``) path location probelms 
- FIX: (Post-Processing) One-offs / storyarcs  in conjunction with using ``[__issueid__]`` file tag 
- FIX: (Post-Processing) Tidyup after Post-Processing would fail to cleanup remnants with a path error
- FIX: Scheduler displaying as ``Running`` when it's not
- FIX: Remove some unnecessary logging lines