### PR TITLE
FIX: invalid query in search box would never finish rendering results page

### DIFF
--- a/data/interfaces/default/queue_management.html
+++ b/data/interfaces/default/queue_management.html
@@ -177,8 +177,8 @@
                     "serverSide": true,
                     "ajaxSource": 'queueManageIt',
                     "paginationType": "full_numbers",
+                    "displayLength": 25,
                     "sorting": [[5, 'desc']],
-                    "displayLength": 15,
                     "stateSave": false,
                     "columnDefs": [
                         {

--- a/data/interfaces/default/searchresults.html
+++ b/data/interfaces/default/searchresults.html
@@ -440,7 +440,7 @@
                     "language": {
                          "search":"Filter:",
                          "lengthMenu":"Show _MENU_ issues per page",
-                         "emptyTable": "No information available",
+                         "emptyTable": "No search results",
                          "info":"Showing _START_ to _END_ of _TOTAL_ issues",
                          "infoEmpty":"Showing 0 to 0 of 0 issues",
                          "infoFiltered":"(filtered from _MAX_ total issues)"

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -867,9 +867,9 @@ class WebInterface(object):
         db_results = myDB.select(queryline, [query])
         if not db_results:
             try:
-                results = mb.findComic(name, mode, issue=None)
-            except TypeError:
-                logger.error('Unable to perform required search for : [name: ' + name + '][mode: ' + mode + ']')
+                results = mb.findComic(query, None, issue=None)
+            except Exception:
+                logger.error('Unable to perform required search for : [name: ' + query + ']')
                 return json.dumps({
                     'iTotalDisplayRecords': 0,
                     'iTotalRecords': 0,


### PR DESCRIPTION
- also set queue management page to display 25 results by default.