### PR TITLE
FIX: hotio docker image would fail to start cleanly - resulting in error when viewing pull

### DIFF
--- a/mylar/versioncheck.py
+++ b/mylar/versioncheck.py
@@ -243,8 +243,11 @@ def getVersion():
                 if os.path.isfile(version_file):
                     #write the name to the .LAST_RELEASE so we don't have to poll for it
                     logger.fdebug('this would have been written to the .LAST_RELEASE file: %s' % (current_release_name))
-                    with open(version_file, 'a') as wf:
-                        wf.write('%s' % current_release_name)
+                    try:
+                        with open(version_file, 'a') as wf:
+                            wf.write('%s' % current_release_name)
+                    except Exception as e:
+                        pass
 
         if current_version:
             if mylar.CONFIG.GIT_BRANCH:


### PR DESCRIPTION
due to .LAST_RELEASE not having write permissions (only when using master branch).  

Not a biggie - put within a try/except for the win.