### PR TITLE
IMP: warnings/info section addition to config page, IMP: carepackage updates

### DIFF
--- a/data/interfaces/carbon/css/style.css
+++ b/data/interfaces/carbon/css/style.css
@@ -2435,6 +2435,14 @@ fieldset.fieldset_header {
   box-shadow: 0px 0px 10px #666;
   padding-top: 5px;
 }
+fieldset.fieldset_header_check {
+  margin: 5px;
+  padding: 0px 5px 5px;
+  border: 1px solid #F50202;
+  border-radius: 8px;
+  box-shadow: 0px 0px 10px #F50202;
+  padding-top: 5px;
+}
 figure.item{
   vertical-align: top;
   display: inline-block;

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -67,6 +67,14 @@
                             </br><span style="float:left;vertical-align:top;" title="${config['br_type']} installation detected.">${config['br_type']}</span>
                             <span style="float:right;vertical-align:top;">${config['branch']}</span>
                   </fieldset>
+                  </br>
+                  <fieldset id="warnings_check">
+                       <legend>WARNINGS / IMPORTANT RELEASE INFO</legend>
+                       <label><strong>PIP requirements: </strong></label><span id="pip_reqcheck"></span></br>
+                       <label><strong>Unrar requirement: </strong></label><span id="rar_reqcheck"></span></br>
+                       <span id="config_messages"><label><strong>Configuration warnings: </strong></label><span id="config_reqcheck"></span></span>
+                       <span id="release_messages"><label><strong>Messages: </strong></label><span id="releasemsg_check"></span></span>
+                  </fieldset>
                   <fieldset>
                        <div>
                             <br/>
@@ -1592,7 +1600,7 @@
                             <div align="center" class="row">
                                 <img name="mattermost_statusicon" id="mattermost_statusicon" src="images/success.png" style="float:right;visibility:hidden;" height="20" width="20" />
                                 <input type="button" value="Test Mattermost" id="mattermost_test" style="float:center" /></br>
-                                <input type="text" name="mattermoststatus" style="text-align:center; font-size:11px;" id="discordstatus" size="55" DISABLED />
+                                <input type="text" name="mattermoststatus" style="text-align:center; font-size:11px;" id="mattermoststatus" size="55" DISABLED />
                             </div>
                         </div>
                     </fieldset>
@@ -1710,7 +1718,7 @@
 </%def>
 
 <%def name="javascriptIncludes()">
-        <script src="js/libs/jquery.dataTables.min.js"></script>
+        <script src="js/libs/jquery.dataTables.1.10.25.min.js"></script>
         <script>
         function changeTest()
         {
@@ -1866,11 +1874,70 @@
             document.getElementById("opds_url").innerHTML = the_line;
         }
 
+        function check_requirements(){
+            $.when($.ajax({
+                 type: "GET",
+                 url: "return_checks",
+                 success: function(response) {
+                    obj = JSON.parse(response);
+                    if (typeof(obj) === "undefined" || obj === null || obj.length === 0) {
+                        document.getElementById("pip_reqcheck").innerHTML = 'OK';
+                        document.getElementById("warnings_check").className = 'fieldset_header';
+                    }
+                 },
+                 error: function(data)
+                     {
+                     },
+            })).done(function(data) {
+                 if (obj['pip']['pip_failure'] === true) {
+                     pjson = obj['pip']['pip_info'];
+                     pting = '<table style="border:none;">';
+                     pjson.forEach(item => {
+                         pting += '<tr><td style="text-align:right;width:20px;">' + item.module + '</td><td style="width:30px;">' + item.message + '</td></tr>';
+                     });
+                     pting += '</table>';
+                     document.getElementById("pip_reqcheck").innerHTML = pting;
+                     document.getElementById("warnings_check").className = 'fieldset_header_check';
+                 } else if (obj['pip']['pip_failure'] === false) {
+                     document.getElementById("pip_reqcheck").innerHTML = 'OK';
+                     document.getElementById("warnings_check").className = 'fieldset_header';
+                 }
+                 if (obj['rar']['rar_message']) {
+                     document.getElementById("rar_reqcheck").innerHTML = obj['rar']['rar_message'];
+                 }
+                 document.getElementById("config_messages").style.display = 'none';
+                 document.getElementById("release_messages").style.display = 'none';
+                 var cck = false;
+                 var cfg = obj['config'];
+                 tcfg = '<table border="0">';
+                 cfg.forEach(item => {
+                     tcfg += '<tr align="left"><td width="60">' + item.error_message + '</td></tr>';
+                     cck = true;
+                 });
+                 tcfg += '</table>';
+                 if (cck === true){
+                     document.getElementById("config_reqcheck").innerHTML = tcfg;
+                     document.getElementById("warnings_check").className = 'fieldset_header_check';
+                     document.getElementById("config_messages").style.display = 'block';
+                     document.getElementById("warnings_check").className = 'fieldset_header';
+                 }
+                 rlsline = obj['release_messages'];
+                 if (typeof(rlsline) != 'undefined' && rlsline != null){
+                     rlsmsg = '<p style="margin-left:10px;">';
+                     rlsline.forEach(item => {
+                         rlsmsg += item + '</br>';
+                     });
+                     document.getElementById("releasemsg_check").innerHTML = rlsmsg + '</p>';
+                     document.getElementById("release_messages").style.display = 'block';
+                 }
+            });
+        }
+
         </script>
-	<script>
-	function initThisPage() 
-	
-	{
+       <script>
+       function initThisPage()
+
+       {
                 var prov_start_id = 0;
                 if ($("#api_enabled").is(":checked"))
                         {
@@ -3180,6 +3247,7 @@
 	$(document).ready(function() {
 		initThisPage();
                 annuals_integration()
+                check_requirements();
 	});
 	</script>
 </%def>

--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -2351,6 +2351,14 @@ fieldset.fieldset_header {
   box-shadow: 0px 0px 10px #c4c4c4;
   padding-top: 5px;
 }
+fieldset.fieldset_header_check {
+  margin: 5px;
+  padding: 0px 5px 5px;
+  border: 1px solid #F50202;
+  border-radius: 8px;
+  box-shadow: 0px 0px 10px #F50202;
+  padding-top: 5px;
+}
 figure.item{
   vertical-align: top;
   display: inline-block;

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -32,7 +32,7 @@
 </%def>
 
 <%def name="javascriptIncludes()">
-        <script src="js/libs/jquery.dataTables.min.js"></script>
+        <script src="js/libs/jquery.dataTables.1.10.25.min.js"></script>
         <script src="js/libs/full_numbers_no_ellipses.js"></script>
 	<script>
         $.fn.DataTable.ext.pager.numbers_length = 3;

--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -612,7 +612,7 @@ class PostProcessor(object):
                                                 else:
                                                     os.replace(tt, clocation)
                                         else:
-                                            logger.warn('[%s] Skipping this file due to path conversion error [path: %s]/[name: %s]' % (e, tpath, tname))
+                                            logger.warn('Skipping this file due to path conversion error [path: %s]/[name: %s]' % (tpath, tname))
                                             path_failure = True
                                     else:
                                         logger.fdebug('tpath: %s' % (tpath))
@@ -671,10 +671,10 @@ class PostProcessor(object):
                                                         else:
                                                             self.nzb_folder = clocation   # this is needed in order to delete after moving.
                                                    else:
-                                                       logger.warn('[%s] Skipping this file due to path conversion error [path: %s]/[name: %s]' % (e, tpath, tname))
+                                                       logger.warn('Skipping this file due to path conversion error [path: %s]/[name: %s]' % (tpath, tname))
                                                        path_failure = True
                                                 else:
-                                                    logger.warn('[%s] Skipping this file due to path conversion error [path: %s]/[name: %s]' % (e, tpath, tname))
+                                                    logger.warn('Skipping this file due to path conversion error [path: %s]/[name: %s]' % (tpath, tname))
                                                     path_failure = True
                                             except Exception as e:
                                                 logger.warn('[%s] Skipping this file due to path conversion error [path: %s]/[name: %s]' % (e, tpath, tname))
@@ -1923,7 +1923,7 @@ class PostProcessor(object):
                         else:
                             logger.fdebug('%s [%s] Post-Processing completed for: %s' % (module, ml['StoryArc'], ml['ComicLocation']))
 
-                        if any([all([mylar.CONFIG.PUSHOVER_IMAGE, mylar.CONFIG.PUSHOVER_ENABLED]), all([mylar.CONFIG.TELEGRAM_IMAGE, mylar.CONFIG.TELEGRAM_ENABLED]),all([mylar.CONFIG.MATTERMOST_ENABLED]) ]):
+                        if any([all([mylar.CONFIG.PUSHOVER_IMAGE, mylar.CONFIG.PUSHOVER_ENABLED]), all([mylar.CONFIG.TELEGRAM_IMAGE, mylar.CONFIG.TELEGRAM_ENABLED]), mylar.CONFIG.DISCORD_ENABLED, mylar.CONFIG.GOTIFY_ENABLED, mylar.CONFIG.MATTERMOST_ENABLED ]):
                             try:
                                 get_cover = getimage.extract_image(grab_dst, single=True, imquality='notif')
                                 imageFile = get_cover['ComicImage']
@@ -2512,7 +2512,7 @@ class PostProcessor(object):
                         logger.info('%s Post-Processing completed for: [ %s #%s ] %s' % (module, comicname, issuenumber, grab_dst))
                         self._log("Post Processing SUCCESSFUL! ")
 
-                    if any([all([mylar.CONFIG.PUSHOVER_IMAGE, mylar.CONFIG.PUSHOVER_ENABLED]), all([mylar.CONFIG.TELEGRAM_IMAGE, mylar.CONFIG.TELEGRAM_ENABLED]), all([mylar.CONFIG.MATTERMOST_ENABLED]) ]):
+                    if any([all([mylar.CONFIG.PUSHOVER_IMAGE, mylar.CONFIG.PUSHOVER_ENABLED]), all([mylar.CONFIG.TELEGRAM_IMAGE, mylar.CONFIG.TELEGRAM_ENABLED]), mylar.CONFIG.DISCORD_ENABLED, mylar.CONFIG.GOTIFY_ENABLED, mylar.CONFIG.MATTERMOST_ENABLED ]):
                         try:
                             get_cover = getimage.extract_image(grab_dst, single=True, imquality='notif')
                             imageFile = get_cover['ComicImage']
@@ -3373,7 +3373,7 @@ class PostProcessor(object):
             #    return self.queue.put(self.valreturn)
 
             # If using Pushover with image enabled, Telegram with image enabled, or Discord, extract the first image in the file for the notification
-            if any([all([mylar.CONFIG.PUSHOVER_IMAGE, mylar.CONFIG.PUSHOVER_ENABLED]), all([mylar.CONFIG.TELEGRAM_IMAGE, mylar.CONFIG.TELEGRAM_ENABLED]), all([mylar.CONFIG.DISCORD_ENABLED]), all([mylar.CONFIG.GOTIFY_ENABLED]), all([mylar.CONFIG.MATTERMOST_ENABLED])]):
+            if any([all([mylar.CONFIG.PUSHOVER_IMAGE, mylar.CONFIG.PUSHOVER_ENABLED]), all([mylar.CONFIG.TELEGRAM_IMAGE, mylar.CONFIG.TELEGRAM_ENABLED]), mylar.CONFIG.DISCORD_ENABLED, mylar.CONFIG.GOTIFY_ENABLED, mylar.CONFIG.MATTERMOST_ENABLED ]):
                 try:
                     get_cover = getimage.extract_image(dst, single=True, imquality='notif')
                     imageFile = get_cover['ComicImage']

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -183,6 +183,7 @@ GLOBAL_MESSAGES = None
 SSE_KEY = None
 SESSION_ID = None
 UPDATE_VALUE = {}
+REQS = {}
 SCHED = BackgroundScheduler({
                              'apscheduler.executors.default': {
                                  'class':  'apscheduler.executors.pool:ThreadPoolExecutor',
@@ -209,7 +210,7 @@ def initialize(config_file):
                MONITOR_SCHEDULER, SEARCH_SCHEDULER, RSS_SCHEDULER, WEEKLY_SCHEDULER, VERSION_SCHEDULER, UPDATER_SCHEDULER, \
                SCHED_RSS_LAST, SCHED_WEEKLY_LAST, SCHED_MONITOR_LAST, SCHED_SEARCH_LAST, SCHED_VERSION_LAST, SCHED_DBUPDATE_LAST, COMICINFO, SEARCH_TIER_DATE, \
                BACKENDSTATUS_CV, BACKENDSTATUS_WS, PROVIDER_STATUS, EXT_IP, ISSUE_EXCEPTIONS, PROVIDER_START_ID, GLOBAL_MESSAGES, CHECK_FOLDER_CACHE, FOLDER_CACHE, SESSION_ID, \
-               MAINTENANCE_UPDATE, MAINTENANCE_DB_COUNT, MAINTENANCE_DB_TOTAL, UPDATE_VALUE
+               MAINTENANCE_UPDATE, MAINTENANCE_DB_COUNT, MAINTENANCE_DB_TOTAL, UPDATE_VALUE, REQS
 
         cc = mylar.config.Config(config_file)
         CONFIG = cc.read(startup=True)

--- a/mylar/carepackage.py
+++ b/mylar/carepackage.py
@@ -13,19 +13,19 @@ from collections import OrderedDict
 from operator import itemgetter
 
 from glob import glob
-from mylar import mylar, config, logger, encrypted
+import mylar
+from mylar import config, logger, encrypted, versioncheck
 import zipfile
 
 class carePackage(object):
 
-    def __init__(self):
+    def __init__(self, maintenance=False):
+        self.maintenance = maintenance
         self.carepackage_version = 1.05
-        self.filename = os.path.join(mylar.CONFIG.LOG_DIR, 'MylarRunningEnvironment.txt')
-        self.panicfile = os.path.join(mylar.CONFIG.LOG_DIR, "carepackage.zip")
         self.configpath = os.path.join(mylar.DATA_DIR, 'config.ini')
-        self.cleanpath = os.path.join(mylar.CONFIG.LOG_DIR, 'clean_config.ini')
         self.lastrelpath = os.path.join(mylar.PROG_DIR, '.LASTRELEASE')
         self.keylist = []
+        self.pass_thru_vals = None
         self.cleaned_list = {
                             ('Interface', 'http_password'),
                             ('SABnzbd', 'sab_username'),
@@ -80,14 +80,43 @@ class carePackage(object):
                             ('Seedbox', 'seedbox_host'),
                             ('Email', 'email_server')
                              }
-        self.environment()
-        self.cleaned_config()
-        self.panicbutton()
 
-    def environment(self):
+    def loaders(self):
+        self.cleaned_config()
+        vers_vals = versioncheck.versionload(cli_values=self.pass_thru_vals)
+        self.filename = os.path.join(self.log_dir, 'MylarRunningEnvironment.txt')
+        logger.info('vers_vals: %s' % (vers_vals,))
+        # set the stage for the filename
+        if not vers_vals:
+            vers_vals = {'current_branch': mylar.CONFIG.GIT_BRANCH,
+                         'current_version': mylar.CURRENT_VERSION,
+                         'current_version_name': mylar.CURRENT_VERSION_NAME,
+                         'current_release_name': mylar.CURRENT_RELEASE_NAME}
+
+        if vers_vals['current_branch'] == 'master' and vers_vals['current_version_name'] is not None:
+            panic_name = 'carepackage_%s.zip' % (vers_vals['current_version_name'])
+        else:
+            panic_name = 'carepackage_%s_(%s).zip' % (vers_vals['current_version'], vers_vals['current_branch'])
+
+        self.panicfile = os.path.join(self.log_dir, panic_name)
+
+        env_status = self.environment(vers_vals)
+        panic_status = self.panicbutton()
+        return {'status': 'success',
+                'carepackage': self.panicfile}
+
+    def environment(self, vers_vals):
         f = open(self.filename, "w+")
         f.write("-- Carepackage version %s --\n" % self.carepackage_version)
-        f.write("Mylar host information:\n")
+        f.write("\n-- Release information --\n")
+        f.write("branch: %s\n" % (vers_vals['current_branch']))
+        f.write("commmit: %s\n" % (vers_vals['current_version']))
+        if vers_vals['current_version_name'] is not None:
+            f.write("version: %s\n" % (vers_vals['current_version_name']))
+        if vers_vals['current_release_name']:
+            f.write("release name: %s\n" % (vers_vals['current_release_name']))
+        f.write("-------------------------\n")
+        f.write("\nMylar host information:\n")
         match = re.search('Windows', platform.system(), re.IGNORECASE)
         if match:
             objline = ['systeminfo']
@@ -99,12 +128,13 @@ class carePackage(object):
             text=True)
         for hiline in hi.stdout.split('\n'):
             if platform.system() == 'Windows':
-                if all(['Host Name' not in hiline, 'OS Name' not in hiline, 
+                if all(['Host Name' not in hiline, 'OS Name' not in hiline,
 				'OS Version' not in hiline, 'OS Configuration' not in hiline,
 				'OS Build Type' not in hiline, 'Locale' not in hiline,
 				'Time Zone' not in hiline]):
                     continue
-            f.write("%s\n" % hiline)
+            if all([hiline is not None, hiline != '', hiline != r'\n']):
+                f.write("%s\n" % hiline)
 
         f.write("\n\nMylar python information:\n")
         pyloc = sys.executable
@@ -144,9 +174,34 @@ class carePackage(object):
         f.close()
 
     def cleaned_config(self):
-        shutil.copy(self.configpath, self.cleanpath)
         tmpconfig = configparser.SafeConfigParser()
-        tmpconfig.readfp(codecs.open(self.cleanpath, 'r', 'utf8'))
+        tmpconfig.readfp(codecs.open(self.configpath, 'r', 'utf8'))
+
+        if self.maintenance is True:
+            self.log_dir = tmpconfig['Logs']['log_dir']
+            if self.log_dir is None:
+                self.log_dir = os.path.join(mylar.DATA_DIR, 'logs')
+
+            # we need to dummy these up if this is via CLI
+            git_tmp = tmpconfig['Git']
+            git_user = git_tmp['git_user']
+            git_branch = git_tmp['git_branch']
+            git_token = git_tmp['git_token']
+            self.git_path = git_tmp['git_path']
+            auto_update = False
+            check_github_on_startup = False
+            self.pass_thru_vals = {'git_user': git_user,
+                                   'git_branch': git_branch,
+                                   'git_token': git_token,
+                                   'git_path': self.git_path,
+                                   'auto_update': auto_update,
+                                   'check_github_on_startup': check_github_on_startup}
+        else:
+            self.log_dir = mylar.CONFIG.LOG_DIR
+
+        self.cleanpath = os.path.join(self.log_dir, 'clean_config.ini')
+
+        shutil.copy(self.configpath, self.cleanpath)
 
         for v in self.cleaned_list:
             try:
@@ -204,7 +259,6 @@ class carePackage(object):
             cleaned_newznabs.append(newnewzline)
 
         for ets in extra_torznabs:
-            logger.info('torznab: %s' % (ets,))
             n_host = None
             n_uid = None
             n_api = None
@@ -260,14 +314,14 @@ class carePackage(object):
 
             files = []
             try:
-                caredir = os.path.join(mylar.CONFIG.LOG_DIR, 'carepackage')
+                caredir = os.path.join(self.log_dir, 'carepackage')
                 os.mkdir(caredir)
             except Exception as e:
                 pass
 
-            for file in glob(os.path.join(mylar.CONFIG.LOG_DIR,'mylar.log*')):
+            for file in glob(os.path.join(self.log_dir,'mylar.log*')):
                 #files.append(pathlib.Path(pathlib.PurePath(mylar.CONFIG.LOG_DIR).joinpath(os.path.basename(file)))) #os.path.join(mylar.CONFIG.LOG_DIR, os.path.basename(file)))
-                files.append(os.path.join(mylar.CONFIG.LOG_DIR, os.path.basename(file)))
+                files.append(os.path.join(self.log_dir, os.path.basename(file)))
 
             if len(files) > 0:
                 for fname in files:

--- a/mylar/req_test.py
+++ b/mylar/req_test.py
@@ -1,0 +1,250 @@
+#  This file is part of Mylar.
+#
+#  Mylar is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Mylar is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import os
+import sys
+import json
+import subprocess
+import codecs
+import configparser
+import platform
+from pkg_resources import parse_version
+
+import mylar
+from mylar import logger
+
+class Req(object):
+
+    def __init__(self):
+        self.file = os.path.join(mylar.DATA_DIR, 'requirements.txt')
+        self.req_list = []
+        self.pip_list = []
+        self.operators = ['==', '>=', '<=']
+        # mylar.REQS = {'pip': {'pip_failure': true/false, 'pip_list': {pip_list_dictionary}},
+        #               'rar': {'rar_failure': true/false, 'rar_exe_path': path to rar / rar message},
+        #               'release_messages': release messages,
+        #               'config': {'config_failure': true/false, 'config_list': {config_list dictionary}}}
+
+    def loaders(self):
+        self.check_the_pip()
+        self.find_the_unrar()
+        self.release_messages()
+
+        #check_config should be run on each config page load/update
+        #self.check_config_values()
+
+    def check_the_pip(self):
+        with open(self.file, 'r')as f:
+            for line in f:
+                if '#' not in line:
+                    for opc in self.operators:
+                        p_test = line.find(opc)
+                        if p_test > 0:
+                            p_arg = opc
+                            p_mod = str(line[:p_test]).strip()
+                            if p_mod == '':
+                                continue
+                            p_version = str(line[p_test+2:]).strip()
+                            if p_version == '':
+                                continue
+                            self.req_list.append({'module': p_mod, 'version': p_version, 'arg': p_arg})
+                            break
+
+        self.pip_load()
+
+        req_pip_list = []
+
+        cest_boom = 'OK'
+
+        for rq in self.req_list:
+            version_match = False
+            for pl in self.pip_list:
+                if re.sub('[\-\_]', '', rq['module']).strip() == re.sub('[\-\_]', '', pl['module']).strip():
+                    if parse_version(pl['version']) == parse_version(rq['version']):
+                        version_match = 'OK'
+                    elif parse_version(pl['version']) < parse_version(rq['version']):
+                        if rq['arg'] == '<=':
+                            version_match = 'OK'
+                        else:
+                            version_match = 'FAIL'
+                            cest_boom = 'FAIL'
+                    elif parse_version(pl['version']) > parse_version(rq['version']):
+                        if rq['arg'] == '>=':
+                            version_match = 'OK'
+                        else:
+                            version_match = 'FAIL'
+                            cest_boom = 'FAIL'
+                    logger.fdebug('[%s] REQUIRED: %s ---> INSTALLED: %s [%s]' % (rq['module'], rq['version'], pl['version'], version_match))
+                    req_pip_list.append({'module': rq['module'],
+                                         'req_version': rq['version'],
+                                         'arg': rq['arg'],
+                                         'pip_version': pl['version'],
+                                         'version_match': version_match})
+                    break
+
+            if version_match is False:
+                version_match = 'FAIL'
+                cest_boom = 'FAIL'
+                logger.fdebug('[%s] REQUIRED: %s ---> INSTALLED: %s ' % (rq['module'], rq['version'], version_match))
+                req_pip_list.append({'module': rq['module'],
+                                     'req_version': rq['version'],
+                                     'arg': rq['arg'],
+                                     'pip_version': 'Not Installed',
+                                     'version_match': version_match})
+
+        pip_failed = False
+        plist = []
+        for x in req_pip_list:
+            if x['version_match'] == 'FAIL':
+                if x['pip_version'] != 'Not Installed':
+                    if x['arg'] == '>=':
+                        targ = '<'
+                    elif x['arg'] == '<=':
+                        targ = '>'
+                    pip_message = "%s installed %s %s required" % (x['pip_version'], targ, x['req_version'])
+                else:
+                    pip_message = "%s %s" % (x['req_version'], x['pip_version'])
+                plist.append({"module": str(x['module']),
+                              "message": pip_message,
+                              "version_match": str(x['version_match'])})
+                pip_failed = True
+ 
+        mylar.REQS['pip'] = {'pip_failure': pip_failed, 'pip_info': plist}
+
+    def pip_load(self):
+        try:
+            pyloc = sys.executable
+            pi = subprocess.run([pyloc, '-V'],
+                capture_output=True,
+                text=True)
+            py_version = pi.stdout
+            logger.fdebug('Python Version: %s' % (py_version.strip()))
+            logger.fdebug('Python executable location: %s' % (pyloc.strip()))
+
+            pf_raw = subprocess.run([pyloc, '-m', 'pip', 'list'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout.splitlines()
+
+            for pf in pf_raw:
+                pipline = str(pf)
+                if any(['WARNING' in pipline, 'You should' in pipline, '----' in pipline, 'Package' in pipline]):
+                    continue
+                else:
+                    p_mod = str(pipline[:pipline.find(' ')]).strip()
+                    p_version = str(pipline[pipline.find(' ')+1:]).strip()
+                    self.pip_list.append({'module': p_mod, 'version': p_version})
+        except Exception as e:
+            logger.fdebug('error: %s' % (e,))
+
+    def find_the_unrar(self):
+
+        cmds = ['unrar']
+        rar_failure = True
+
+        # check the ini first
+        if mylar.CONFIG.UNRAR_CMD:
+            cmds.append(mylar.CONFIG.UNRAR_CMD)
+            logger.fdebug('unrar_cmd location added to cmd checker: %s' % mylar.CONFIG.UNRAR_CMD)
+
+        # check the ct_settingspath
+        ctpath = os.path.join(mylar.CONFIG.CT_SETTINGSPATH, 'settings')
+        config = configparser.ConfigParser()
+        if os.path.isfile(ctpath):
+            ct_config = config.read_file(codecs.open(ctpath, 'r', 'utf8'))
+            ctrarpath = config.get('settings', 'rar_exe_path')
+            if ctrarpath is not None:
+                cmds.append(ctrarpath)
+                logger.fdebug('comictagger .settings file path added to cmd checker: %s' % ctrarpath)
+
+        itworked = False
+        output = None
+        if platform.system() == 'Windows':
+            cmds.append('RaR')
+
+        for cmd in cmds:
+            try:
+                logger.fdebug('Trying to execute: %s' % (cmd))
+                output = subprocess.run(cmd, text=True, capture_output=True, shell=True)
+                logger.fdebug('rar_check output: %s' % output)
+                itworked = True
+            except Exception as e:
+                logger.fdebug('Command %s didn\'t work [%s]' % (cmd, e))
+                itworked = False
+                continue
+            else:
+                if all([output.stderr is not None, output.stderr != '', output.returncode > 0]):
+                    logger.fdebug('Encountered error: %s' % output.stderr)
+                    itworked = False
+
+            if "not found" in output.stdout or "not recognized as an internal or external command" in output.stdout:
+                logger.fdebug('[%s] Unable to find executable with command: %s' % (output.stdout, cmd))
+                output = None
+                itworked = False
+            elif itworked:
+                tmp_chk = output.stdout.split(r'\n')
+                for tc in tmp_chk:
+                    if 'unrar' in tc:
+                        tt = tc.lower().find('copyright')
+                        if tt != -1:
+                            output = tc[:tt]
+                            rar_failure = False
+                            break
+
+            if rar_failure is False:
+                break
+
+        if output is None:
+            output = 'Unable to locate unrar'
+
+        rar_exe_path = output
+
+        print('rar_exe_path: %s' % rar_exe_path)
+        rar_message = 'Unable to locate unrar'
+        try:
+            if rar_exe_path is not None:
+                rar_message = rar_exe_path # set the message to be the path to the binary
+                rar_failure = rar_failure
+        except Exception as e:
+            pass
+
+        mylar.REQS['rar'] = {'rar_failure': rar_failure, 'rar_message': rar_message}
+
+    def release_messages(self):
+        with open('.release_messages', 'r') as rmf:
+            rls_messages = rmf.readlines()
+
+        if len(rls_messages) == 0:
+            rls_messages = None
+        logger.info('release_messages: %s' % (rls_messages,))
+        mylar.REQS['release_messages'] = rls_messages
+
+    def check_config_values(self):
+        mylar.REQS['config'] = []   # make sure to reset config dict here
+        if any(
+                [
+                    mylar.CONFIG.DESTINATION_DIR is None,
+                    mylar.CONFIG.DESTINATION_DIR == 'None',
+                    mylar.CONFIG.DESTINATION_DIR == '',
+                ]
+        ):
+            mylar.REQS['config'].append({'error_message': 'No Comic Location path specified'})
+
+        if any(
+                [
+                    mylar.CONFIG.COMICVINE_API is None,
+                    mylar.CONFIG.COMICVINE_API == 'None',
+                    mylar.CONFIG.COMICVINE_API == '',
+                ]
+        ):
+            mylar.REQS['config'].append({'error_message': 'No Comicvine API key specified'})

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -1,4 +1,3 @@
-
 #  This file is part of Mylar.
 #
 #  Mylar is free software: you can redistribute it and/or modify
@@ -44,15 +43,37 @@ import platform
 import urllib.request, urllib.parse, urllib.error
 import shutil
 import fnmatch
+import simplejson as simplejson
+from operator import itemgetter
 
 import mylar
-
-from mylar import logger, db, importer, mb, search, filechecker, helpers, updater, parseit, weeklypull, PostProcessor, librarysync, moveit, Failed, readinglist, notifiers, sabparse, config, series_metadata
-from mylar.auth import AuthController, require
-
-import simplejson as simplejson
-
-from operator import itemgetter
+from mylar import (
+    carepackage,
+    config,
+    db,
+    Failed,
+    filechecker,
+    helpers,
+    importer,
+    librarysync,
+    logger,
+    mb,
+    moveit,
+    notifiers,
+    parseit,
+    PostProcessor,
+    readinglist,
+    req_test,
+    sabparse,
+    search,
+    series_metadata,
+    updater,
+    weeklypull,
+)
+from mylar.auth import (
+    AuthController,
+    require,
+)
 
 def serve_template(templatename, **kwargs):
     interface_dir = os.path.join(str(mylar.PROG_DIR), 'data/interfaces/')
@@ -7182,11 +7203,10 @@ class WebInterface(object):
     NZBGet_test.exposed = True
 
     def carepackage(self):
-        from mylar.carepackage import carePackage
-        cp = carePackage()
+        cp = carepackage.carePackage()
+        file_to_care = cp.loaders()
         from cherrypy.lib.static import serve_download
-        cppb = os.path.join(mylar.CONFIG.LOG_DIR, "carepackage.zip")
-        return serve_download(cppb)
+        return serve_download(file_to_care['carepackage'])
     carepackage.exposed = True
 
     def shutdown(self):
@@ -8905,3 +8925,10 @@ class WebInterface(object):
                 pass
 
     addMissingSeriesFromArc.exposed = True
+
+    def return_checks(self):
+        r = mylar.req_test.Req()
+        r.check_config_values()
+
+        return json.dumps(mylar.REQS)
+    return_checks.exposed = True


### PR DESCRIPTION
- IMP: warnings/info section added to configuration page 1st tab:
    - Will indicate if current pip requirements have been met, and if unrar is able to be located (and thereby used). 
    - If pip requirements not met, will indicate which module and why it wasn't met. 
    - Any warnings will turn the section box red to draw attention.
    - Messages section will relay messages from a .release_messages file in the data_dir location if present
- IMP: carepackage improvements:
   - added release information where git branch, commit and version will now be written
   - carepackage filename will now include the git commit and branch in the filename
   - CLI option added to maintenance mode - ``maintenance -care`` or ``maintenance --carepackage``
   - CLI option will run outside of the GUI so that it's possible to generate a carepackage if the GUI won't start for some reason
- FIX: post processor notification inclusion (missing some mattermost & gotify notif checks during post-processing)