### PR TITLE
this is the rick to your roll

### DIFF
--- a/data/css/style.css
+++ b/data/css/style.css
@@ -160,20 +160,6 @@ table#log_table th#timestamp { text-align: left; min-width: 150px; }
 table#log_table th#level { text-align: left; min-width: 60px; }
 table#log_table th#message { text-align: left; min-width: 500px; }
 
-table#upcoming_table th#albumart { text-align: center; min-width: 50px; }
-table#upcoming_table th#albumname { text-align: center; min-width: 200px; }
-table#upcoming_table th#artistname { text-align: center; min-width: 150px; }
-table#upcoming_table th#reldate { text-align: center; min-width: 100px; }
-table#upcoming_table th#type { text-align: center; min-width: 75px; }
-
-table#upcoming_table td#select { vertical-align: middle; text-align: center; }
-table#upcoming_table td#albumart { vertical-align: middle; text-align: center; min-width: 50px; }
-table#upcoming_table td#albumname { vertical-align: middle; text-align: center; min-width: 200px; }
-table#upcoming_table td#artistname { vertical-align: middle; text-align: center; min-width: 150px; }
-table#upcoming_table td#reldate { vertical-align: middle; text-align: center; min-width: 100px; }
-table#upcoming_table td#type { vertical-align: middle; text-align: center; min-width: 75px; }
-table#upcoming_table td#status { vertical-align: middle; text-align: center; }
-
 table#searchresults_table th#name { text-align: left; min-width: 500px; }
 table#searchresults_table th#comicyear { text-align: center; min-width: 50px; }
 table#searchresults_table th#issues { text-align: center; min-width: 50px; }

--- a/data/interfaces/carbon/css/style.css
+++ b/data/interfaces/carbon/css/style.css
@@ -2110,109 +2110,119 @@ DIV.progress-container > DIV
 .clearfix:after {
   clear: both;
 }
+#upcoming_nodata_table th#delcolumn,
 #wanted_table th#select {
   text-align: center;
   vertical-align: middle;
   width: 32px;
 }
-#wanted_table th#comicname {
-  min-width: 256px;
+#upcoming_table th#comicname,
+#wanted_table th#comicname,
+#upcoming_nodata_table th#comicname {
+  min-width: 225px;
   text-align: center;
 }
-#wanted_table th#issuenumber {
+#mismatched_table th#comicname {
+  min-width: 150px;
+  text-align: center;
+}
+#upcoming_table th#issuenumber,
+#wanted_table th#issuenumber,
+#upcoming_nodata_table th#issuenumber,
+#mismatched_table th#issuenumber {
   text-align: center;
   vertical-align: middle;
-  width: 55px;
+  width: 50px;
 }
 #wanted_table th#reldate {
-  width: 99px;
+  min-width: 50px;
   text-align: center;
 }
-#wanted_table th#status {
+#upcoming_table th#reldate, 
+#upcoming_nodata_table th#reldate {
+  max-width: 50px;
+  text-align: center;
+}
+#upcoming_table th#status,
+#wanted_table th#status,
+#upcoming_nodata_table th#status{
   text-align: center;
   vertical-align: middle;
   width: 69px;
+}
+#mismatched_table th#misinfo {
+  text-align: center;
+  min-width: 150px;
+}
+#mismatched_table th#weekinfo {
+  text-align: center;
+  width: 60px;
 }
 #wanted_table th#tier {
   width: 159px;
   text-align: center;
 }
+#upcoming_table td#comicname,
+#wanted_table td#comicname,
+#upcoming_nodata_table td#comicname {
+  min-width: 225px;
+  text-align: center;
+}
+#mismatched_table td#comicname {
+  min-width: 150px;
+  text-align: center;
+}
+#upcoming_nodata_table td#delcolumn,
 #wanted_table td#select {
   text-align: center;
   vertical-align: middle;
   width: 32px;
 }
