### PR TITLE
FIX:(#1237)(#1243)(#1247) requirements.txt not found when data_dir is specified via CLI

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -1919,7 +1919,7 @@
                      document.getElementById("config_reqcheck").innerHTML = tcfg;
                      document.getElementById("warnings_check").className = 'fieldset_header_check';
                      document.getElementById("config_messages").style.display = 'block';
-                     document.getElementById("warnings_check").className = 'fieldset_header';
+                     //document.getElementById("warnings_check").className = 'fieldset_header';
                  }
                  rlsline = obj['release_messages'];
                  if (typeof(rlsline) != 'undefined' && rlsline != null){


### PR DESCRIPTION
This would also affect schedulers not initialising at startup (and thereafter unable to run), if the requirements.txt file could not be located.

Also fixed the config page so that it will highlight the red border on failure to find / do pip comparisons.