### PR TITLE
IMP: Ignore Words - Search Restrictions added to Configuration page, FIX: branch history not displaying

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -1077,13 +1077,22 @@
             <tr>
                 <td>
                         <fieldset>
-                                <legend>Quality</legend>
+                                <legend>File-Type Search Restrictions</legend>
                                 <div class="row radio left clearfix">
                                      <input type="radio" style="vertical-align: middle; margin: 3px; margin-top: -1px;" name="preferred_quality" value="1" ${config['pref_qual_1']} /><label>cbr</label>
                                      <input type="radio" style="vertical-align: middle; margin: 3px; margin-top: -1px;" name="preferred_quality" value="2" ${config['pref_qual_2']} /><label>cbz</label>
                                      <input type="radio" style="vertical-align: middle; margin: 3px; margin-top: -1px;" name="preferred_quality" value="0" ${config['pref_qual_0']} /><label>Whichever - just get it</label>
                                 </div>
                         </fieldset>
+                         <fieldset>
+                                <legend>Ignore Words Search Restrictions</legend>
+                                   <div name="ignore_words_selection" id="ignore_words_selection" style="vertical-align: middle; text-align: center;">
+                                     <div>
+                                       <select id="ignore_words" name="ignore_search_words[]" multiple style="width:75%;" placeholder="Ignore words for search results...">
+                                       </select>
+                                     <div>
+                                   </div>
+                         </fieldset>
                         <fieldset>
                                 <legend>File-Size Search Restrictions</legend>
                                 <div class="row checkbox left">
@@ -1093,7 +1102,6 @@
                                        <div class="row">
                                            <input type="text" name="minsize" value="${config['minsize']}" size="6">
                                        </div>
-                                </div>
                                 </div>
                          </fieldset>
                          <fieldset>
@@ -1715,10 +1723,12 @@
 
 <%def name="headIncludes()">
         <link rel="stylesheet" href="interfaces/${interface}/css/data_table.css">
+        <link rel="stylesheet" type="text/css" href="css/selectize.default.css">
 </%def>
 
 <%def name="javascriptIncludes()">
         <script src="js/libs/jquery.dataTables.1.10.25.min.js"></script>
+        <script src="js/libs/selectize.js"></script>
         <script>
         function changeTest()
         {
@@ -3211,6 +3221,85 @@
 			$( "#tabs" ).tabs();
 		});
 		initActions();
+                $(function selector(){
+                        $.when($.ajax({
+                                type: "GET",
+                                url: "ignore_search_word_listing",
+                                dataType: 'json',
+                                success: function ( response ) {
+                                    results = response;
+                                },
+                                error: function (data) {
+                                    var options = [];
+                                },
+                        })).done(function(data) {
+                            var options = [];
+                            $.each(results, function() {
+                                options.push({
+                                    name : this.name
+                                });
+                            })
+                            //options = [{"name":"publisher name here"}];
+                            try {
+                                items = options.map(x => x.name);
+                            } catch(e) {
+                                const options = [];
+                                items = [];
+                            }
+                        $( "#ignore_words" ).selectize({
+                             valueField: 'name',
+                             labelField: 'name',
+                             options: options,
+                             items: items,
+                             createOnBlur: true,
+                             showAddOptionOnCreate: false,
+                             create: function (input, callback) {
+                                 $.ajax({
+                                     type: "GET",
+                                     url: "ignore_search_word_listing",
+                                     data: { inputvalue: input },
+                                     dataType: 'json',
+                                     success: function ( response ){
+                                          return callback(response);
+                                     }
+                                 });
+                             },
+                             onItemRemove: function (input, callback){
+                                 $.ajax({
+                                     type: "GET",
+                                     url: "ignore_search_word_listing",
+                                     data: { deletevalue: input },
+                                     dataType: 'json',
+                                     success: function ( response ){
+                                          console.log('deleted '+input);
+                                     }
+                                 });
+                             },
+                             render: {
+                                 option: function (item, escape) {
+                                    console.log(item.name);
+                                    return '<div>' + escape(item.name) + '</div>';
+                                 }
+                             },
+                             load: function (query, callback) {
+                                 if (!query.length) return callback();
+                                 $.ajax({
+                                     type: "GET",
+                                     url: "ignore_search_word_listing",
+                                     contentType: "application/json; charset=utf-8",
+                                     dataType: 'json',
+                                     error: function () {
+                                         callback();
+                                     },
+                                     success: function (res) {
+                                         var rspns = eval(res)
+                                         callback(rspns);
+                                    }
+                                 });
+                             },
+                        });
+                   });
+                });
                 changeTest();
                 initConfigCheckbox("#launch_browser");
                 initConfigCheckbox("#enable_https");

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -74,6 +74,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'FAILED_DOWNLOAD_HANDLING': (bool, 'General', False),
     'FAILED_AUTO': (bool, 'General',False),
     'PREFERRED_QUALITY': (int, 'General', 0),
+    'IGNORE_SEARCH_WORDS': (str, 'General', []),
     'USE_MINSIZE': (bool, 'General', False),
     'MINSIZE': (str, 'General', None),
     'USE_MAXSIZE': (bool, 'General', False),
