### PR TITLE
FIX: cid mistakingly referenced druing series.json creation (reverted)

### DIFF
--- a/mylar/series_metadata.py
+++ b/mylar/series_metadata.py
@@ -167,7 +167,7 @@ class metadata_Series(object):
                                              'publisher': comic['ComicPublisher'],
                                              'imprint': comic['PublisherImprint'],
                                              'name': comic['ComicName'],
-                                             'cid': int(cid),
+                                             'comicid': int(cid),
                                              'year': SeriesYear,
                                              'description_text': cdes_removed,
                                              'description_formatted': cdes_formatted,


### PR DESCRIPTION
schema itself is not broken so no need to adjust. 

Users would just need to recreate series.json from this point forward (or let it auto-recreate for new / ongoing series)