### PR TITLE
FIX: (#1125) config port value not being honoured, FIX: -cp switch would not run correctly

### DIFF
--- a/Mylar.py
+++ b/Mylar.py
@@ -109,7 +109,7 @@ def main():
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Increase console logging verbosity')
     parser.add_argument('-q', '--quiet', action='store_true', default=False, help='Turn off console logging')
     parser.add_argument('-d', '--daemon', action='store_true', default=False, help='Run as a daemon')
-    parser.add_argument('-p', '--port', type=int, default=8090, help='Force mylar to run on a specified port')
+    parser.add_argument('-p', '--port', type=int, default=0, help='Force mylar to run on a specified port')
     parser.add_argument('-b', '--backup', nargs='?', const='both', help='Will automatically backup & keep the last 4 rolling copies.')
     parser.add_argument('-w', '--noweekly', action='store_true', default=False, help='Turn off weekly pull list check on startup (quicker boot sequence)')
     parser.add_argument('-iu', '--ignoreupdate', action='store_true', default=False, help='Do not update db if required (for problem bypass)')
@@ -254,6 +254,13 @@ def main():
     #    print e
     #    raise SystemExit('FATAL ERROR')
 
+
+    # check for clearprovidertable value after ini load
+    if mylar.CONFIG.CLEAR_PROVIDER_TABLE is True:
+        logger.info('[CLEAR_PROVIDER_TABLE] forcing over-ride value from config.ini')
+        args_clearprovidertable = True
+        mylar.MAINTENANCE = True
+
     if mylar.MAINTENANCE is False:
         filechecker.validateAndCreateDirectory(mylar.DATA_DIR, True, dmode='DATA')
 
@@ -379,7 +386,7 @@ def main():
         mylar.shutdown(restart=restart_method, maintenance=True)
 
     # Force the http port if neccessary
-    if args_port:
+    if args_port > 0:
         http_port = args_port
         logger.info('Starting Mylar on forced port: %i' % http_port)
     else:

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -226,7 +226,8 @@ def initialize(config_file):
         except Exception as e:
             logger.error('Cannot connect to the database: %s' % e)
         else:
-            cc.provider_sequence()
+            if mylar.MAINTENANCE is False:
+                cc.provider_sequence()
 
             # quick check here to see if a previous db update failed.
             chk = maintenance.Maintenance(mode='db update')

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -108,6 +108,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'DEFAULT_DATES': (str, 'General', 'store_date'),
     'FOLDER_CACHE_LOCATION': (str, 'General', None),
     'SCAN_ON_SERIES_CHANGES': (bool, 'General', True),
+    'CLEAR_PROVIDER_TABLE': (bool, 'General', False),
 
     'RSS_CHECKINTERVAL': (int, 'Scheduler', 20),
     'SEARCH_INTERVAL': (int, 'Scheduler', 360),
@@ -981,6 +982,9 @@ class Config(object):
             self.WRITE_THE_CONFIG = True
 
     def configure(self, update=False, startup=False):
+
+        if all([self.CLEAR_PROVIDER_TABLE is True, startup is True]):
+            mylar.MAINTENANCE = True
 
         #force alt_pull = 2 on restarts regardless of settings
         if self.ALT_PULL != 2:

--- a/mylar/maintenance.py
+++ b/mylar/maintenance.py
@@ -231,8 +231,12 @@ class Maintenance(object):
 
     def clear_provider_table(self):
         self.sql_attachmylar()
+        # drop it
         self.dbmylar.execute("DROP TABLE provider_searches")
+        # bring it back hot
+        self.dbmylar.execute("CREATE TABLE IF NOT EXISTS provider_searches(id INTEGER UNIQUE, provider TEXT UNIQUE, type TEXT, lastrun INTEGER, active TEXT, hits INTEGER DEFAULT 0)")
         self.sql_closemylar()
+        mylar.CONFIG.writeconfig(values={'clear_provider_table': False})
         logger.info('[MAINTENANCE-MODE][%s] Successfully cleared the provider_searches table' % (self.mode.upper()))
 
     def check_status(self):


### PR DESCRIPTION
- FIX: (#1125) config port value not being honoured
- FIX: ``-cp`` switch would not run correctly
- IMP: config value of ``clear_provider_table`` (``True``/``False``) to allow clear the table on startup for docker users (will auto-change to ``False`` if previously set to ``True`` on successful run (ie. provider table is cleared).