@@ -813,7 +814,7 @@ class Config(object):
         Given a big bunch of key value pairs, apply them to the ini.
         """
         for name, value in list(kwargs.items()):
-            if not any([(name.startswith('newznab') and name[-1].isdigit()), name.startswith('torznab') and name[-1].isdigit()]):
+            if not any([(name.startswith('newznab') and name[-1].isdigit()), name.startswith('torznab') and name[-1].isdigit(), name == 'ignore_search_words[]']):
                 key, definition_type, section, ini_key, default = self._define(name)
                 if definition_type == str:
                     try:
@@ -1172,6 +1173,18 @@ class Config(object):
                 except Exception as e:
                     logger.warn('[MASS_PUBLISHERS] Unable to convert publishers [%s]. Error returned: %s' % (self.MASS_PUBLISHERS, e))
         logger.info('[MASS_PUBLISHERS] Auto-add for weekly publishers set to: %s' % (self.MASS_PUBLISHERS,))
+
+        if len(self.IGNORE_SEARCH_WORDS) > 0 and self.IGNORE_SEARCH_WORDS != '[]':
+            if type(self.IGNORE_SEARCH_WORDS) != list:
+                try:
+                    self.IGNORE_SEARCH_WORDS = json.loads(self.IGNORE_SEARCH_WORDS)
+                except Exception as e:
+                    logger.warn('unable to load ignored search words')
+        else:
+            setattr(self, 'IGNORE_SEARCH_WORDS', [".exe", ".iso", "pdf-xpost", "pdf", "ebook"])
+            config.set('General', 'ignore_search_words', json.dumps(self.IGNORE_SEARCH_WORDS))
+
+        logger.info('[IGNORE_SEARCH_WORDS] Words to flag search result as invalid: %s' % (self.IGNORE_SEARCH_WORDS,))
 
         if len(self.PROBLEM_DATES) > 0 and self.PROBLEM_DATES != '[]':
             if type(self.PROBLEM_DATES) != list:

--- a/mylar/search_filer.py
+++ b/mylar/search_filer.py
@@ -110,6 +110,15 @@ class search_check(object):
                     except Exception:
                         break
 
+                ignored = []
+                for x in mylar.CONFIG.IGNORE_SEARCH_WORDS:
+                    if x.lower() in ComicTitle.lower():
+                        ignored.append(x)
+
+                if ignored:
+                    logger.fdebug('[IGNORE_SEARCH_WORDS] %s exists within the search result (%s). Ignoring this result.' % (ignored, ComicTitle))
+                    continue
+
                 comsize_m = 0
                 if nzbprov != "dognzb":
                     # rss for experimental doesn't have the size constraints embedded.

--- a/mylar/versioncheck.py
+++ b/mylar/versioncheck.py
@@ -63,13 +63,14 @@ def runGit(args, ptv=None):
         except Exception as e:
             logger.error('Command %s didn\'t work [%s]' % (cmd, e))
             gitworked = False
+            output = None
             continue
         else:
             if all([output.stderr is not None, output.stderr != '', output.returncode > 0]):
                 logger.error('Encountered error: %s' % output.stderr)
                 gitworked = False
 
-        if "not found" in output.stdout or "not recognized as an internal or external command" in output.stdout:
+        if all([gitworked is True, "not found" in output.stdout, "not recognized as an internal or external command" in output.stdout]):
             logger.error('[%s] Unable to find git with command: %s' % (output.stdout, cmd))
             output = None
             gitworked = False

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -8717,6 +8717,34 @@ class WebInterface(object):
         return json.dumps(x)
     get_the_pubs.exposed = True
 
+    def ignore_search_word_listing(self, inputvalue=None, deletevalue=None):
+        ignorelist = []
+        new_list = []
+        deleted = False
+        for ts in mylar.CONFIG.IGNORE_SEARCH_WORDS:
+            #logger.fdebug('ts:%s / inputvalue:%s' % (ts, inputvalue))
+            if ts == deletevalue:
+                deleted = True
+            elif ts != inputvalue:
+                ignorelist.append({"name": ts})
+                new_list.append(ts)
+                #logger.fdebug('inputvalue is to be deleted')
+
+        if any([inputvalue, deletevalue]):
+            if inputvalue:
+                ignorelist.append({"name": inputvalue})
+                new_list.append(inputvalue)
+                mylar.CONFIG.IGNORE_SEARCH_WORDS = new_list
+                return json.dumps({"name": inputvalue})
+            else:
+                mylar.CONFIG.IGNORE_SEARCH_WORDS = new_list
+                return json.dumps({"name": deletevalue})
+
+        mylar.CONFIG.writeconfig(values={'ignore_search_words': json.dumps(new_list)})
+        mylar.CONFIG.IGNORE_SEARCH_WORDS = new_list
+        return json.dumps(ignorelist)
+    ignore_search_word_listing.exposed=True
+
     def list_the_directories(self, foldername=None, iDisplayStart=0, iDisplayLength=25, iSortCol_0='1', sSortDir_0="desc", sSearch="", **kwargs):
         if foldername is None or not os.path.exists(foldername):
              return json.dumps({'status': 'fail', 'message': '%s does not exist - please verify!' % (foldername)})


### PR DESCRIPTION
Added Ignore Words (Search Restrictions) to the configuration page - Quality & Post-Processing.

Default values are set to:  ``.exe, .iso, pdf-xpost, pdf, ebook`` which obviously can be either removed or added to.

This currently only applies to searches atm - could possibly be included for post-processing, but this is the 1st step at least towards that.