### PR TITLE
FIX: mattermost previous PR forgot some stuff

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -1576,7 +1576,7 @@
                     <fieldset>
                         <h3><img src="images/mattermost_logo.png" style="vertical-align: middle; margin: 3px; margin-top: -1px;" height="30" width="30"/>Mattermost</h3>
                         <div class="row checkbox">
-                            <input type="checkbox" name="mattermost_enabled" id="mattermost" value="1" ${config['mattermost_enabled']} /><label>Enable Discord Notifications</label>
+                            <input type="checkbox" name="mattermost_enabled" id="mattermost" value="1" ${config['mattermost_enabled']} /><label>Enable Mattermost Notifications</label>
                         </div>
                         <div id="mattermostoptions">
                             <div class="row">
@@ -2212,6 +2212,26 @@
                     else
                     {
                         $("#gotifyoptions").slideUp();
+                    }
+                });
+
+                if ($("#mattermost").is(":checked"))
+                {
+                    $("#mattermostoptions").show();
+                }
+                else
+                {
+                    $("#mattermostoptions").hide();
+                }
+
+                $("#mattermost").click(function(){
+                    if ($("#mattermost").is(":checked"))
+                    {
+                        $("#mattermostoptions").slideDown();
+                    }
+                    else
+                    {
+                        $("#mattermostoptions").slideUp();
                     }
                 });
 
@@ -2959,7 +2979,7 @@
                 $('#mattermost_test').click(function () {
                     var imagechk = document.getElementById("mattermost_statusicon");
                     var webhook_url = document.getElementById("mattermost_webhook_url").value;
-                    $.get("testslack",
+                    $.get("testmattermost",
                         { webhook_url: webhook_url },
                         function(data){
                             if (data.error != undefined) {

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6974,7 +6974,7 @@ class WebInterface(object):
                            'enable_meta', 'cbr2cbz_only', 'ct_tag_cr', 'ct_tag_cbl', 'ct_cbz_overwrite', 'cmtag_start_year_as_volume', 'cmtag_volume',
                            'rename_files', 'replace_spaces', 'zero_level',
                            'lowercase_filenames', 'autowant_upcoming', 'autowant_all', 'comic_cover_local', 'cover_folder_local', 'series_metadata_local', 'alternate_latest_series_covers', 'cvinfo', 'snatchedtorrent_notify',
-                           'prowl_enabled', 'prowl_onsnatch', 'pushover_enabled', 'pushover_onsnatch', 'pushover_image', 'boxcar_enabled',
+                           'prowl_enabled', 'prowl_onsnatch', 'pushover_enabled', 'pushover_onsnatch', 'pushover_image', 'mattermost_enabled', 'mattermost_onsnatch', 'boxcar_enabled',
                            'boxcar_onsnatch', 'pushbullet_enabled', 'pushbullet_onsnatch', 'telegram_enabled', 'telegram_onsnatch', 'telegram_image', 'discord_enabled', 'discord_onsnatch', 'slack_enabled', 'slack_onsnatch',
                            'email_enabled', 'email_enc', 'email_ongrab', 'email_onpost', 'gotify_enabled', 'gotify_server_url', 'gotify_token', 'gotify_onsnatch', 'opds_enable', 'opds_authentication', 'opds_metainfo', 'opds_pagesize', 'enable_ddl',
                            'enable_getcomics', 'deluge_pause'] #enable_public
@@ -7822,7 +7822,7 @@ class WebInterface(object):
             logger.warn('Test variables used [WEBHOOK_URL: %s][USERNAME: %s]' % (webhook_url, username))
             return "Error sending test message to Slack"
     testslack.exposed = True
-    
+
     def testmattermost(self, webhook_url):
         mattermost = notifiers.MATTERMOST(test_webhook_url=webhook_url)
         result = mattermost.test_notify()


### PR DESCRIPTION
Just some slight misses:
- FIX: typo of discord notifications instead of Mattermost notifications
- FIX: showing / hiding of Mattermost section not linked to enable Mattermost option
- FIX: test Mattermost option would test against slack, not Mattermost function
- FIX: config options for Mattermost would not be saved