-#wanted_table td#comicname {
-  min-width: 256px;
+#mismatched_table td#misinfo {
   text-align: center;
+  min-width: 150px;
 }
-#wanted_table td#issuenumber {
+#mismatched_table td#weekinfo {
   text-align: center;
-  vertical-align: middle;
-  width: 55px;
-}
-#wanted_table td#reldate {
-  width: 99px;
-  text-align: center;
-}
-#wanted_table td#status {
-  text-align: center;
-  vertical-align: middle;
-  width: 69px;
-}
-#wanted_table td#tier {
-  width: 159px;
-  text-align: center;
-}
-#searchresults_table th#score {
-  min-width: 75px;
-  text-align: center;
-}
-#wanted_table th#albumart {
-  min-width: 50px;
-  text-align: center;
-}
-#upcoming_table th#issuenumber,
-#wanted_table th#issuenumber {
-  min-width: 50px;
-  text-align: center;
-}
-#upcoming_table th#reldate,
-#wanted_table th#reldate {
-  min-width: 50px;
-  text-align: center;
-}
-#upcoming_table td#albumart,
-#wanted_table td#albumart {
-  min-width: 50px;
-  text-align: center;
-  vertical-align: middle;
-}
-#upcoming_table td#comicname,
-#wanted_table td#comicname {
-  min-width: 200px;
-  text-align: center;
-  vertical-align: middle;
+  width: 60px;
 }
 #upcoming_table td#issuenumber,
-#wanted_table td#issuenumber {
+#wanted_table td#issuenumber,
+#upcoming_nodata_table td#issuenumber,
+#mismatched_table td#issuenumber {
+  min-width: 50px;
+  text-align: center;
+  vertical-align: middle;
+}
+#wanted_table td#reldate {
   min-width: 50px;
   text-align: center;
   vertical-align: middle;
 }
 #upcoming_table td#reldate,
-#wanted_table td#reldate {
-  min-width: 50px;
+#upcoming_nodata_table td#reldate,
+#mismatched_table td#reldate {
+  max-width: 50px;
   text-align: center;
   vertical-align: middle;
 }
-#upcoming_table td#type,
-#wanted_table td#type,
+#upcoming_table td#status,
+#wanted_table td#status,
+#upcoming_nodata_table td#status,
+#mismatched_table td#status {
+  text-align: center;
+  vertical-align: middle;
+  width: 69px;
+}
 #wanted_table td#tier,
 #searchresults_table td#score {
   min-width: 75px;
   text-align: center;
   vertical-align: middle;
+}
+#searchresults_table th#score {
+  min-width: 75px;
+  text-align: center;
 }
 table tr td#status a {
   color: #4183c4;
@@ -2494,4 +2504,7 @@ img.mylarload.lastbad {
     text-shadow:
       .25em 0 0 white,
       .5em 0 0 white;}
+}
+.version_display {
+  color: white;
 }

