### PR TITLE
Compare length of result substring against length of comic name

### DIFF
--- a/mylar/search_filer.py
+++ b/mylar/search_filer.py
@@ -90,7 +90,7 @@ class search_check(object):
                     logger.fdebug('sub: %s' % subs)
                     try:
                         if (
-                            len(subs) >= len(ComicName.split())
+                            len(subs) >= len(ComicName)
                             and not any(d in subs.lower() for d in except_list)
                             and bool(_digits.search(subs)) is True
                         ):


### PR DESCRIPTION
Prior to commit cdddddbc93af171f9c90bc84f0a66613f685f71f this condition was `if len(subs) >= len(seriesname)`. I believe it is meant to be a sanity test to determine if the substring likely contains the series name and should test whether the substring is longer than the series name. As written I believe it is testing whether the substring in the search result is longer than the _number of fields_ in the comicName.

Without this fix the first field of the search result _2021-09-01 Indie [25/31] - "The Many Deaths of Laila Starr 05 (of 05) (2021) (digital) (Son of Ultron-Empire).cbr" yEnc_ was identified as the title. E.g.
```
20-Mar-2022 20:57:30 - DEBUG   :: mylar.checker.72 : SEARCH-QUEUE : checking search result: 2021-09-01 Indie [25/31] - "The Many Deaths of Laila Starr 05 (of 05) (2021) (digital) (Son of Ultron-Empire).cbr" yEnc
20-Mar-2022 20:57:30 - DEBUG   :: mylar.checker.90 : SEARCH-QUEUE : sub: 2021-09-01 Indie [25/31] - 
```
With this fix the second field is correctly identified as the title name. E.g.
```
20-Mar-2022 20:57:30 - DEBUG   :: mylar.checker.90 : SEARCH-QUEUE : sub: The Many Deaths of Laila Starr 05 (of 05) (2021) (digital) (Son of Ultron-Empire).cbr  ComicName: The Many Deaths of Laila Starr
20-Mar-2022 20:57:30 - DEBUG   :: mylar.checker.142 : SEARCH-QUEUE : comsize_b: 4322567320-Mar-2022 20:57:30 - DEBUG   :: mylar.checker.155 : SEARCH-QUEUE : size given as: 41.2 MB
20-Mar-2022 20:57:30 - DEBUG   :: mylar.checker.235 : SEARCH-QUEUE : store date used is : 2021-04-2120-Mar-2022 20:57:30 - DEBUG   :: mylar.checker.236 : SEARCH-QUEUE : date used is : 2021-04-21
20-Mar-2022 20:57:30 - DEBUG   :: mylar.checker.288 : SEARCH-QUEUE : usedate: 2021-04-21
```