### PR TITLE
FIX: configurable user-agent (cv_user_agent) via config.ini

### DIFF
--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -288,7 +288,7 @@ def initialize(config_file):
 
         SESSION_ID = random.randint(10000,999999)
 
-        CV_HEADERS = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1'}
+        CV_HEADERS = {'User-Agent': mylar.CONFIG.CV_USER_AGENT}
 
         # set the current week for the pull-list
         todaydate = datetime.datetime.today()

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -153,6 +153,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'CV_ONLY': (bool, 'CV', True),
     'CV_ONETIMER': (bool, 'CV', True),
     'CVINFO': (bool, 'CV', False),
+    'CV_USER_AGENT': (str, 'CV', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246'),
 
     'LOG_DIR' : (str, 'Logs', None),
     'MAX_LOGSIZE' : (int, 'Logs', 10000000),


### PR DESCRIPTION
default value if not manually set will use a semi-recent UA.