### PR TITLE
IMP: User-configurable search tier cutoff, FIX:(#1254) Black & White issues, FIX: CSS series page progress bar

### DIFF
--- a/data/interfaces/carbon/css/style.css
+++ b/data/interfaces/carbon/css/style.css
@@ -1914,6 +1914,38 @@ DIV.progress-container > DIV
 	text-align: center;
 	z-index: 900;
 }
+DIV.series-progress-container
+{
+        position: relative;
+        width: 100px;
+        height: 18px;
+        margin: 2px 5px 2px 2px;
+        -border:1px solid #ccc;
+        background-color: #272b30;
+        background-image: -moz-linear-gradient(top, whiteSmoke, #F9F9F9);
+        background-image: -webkit-gradient(linear, 0 0, 0 100%, from(whiteSmoke), to(#F9F9F9));
+        background-image: -webkit-linear-gradient(top, whiteSmoke, #F9F9F9);
+        background-image: -o-linear-gradient(top, whiteSmoke, #F9F9F9);
+        background-image: linear-gradient(to bottom, whiteSmoke, #F9F9F9);
+        background-repeat: repeat-x;
+        -webkit-border-radius: 4px;
+        -moz-border-radius: 4px;
+        border-radius: 4px;
+        filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff5f5f5', endColorstr='#fff9f9f9', GradientType=0);
+        -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+        -moz-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+        color: #000;
+}
+DIV.series-progress-container > DIV
+{
+        background-color: #0EBEED;
+        height: 18px;
+        -webkit-border-radius: 4px;
+        -moz-border-radius: 4px;
+        text-align: center;
+        z-index: 900;
+}
 .danger > DIV
 {
 	background-color: #DD514C;

--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -97,11 +97,11 @@
                    </fieldset>
                          <%
                                  if comicConfig['percent'] == 101:
-                                         css = '<div class=\"progress-container warning\">'
+                                         css = '<div class=\"series-progress-container warning\">'
                                  if comicConfig['percent'] == 100:
-                                         css = '<div class=\"progress-container complete\">'
+                                         css = '<div class=\"series-progress-container complete\">'
                                  if comicConfig['percent'] < 100:
-                                         css = '<div class=\"progress-container missing\">'
+                                         css = '<div class=\"series-progress-container missing\">'
                           %>
                    <div style="display:table;position:relative;margin:auto;top:0px;"><span title="${comicConfig['percent']}"></span>${css}<div style="width:${comicConfig['percent']}%"><span class="progressbar-front-text">${comicConfig['haveissues']}/${comicConfig['totalissues']}</span></div></div></div>
                    <%

--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -1814,6 +1814,38 @@ DIV.progress-container > DIV
 	text-align: center;
 	z-index: 900;
 }
+DIV.series-progress-container
+{
+        position: relative;
+        width: 100px;
+        height: 18px;
+        margin: 2px 5px 2px 2px;
+        -border:1px solid #ccc;
+        background-color: #272b30;
+        background-image: -moz-linear-gradient(top, whiteSmoke, #F9F9F9);
+        background-image: -webkit-gradient(linear, 0 0, 0 100%, from(whiteSmoke), to(#F9F9F9));
+        background-image: -webkit-linear-gradient(top, whiteSmoke, #F9F9F9);
+        background-image: -o-linear-gradient(top, whiteSmoke, #F9F9F9);
+        background-image: linear-gradient(to bottom, whiteSmoke, #F9F9F9);
+        background-repeat: repeat-x;
+        -webkit-border-radius: 4px;
+        -moz-border-radius: 4px;
+        border-radius: 4px;
+        filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff5f5f5', endColorstr='#fff9f9f9', GradientType=0);
+        -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+        -moz-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+        color: #000;
+}
+DIV.series-progress-container > DIV
+{
+        background-color: #0EBEED;
+        height: 18px;
+        -webkit-border-radius: 4px;
+        -moz-border-radius: 4px;
+        text-align: center;
+        z-index: 900;
+}
 .danger > DIV
 {
 	background-color: #DD514C;

--- a/data/interfaces/default/upcoming.html
+++ b/data/interfaces/default/upcoming.html
@@ -18,6 +18,8 @@
 		<h1 class="clearfix"><img src="${icons['icon_wanted']}" alt="Wanted Issues"/>Wanted Issues (<span id="wanted_count"></span>)</h1>
 	</div>
 
+        <span style="vertical-align: middle;"><small>Tier-1 cutoff length: <span id="cutoff">${mylar.CONFIG.SEARCH_TIER_CUTOFF}</span> days</small></span>
+
         <div id="checkboxControls" name="checkboxControls" style="float: right; vertical-align: middle; margin: 5px 3px 3px 3px;">
          <div style="padding-bottom: 5px;">
              <label for="Wanted" class="checkbox inline Wanted" id="wantedlabel" style="display:none;"><input type="checkbox" name="Wanted" id="Wanted" checked="checked" /> Wanted: <b><span id="wantedcount"></span></b></label>

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -172,7 +172,7 @@ DDL_LOCK = False
 CMTAGGER_PATH = None
 STATIC_COMICRN_VERSION = "1.01"
 STATIC_APC_VERSION = "2.04"
-ISSUE_EXCEPTIONS = ['AU', 'AI', 'INH', 'NOW', 'BEY', 'MU', 'HU', 'LR', 'A', 'B', 'C', 'X', 'O','SUMMER', 'SPRING', 'FALL', 'WINTER', 'PREVIEW', 'ALPHA', 'OMEGA', "DIRECTOR'S CUT", "(DC)"]
+ISSUE_EXCEPTIONS = ['AU', 'AI', 'INH', 'NOW', 'BEY', 'MU', 'HU', 'LR', 'A', 'B', 'C', 'X', 'O', 'BLACK', 'WHITE', 'SUMMER', 'SPRING', 'FALL', 'WINTER', 'PREVIEW', 'ALPHA', 'OMEGA', "DIRECTOR'S CUT", "(DC)"]
 SAB_PARAMS = None
 EXT_IP = None
 PROVIDER_START_ID=0
@@ -299,9 +299,10 @@ def initialize(config_file):
         CURRENT_YEAR = todaydate.strftime("%Y")
 
         if SEARCH_TIER_DATE is None:
-            #tier the wanted listed so anything older than 14 days won't trigger the API during searches.
+            #tier the wanted listed so anything older than SEARCH_TIER_CUTOFF (default 14 days)
+            #won't trigger the API during searches.
             #utc_date = datetime.datetime.utcnow()
-            STD = todaydate - timedelta(days = 14)
+            STD = todaydate - timedelta(days = mylar.CONFIG.SEARCH_TIER_CUTOFF)
             SEARCH_TIER_DATE = STD.strftime('%Y-%m-%d')
             logger.fdebug('SEARCH_TIER_DATE set to : %s' % SEARCH_TIER_DATE)
 

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -109,6 +109,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'FOLDER_CACHE_LOCATION': (str, 'General', None),
     'SCAN_ON_SERIES_CHANGES': (bool, 'General', True),
     'CLEAR_PROVIDER_TABLE': (bool, 'General', False),
+    'SEARCH_TIER_CUTOFF': (int, 'General', 14), # days
 
     'RSS_CHECKINTERVAL': (int, 'Scheduler', 20),
     'SEARCH_INTERVAL': (int, 'Scheduler', 360),
@@ -1295,6 +1296,15 @@ class Config(object):
             if dcreate is False and self.ENABLE_DDL is True:
                 logger.warn('Unable to create ddl_location specified in config: %s. Reverting to default cache location.' % self.DDL_LOCATION)
                 self.DDL_LOCATION = self.CACHE_DIR
+
+        if self.SEARCH_TIER_CUTOFF is None:
+            self.SEARCH_TIER_CUTOFF = 14
+            config.set('General', 'search_tier_cutoff', str(self.SEARCH_TIER_CUTOFF))
+        else:
+            if not str(self.SEARCH_TIER_CUTOFF).isdigit():
+                self.SEARCH_TIER_CUTOFF = 14
+                config.set('General', 'search_tier_cutoff', str(self.SEARCH_TIER_CUTOFF))
+        logger.info('[Search Tier Cutoff] Setting Tier-1 cutoff point to %s days' % self.SEARCH_TIER_CUTOFF)
 
         if self.MODE_32P is False and self.RSSFEED_32P is not None:
             mylar.KEYS_32P = self.parse_32pfeed(self.RSSFEED_32P)

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -677,6 +677,11 @@ class FileChecker(object):
                                               'mod_position': self.char_file_position(modfilename, sf, lastmod_position),
                                               'validcountchk': validcountchk})
 
+                #used to see if the issue is an alpha-numeric (ie. 18.NOW, 50-X, etc)
+                lastissue_position = split_file.index(sf, lastissue_position)
+                lastissue_label = sf
+                lastissue_mod_position = file_length
+
             #now we try to find the series title &/or volume lablel.
             if any( [sf.lower().startswith('v'), sf.lower().startswith('vol'), volumeprior == True, 'volume' in sf.lower(), 'vol' in sf.lower(), 'part' in sf.lower()] ) and sf.lower() not in {'one','two','three','four','five','six'}:
                 if any([ split_file[split_file.index(sf)].isdigit(), split_file[split_file.index(sf)][3:].isdigit(), split_file[split_file.index(sf)][1:].isdigit() ]):

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -1026,6 +1026,13 @@ def issuedigits(issnum):
                     int_issnum = (int(issnum[:-2]) * 1000) + ord('h') + ord('u')
                 else:
                     int_issnum = (int(issnum[:-3]) * 1000) + ord('h') + ord('u')
+            elif 'black' in issnum.lower():
+                remdec = issnum.find('.')  #find the decimal position.
+                if remdec != -1:
+                    issnum = '%s %s' % (issnum[:remdec], issnum[remdec+1:])
+                    #int_issnum = (int(issnum[:-2]) * 1000) + ord('b') + ord('l')
+                #else:
+                #    int_issnum = (int(issnum[:-3]) * 1000) + ord('h') + ord('u')
 
         except ValueError as e:
             logger.error('[' + issnum + '] Unable to properly determine the issue number. Error: %s', e)


### PR DESCRIPTION
- IMP: User-configurable search tier cutoff (config ini field ``search_tier_cutoff``, value in days). Will display cutoff in GUI as well.
- FIX:(#1254) Black & White issues not being properly recognised (works with ``001 Black``, ``001.Black``, ``001Black`` as well as with the ``#`` preceeding the issue number)
- FIX: CSS series page progress-bar fix (if no issues were present in series directory, no progress-bar would display to indicate have / total count)