--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -280,21 +280,21 @@
                 if (data.commmits_behind < 0){
                     if (data.docker == 'true'){
                         up_mess = 'You are running an unknown version of Mylar3. <a href="#" onclick="'+cck+'">Close</a>';
-                        up_linemess = '<span style="color:white;">Unknown version</span>';
+                        up_linemess = '<span class="version_display">Unknown version</span>';
                     } else {
                         up_mess = 'You are running an unknown version of Mylar3. <a href="update">Update</a> or <a href="#" onclick="'+cck+'">Close</a>';
-                        up_linemess = '<a href="#" onclick="update_mylar()" title="You are running an Unknown version. Click to update" style="color:white;"/>Unknown version</a>';
+                        up_linemess = '<a href="#" onclick="update_mylar()" title="You are running an Unknown version. Click to update" class="version_display"/>Unknown version</a>';
                     }
                 } else if (data.current_version != data.latest_version && dc_behind > 0){
                     if (data.docker == 'true'){
                         up_mess = 'A <a href="https://github.com/mylar3/mylar3/compare/'+data.current_version+'...'+data.latest_version+'" target="_blank"> newer version</a> is availble. You are '+dc_behind+' commits behind. <a href="#" onclick="'+cck+'">Close</a>';
-                        up_linemess = '<span style="color:white;">'+dc_behind+' commits behind</span>';
+                        up_linemess = '<span class="version_display">'+dc_behind+' commits behind</span>';
                     } else {
                         up_mess = 'A <a href="https://github.com/mylar3/mylar3/compare/'+data.current_version+'...'+data.latest_version+'" target="_blank"> newer version</a> is availble. You are '+dc_behind+' commits behind. <a href="update">Update</a> or <a href="#" onclick="'+cck+'">Close</a>';
-                        up_linemess = '<a href="#" onclick="location.href=\'update\';" title="Update now" style="color:white;">'+dc_behind+' commits behind</a>';
+                        up_linemess = '<a href="#" onclick="location.href=\'update\';" title="Update now" class="version_display">'+dc_behind+' commits behind</a>';
                     }
                 } else if (data.current_version == data.latest_version && dc_behind === 0){
-                    up_linemess = '<span style="color:white;">No updates available</span>';
+                    up_linemess = '<span class="version_display">No updates available</span>';
                     uptodate = true;
                 } else {
                     up_linemess = '???'
@@ -661,7 +661,7 @@
         function check_the_update(){
             var updateval = JSON.parse('${pre_update}');
             if (updateval['update_value'] === 0){
-                up_linemess = '<span color="white;">No updates available</span>';
+                up_linemess = '<span class="version_display">No updates available</span>';
                 var startTime = new Date().getTime();
                 var interval = setInterval(function(){
                     if (new Date().getTime() - startTime > 60000){
@@ -672,15 +672,15 @@
                 }, 2000);
             } else if (updateval['update_value'] > 0){
                 if (updateval['docker'] == 'true'){
-                    up_linemess = '<a href="#" title="you must manually update your docker" style="color:white;">'+updateval['update_value']+' commits behind</a>';
+                    up_linemess = '<a href="#" title="you must manually update your docker" class="version_display">'+updateval['update_value']+' commits behind</a>';
                 } else {
-                    up_linemess = '<a href="#" onclick="location.href=\'update\';" title="Update now" style="color:white;">'+updateval['update_value']+' commits behind</a>';
+                    up_linemess = '<a href="#" onclick="location.href=\'update\';" title="Update now" class="version_display">'+updateval['update_value']+' commits behind</a>';
                 }
             } else if (updateval['update_value'] == -1){
                 if (updateval['docker'] == 'true'){
-                    up_linemess = '<a href="#" title="You are running an Unknown version" style="color:white;">Unknown version</a>';
+                    up_linemess = '<a href="#" title="You are running an Unknown version" class="version_display">Unknown version</a>';
                 } else {
-                    up_linemess = '<a href="#" onclick="update_mylar()" title="You are running an Unknown version" style="color:white;">Unknown version</a>';
+                    up_linemess = '<a href="#" onclick="update_mylar()" title="You are running an Unknown version" class="version_display">Unknown version</a>';
                 }
             } else {
                 up_linemess = '<a href="#" onclick="check_the_hub()"><span class="ui-icon ui-icon-refresh"></span><span id="version_line">Check for new version</span></a>';

--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -1983,10 +1983,7 @@
                 $('#annual_table').DataTable().draw(false);
             });
 
-            if ("${default_dates}" != document.getElementById("display_the_date").innerHTML){
-                document.getElementById("display_the_date").innerHTML = "${default_dates}";
-                display_date(null);
-            }
+            display_date(null);
 
             title_loading();
 

--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -2045,70 +2045,119 @@ DIV.progress-container > DIV
 .clearfix:after {
   clear: both;
 }
+#upcoming_nodata_table th#delcolumn,
+#wanted_table th#select{
+  text-align: center;
+  vertical-align: middle;
+  width: 32px;
+}
 #upcoming_table th#comicname,
-#wanted_table th#comicname {
+#wanted_table th#comicname,
+#upcoming_nodata_table th#comicname {
+  min-width: 225px;
+  text-align: center;
+}
+#mismatched_table th#comicname {
   min-width: 150px;
   text-align: center;
 }
