### PR TITLE
FIX: Exclude deleted Arc items from AddMissingSeriesFromArc

### DIFF
--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -8907,7 +8907,7 @@ class WebInterface(object):
         storyarcname = None
 
         myDB = db.DBConnection()
-        arcs = myDB.select('Select ComicID, ComicName, SeriesYear, StoryArc FROM storyarcs WHERE storyarcid=? GROUP BY ComicID', [storyarcid])
+        arcs = myDB.select('Select ComicID, ComicName, SeriesYear, StoryArc FROM storyarcs WHERE storyarcid=? AND (Manual IS NOT "deleted" OR Manual IS NULL) GROUP BY ComicID', [storyarcid])
 
         for ac in arcs:
             if storyarcname is None and ac['StoryArc'] is not None:


### PR DESCRIPTION
Currently, Story Arc entries which are marked as 'deleted' (indicates a manual deletion by the user) are still getting added to the watchlist despite being unwanted and invisible in the UI. This tweak to the SQL should filter out any 'deleted' entries.