### PR TITLE
FIX: publisher name ending with decimal during folder creation, FIX: auto-want upcoming error with annuals

### DIFF
--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -93,13 +93,13 @@ class FileHandlers(object):
         if mylar.OS_DETECT == 'Windows':
             if '/' in folder_format:
                 folder_format = re.sub('/', '\\', folder_format).strip()
-            if publisher is not None:
-                # windows - she go boom when a directory ends with a period. *nix not so much.
-                if publisher.endswith(r'\.'):
-                    publisher = publisher[:-1]
         else:
             if '\\' in folder_format:
                 folder_format = folder_format.replace('\\', '/').strip()
+
+        if publisher is not None:
+            if publisher.endswith('.'):
+                publisher = publisher[:-1]
 
         u_comicnm = self.comic['ComicName']
         # let's remove the non-standard characters here that will break filenaming / searching.

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -1158,7 +1158,7 @@ def manualAnnual(manual_comicid=None, comicname=None, comicyear=None, comicid=No
                         logger.fdebug('[Marking as Wanted] week %s >= week %s' % (now_week, issue_week))
                         astatus = "Wanted"
                     elif all([int(re.sub('-', '', serieslast_updated).strip()) < int(dk), mylar.CONFIG.AUTOWANT_UPCOMING is True]):
-                        logger.info('Autowant upcoming triggered for issue #%s' % issue['Issue_Number'])
+                        logger.info('Autowant upcoming triggered for issue #%s' % firstval['Issue_Number'])
                         astatus = "Wanted"
                     else:
                         astatus = "Skipped"


### PR DESCRIPTION
- FIX: publisher name ending with ``.``  during folder creation would cause incorrect pathing
- FIX: auto-want upcoming error with annuals when used with annual integration