### PR TITLE
FIX:(#1230) Check SABnzbd version on startup sequence as opposed to manual / initial value only

### DIFF
--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -40,7 +40,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 import cherrypy
 
-from mylar import logger, versioncheckit, rsscheckit, searchit, weeklypullit, PostProcessor, updater, helpers
+from mylar import logger, versioncheckit, rsscheckit, searchit, weeklypullit, PostProcessor, updater, helpers, sabnzbd
 
 import mylar.config
 
@@ -359,6 +359,12 @@ def initialize(config_file):
 
         if CONFIG.LOCMOVE:
             helpers.updateComicLocation()
+
+        # startup check(s) here so that the config values are already loaded against.
+        if all([mylar.USE_SABNZBD is True, mylar.CONFIG.SAB_HOST is not None]):
+            s_to_the_ab = sabnzbd.SABnzbd(params=None)
+            s_to_the_ab.sab_versioncheck()
+            logger.info('[SAB-VERSION-CHECK] SABnzbd version detected as: %s' % mylar.CONFIG.SAB_VERSION)
 
         # make sure the intLatestIssue field is populated with values...
         # ??helpers.latestissue_update()

--- a/mylar/sabnzbd.py
+++ b/mylar/sabnzbd.py
@@ -137,17 +137,11 @@ class SABnzbd(object):
 
         sab_check = None
         if mylar.CONFIG.SAB_VERSION is None:
-            try:
-                sc = mylar.webserve.WebInterface()
-                sab_check = sc.SABtest(sabhost=mylar.CONFIG.SAB_HOST, sabusername=mylar.CONFIG.SAB_USERNAME, sabpassword=mylar.CONFIG.SAB_PASSWORD, sabapikey=mylar.CONFIG.SAB_APIKEY)
-            except Exception as e:
-                logger.warn('[SABNZBD-VERSION-TEST] Exception encountered trying to retrieve SABnzbd version: %s. Setting history length to last 200 items.' % e)
-                hist_params['limit'] = 200
-                sab_check = 'some value'
-            else:
-                sab_check = None
+            sab_check = self.sab_versioncheck()
 
-        if sab_check is None:
+        if sab_check == 'some value':
+            hist_params['limit'] = 200
+        else:
             #set min_sab to 3.2.0 since 3.2.0 beta 1 has the api call for history search by nzo_id
             try:
                 min_sab = '3.2.0'
@@ -277,3 +271,15 @@ class SABnzbd(object):
             return {'status': False, 'failed': False}
 
         return found
+
+    def sab_versioncheck(self):
+        try:
+            sc = mylar.webserve.WebInterface()
+            sab_check = sc.SABtest(sabhost=mylar.CONFIG.SAB_HOST, sabusername=mylar.CONFIG.SAB_USERNAME, sabpassword=mylar.CONFIG.SAB_PASSWORD, sabapikey=mylar.CONFIG.SAB_APIKEY)
+        except Exception as e:
+            logger.warn('[SABNZBD-VERSION-TEST] Exception encountered trying to retrieve SABnzbd version: %s. Setting history length to last 200 items.' % e)
+            sab_check = 'some value'
+        else:
+            sab_check = None
+
+        return sab_check

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -7148,9 +7148,10 @@ class WebInterface(object):
             return json.dumps({"status": False, "message": "Invalid API Key provided.", "version": str(version)})
 
         mylar.CONFIG.SAB_APIKEY = q_apikey
-        logger.info('APIKey provided is the FULL API Key which is the correct key. You still need to SAVE the config for the changes to be applied.')
+        logger.info('APIKey provided is the FULL API Key which is the correct key.')
         logger.info('Connection to SABnzbd tested sucessfully')
         mylar.CONFIG.SAB_VERSION = version
+        mylar.CONFIG.writeconfig(values={'sab_version': version, 'sab_apikey': q_apikey})
         return json.dumps({"status": True, "message": "Successfully verified API Key.", "version": str(version)})
 
     SABtest.exposed = True


### PR DESCRIPTION
Previously, the SABnzbd version would only be checked when manually tested, or if the value for sab_version was set to None (typically a new installation). If SABnzbd was updated thereafter, mylar would not display the new version and instead would assume the initially tested version was being used. 

If the version was < 3.2.0, then this would restrict how much history mylar can retrieve from sabnzbd before assuming a download has failed. 

(This will allow for accommodation to future changes to the SABnzbd API if it should be required).

Also updated the config page so that it will auto-save the SABnzbd API key and SABnzbd version upon testing instead of waiting for the user to save things.