-#upcoming_table td#select,
-#upcoming_table td#status,
-#wanted_table td#select,
-#wanted_table td#status {
+#upcoming_table th#issuenumber,
+#wanted_table th#issuenumber,
+#upcoming_nodata_table th#issuenumber,
+#mismatched_table th#issuenumber {
   text-align: center;
   vertical-align: middle;
+  width: 50px;
 }
-#upcoming_table th#type,
-#wanted_table th#type,
-#wanted_table th#tier,
-#searchresults_table th#score {
-  min-width: 75px;
-  text-align: center;
-}
-#wanted_table th#albumart {
-  min-width: 50px;
-  text-align: center;
-}
-#upcoming_table th#issuenumber,
-#wanted_table th#issuenumber {
-  min-width: 50px;
-  text-align: center;
-}
-#upcoming_table th#reldate,
 #wanted_table th#reldate {
   min-width: 50px;
   text-align: center;
 }
-#upcoming_table td#albumart,
-#wanted_table td#albumart {
-  min-width: 50px;
+#upcoming_table th#reldate,
+#upcoming_nodata_table th#reldate {
+  max-width: 50px;
+  text-align: center;
+}
+#upcoming_table th#status,
+#wanted_table th#status,
+#upcoming_nodata_table th#status{
   text-align: center;
   vertical-align: middle;
+  width: 69px;
+}
+#mismatched_table th#misinfo {
+  text-align: center;
+  min-width: 150px;
+}
+#mismatched_table th#weekinfo {
+  text-align: center;
+  width: 60px;
+}
+#wanted_table th#tier {
+  width: 159px;
+  text-align: center;
 }
 #upcoming_table td#comicname,
-#wanted_table td#comicname {
-  min-width: 200px;
+#wanted_table td#comicname,
+#upcoming_nodata_table td#comicname {
+  min-width: 225px;
+  text-align: center;
+}
+#mismatched_table td#comicname {
+  min-width: 150px;
+  text-align: center;
+}
+#upcoming_nodata_table td#delcolumn,
+#wanted_table td#select {
   text-align: center;
   vertical-align: middle;
+  width: 32px;
+}
+#mismatched_table td#misinfo {
+  text-align: center;
+  min-width: 150px;
+}
+#mismatched_table td#weekinfo {
+  text-align: center;
+  width: 60px;
 }
 #upcoming_table td#issuenumber,
-#wanted_table td#issuenumber {
+#wanted_table td#issuenumber,
+#upcoming_nodata_table td#issuenumber,
+#mismatched_table td#issuenumber {
   min-width: 50px;
   text-align: center;
   vertical-align: middle;
 }
-#upcoming_table td#reldate,
 #wanted_table td#reldate {
   min-width: 50px;
   text-align: center;
   vertical-align: middle;
 }
-#upcoming_table td#type,
-#wanted_table td#type,
+#upcoming_table td#reldate,
+#upcoming_nodata_table td#reldate,
+#mismatched_table td#reldate {
+  max-width: 50px;
+  text-align: center;
+  vertical-align: middle;
+}
+#upcoming_table td#status,
+#wanted_table td#status,
+#upcoming_nodata_table td#status,
+#mismatched_table td#status {
+  text-align: center;
+  vertical-align: middle;
+  width: 69px;
+}
 #wanted_table td#tier,
 #searchresults_table td#score {
   min-width: 75px;
   text-align: center;
   vertical-align: middle;
+}
+#searchresults_table th#score {
+  min-width: 75px;
+  text-align: center;
 }
 table tr td#status a {
   color: #4183c4;
@@ -2372,4 +2421,7 @@ img.mylarload.lastbad {
     text-shadow:
       .25em 0 0 white,
       .5em 0 0 white;}
+}
+.version_display {
+  color: black;
 }

--- a/data/interfaces/default/upcoming.html
+++ b/data/interfaces/default/upcoming.html
@@ -51,7 +51,7 @@
                                 <th id="select"><input type="checkbox" name="select_all" value="1" id="wanted-select-all" class="checkbox" /></th>
 				<th id="comicname">Comic</th>
 				<th id="issuenumber">#</th>
-				<th id="reldate">Rls Date</th>
+				<th id="reldate">Release Date</th>
 				<th id="status">Status</th>
                                 <th id="tier">SearchTier</th>
 			</tr>
@@ -71,7 +71,7 @@
                 <ul>
                         <li><a href="#tabs-1">This Week's Upcoming (${upcoming_count})</a></li>
                         <li><a href="#tabs-2">Future Auto-Wants</a></li>
-                        <li><a href="#tabs-3">Incomplete / Mismatched CV</a></li>
+                        <li><a href="#tabs-3">Incomplete / Mismatched CV (${mismatched_count})</a></li>
                 </ul>
 
         <div id="tabs-1">
@@ -101,13 +101,14 @@
                </tbody>
             </table>
           </div>
+          <center><small>Issues listed here are not on CV yet <a href="https://github.com/mylar3/mylar3/wiki/Where-Mylar-gets-the-metadata-from" target="_new">(read more)</a></small></center>
         </div>
         <div id="tabs-2">
            <a name="upcoming_nodata"></a>
            <a id="menu_link_edit" href="future_check">Force Check Availability</a>
            <div style="float:right;text-align:right;font-size:20px;font-weight:bold;" title="manually add issue to auto-want list">+</div>
            <div class="table_wrapper">
-                <table class="display_no_select" id="upcoming_table">
+                <table class="display_no_select" id="upcoming_nodata_table">
                 %if future_nodata_upcoming:
                     <thead>
                         <tr>
@@ -143,35 +144,41 @@
         </div>
         <div id="tabs-3">
           <div class="table_wrapper">
-            <table class="display_no_select" id="upcoming_table">
+            <table class="display_no_select" id="mismatched_table">
                 %if mismatched:
                     <thead>
                             <tr>
                                     <th id="comicname">Comic</th>
                                     <th id="issuenumber">Issue</th>
-                                    <th id="reldate">Release Date</th>
-                                    <th id="status">Status</th>
+                                    <th id="misinfo">Reason for Mismatch (CV - Pull)</th>
                                     <th id="weekinfo">Pull-list</th>
                             </tr>
                     </thead>
                     <tbody>
                     %for mis in mismatched:
-                            <tr class="gradeZ">
+                            <%
+                               if mis['status'] == 'Mismatched':
+                                   grade = "Z"
+                               else:
+                                   grade = "Y"
+                            %>
+                            <tr class="grade${grade}">
                                     <td id="comicname"><a href="comicDetails?ComicID=${mis['comicid']}">${mis['comicname']}</a></td>
                                     <td id="issuenumber">${mis['issuenumber']}</td>
-                                    <td id="reldate">${mis['releasedate']}</td>
-                                    <td id="status">${mis['status']}</td>
-                                    <td id="weekinfo">${mis['weekinfo']}</td>
+                                    <td id="misinfo">${mis['mismatch_type']}</td>
+                                    <td id="weekinfo"><a href="pullist?week=${mis['pullweek']}&year=${mis['pullyear']}#${mis['comicname']}_${mis['issuenumber']}">${mis['pullyear']}-${mis['pullweek']}</a></td>
                             </tr>
                     %endfor
+                    </tbody>
                 %else:
-                  <tr><td align="center" width="100%"> no mismatched data</td></tr>
+                  <tr><td align="center" width="100%">No mismatched data</td></tr>
                 %endif
-               </tbody>
             </table>
           </div>
+          <center><small>Mismatches can possibly indicate: the dates are incorrect btwn CV & Mylar, an incorrect volume, or an incorrect booktype</br>
+          A <b>Recreate Pullist</b> for the given week (click in column) may correct stale dates</small></center>
         </div>
-
+      </div>
 </%def>
 
 <%def name="headIncludes()">

--- a/data/interfaces/default/weeklypull.html
+++ b/data/interfaces/default/weeklypull.html
@@ -130,6 +130,7 @@
 
 			%>
 			<tr class="grade${grade}">
+                                <a name="${weekly['COMIC']}_${weekly['ISSUE']}"></a>
                                 %if pullfilter is True:
                                         <td class="publisher">${weekly['PUBLISHER']}</td>
                                         <td class="comicname">

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -16,12 +16,15 @@
 
 import mylar
 from mylar import db, mb, importer, search, process, versioncheck, logger, webserve, helpers, encrypted, series_metadata
+import threading
 import json
 import cherrypy
+import time
 import random
 import os
 import re
 import shutil
+import queue
 import urllib.request, urllib.error, urllib.parse
 from . import cache
 import imghdr
@@ -34,7 +37,7 @@ cmd_list = ['getIndex', 'getComic', 'getUpcoming', 'getWanted', 'getHistory',
             'pauseComic', 'resumeComic', 'refreshComic', 'addIssue', 'recheckFiles',
             'queueIssue', 'unqueueIssue', 'forceSearch', 'forceProcess', 'changeStatus',
             'getVersion', 'checkGithub','shutdown', 'restart', 'update', 'changeBookType',
-            'getComicInfo', 'getIssueInfo', 'getArt', 'downloadIssue',
+            'getComicInfo', 'getIssueInfo', 'getArt', 'downloadIssue', 'regenerateCovers',
             'refreshSeriesjson', 'seriesjsonListing', 'checkGlobalMessages',
             'listProviders', 'changeProvider', 'addProvider', 'delProvider',
             'downloadNZB', 'getReadList', 'getStoryArc', 'addStoryArc']
@@ -476,6 +479,88 @@ class Api(object):
         newValueDict = {'Status': 'Active'}
         myDB.upsert("comics", newValueDict, controlValueDict)
 
+    def _regenerateCovers(self, **kwargs):
+        # kwargs = id: {comicid, {comicid_list}, 'all', 'missing'}
+        #               -- comicid = specific comicid
+        #               -- comicid_list = list of comicids
+        #               -- all = all series on watchlist
+        #               -- missing = just series on watchlist with no cover image in cache
+        #        = overwrite_existing: {true, false} (applies only to {comicid, comicid_list, all})
+
+        myDB = db.DBConnection()
+        if 'id' not in kwargs:
+            self.data = self._failureResponse('Missing parameter: id')
+            return
+        else:
+            self.id = kwargs['id']
+            id_list = []
+            if any([self.id == 'all', self.id == 'missing']):
+                the_list = myDB.select('SELECT * FROM comics')
+                for tt in the_list:
+                    if self.id == 'missing':
+                        if os.path.isfile(os.path.join(mylar.CONFIG.CACHE_DIR, '%s.jpg' % (tt['comicid']))):
+                            continue
+                    id_list.append({'comicid': tt['ComicID'],
+                                    'comicimage': tt['ComicImage'],
+                                    'comicimageurl': tt['ComicImageURL'],
+                                    'comicimagealturl': tt['ComicImageALTURL'],
+                                    'firstimagesize': tt['FirstImageSize']})
+            else:
+                tmp_list = []
+                if ',' in self.id:
+                    tmp_list = self.id.split(',')
+                else:
+                    tmp_list.append(self.id)
+
+                for tm in tmp_list:
+                    th = myDB.selectone('SELECT * FROM comics WHERE comicid=?', [tm]).fetchone()
+                    id_list.append({'comicid': th['ComicID'],
+                                    'comicimage': th['ComicImage'],
+                                    'comicimageurl': th['ComicImageURL'],
+                                    'comicimagealturl': th['ComicImageALTURL'],
+                                    'firstimagesize': th['FirstImageSize']})
+
+            threading.Thread(target=self.get_the_images, name="regenerateCovers", args=(id_list,)).start()
+            logger.info('[API-regenerateCovers] Successfully background submitted cover regeneration for  %s series' % (len(id_list)))
+            self.data = self._successResponse('RegenerateCovers successfully submitted for %s series.' % (len(id_list)))
+            return
+
+    def get_the_images(self, id_list):
+        resultresponse = []
+        success_count = 0
+        failed_count = 0
+        already_present = 0
+        for idl in id_list:
+            comicid = idl['comicid']
+            firstimagesize = idl['firstimagesize']
+            if firstimagesize is None:
+                firstimagesize = 0
+            cimage = os.path.join(mylar.CONFIG.CACHE_DIR, '%s.jpg' % (comicid))
+            if mylar.CONFIG.ALTERNATE_LATEST_SERIES_COVERS is False or not os.path.isfile(cimage):
+                PRComicImage = os.path.join('cache', str(comicid) + ".jpg")
+                ComicImage = helpers.replacetheslash(PRComicImage)
+                coversize = 0
+                if os.path.isfile(cimage):
+                    statinfo = os.stat(cimage)
+                    coversize = statinfo.st_size
+                if firstimagesize != 0 and (os.path.isfile(cimage) is True and firstimagesize == coversize):
+                    logger.fdebug('[%s] Cover already exists for series. Not redownloading.' % comicid)
+                    already_present +=1
+                else:
+                    covercheck = helpers.getImage(comicid, idl['comicimageurl'], apicall=True)
+                    firstimagesize = covercheck['coversize']
+                    if covercheck['status'] == 'retry':
+                        logger.info('[%s] Attempting to retrieve alternate comic image for the series.' % comicid)
+                        covercheck = helpers.getImage(comicid, idl['comicimagealturl'], apicall=True)
+                    if covercheck['status'] == 'success':
+                        success_count +=1
+                    else:
+                        failed_count +=1
+
+            time.sleep(4)
+
+        logger.info('[API-regenerateCovers] Completed: %s covers successfully regenerated, %s covers failed to generate, %s covers already existed.' % (success_count, failed_count, already_present))
+
     def _refreshComic(self, **kwargs):
         if 'id' not in kwargs:
             self.data = self._failureResponse('Missing parameter: id')
@@ -508,7 +593,7 @@ class Api(object):
 
         if len(notfound) > 0:
             logger.info('Unable to locate the following requested ID\'s for Refreshing: %s' % (notfound,))
-            self.data = self._successResponse('Unable to locate the following ID\'s for Refreshing (%s)' % (notfound,))
+            self.data = self._failureResponse('Unable to locate the following ID\'s for Refreshing (%s)' % (notfound,))
         if len(already_added) == 1:
             self.data = self._successResponse('[%s] %s has already been queued for refresh in a queue of %s items.' % (already_added[0]['comicid'], already_added[0]['comicname'], mylar.REFRESH_QUEUE.qsize()))
         elif len(already_added) > 1:


### PR DESCRIPTION
- IMP: added ``regenerateCovers`` API endpoint to allow for regeneration of series covers in cache folder [see here](https://github.com/mylar3/mylar3/wiki/regenerateCovers)
- IMP: Added reason and additional information to Mismatch table on Wanted page / Upcoming section to try to briefly explain why the mismatch
- FIX: ``default_dates`` would not be honoured when trying to set default view on series detail page for Store / Cover dates
- FIX: check version results could not be seen in default interface due to white color
- FIX: fix upcoming table in Wanted page css layout

