### PR TITLE
FIX: History page not showing DDL snatches, FIX: GUI notifs not firing on DDL snatches

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -1608,14 +1608,14 @@ def verification(verified_matches, is_info):
                     alt_nzbname=alt_nzbname,
                     oneoff=is_info['oneoff'],
                 )
-                updater.foundsearch(
-                    is_info['ComicID'],
-                    is_info['IssueID'],
-                    mode=is_info['smode'], #'series',
-                    provider=tmpprov,
-                    SARC=is_info['SARC'],
-                    IssueArcID=is_info['IssueArcID']
-                )
+            updater.foundsearch(
+                is_info['ComicID'],
+                is_info['IssueID'],
+                mode=is_info['smode'], #'series',
+                provider=tmpprov,
+                SARC=is_info['SARC'],
+                IssueArcID=is_info['IssueArcID']
+            )
 
             # send out the notifications for the snatch.
             if any([is_info['oneoff'] is True, is_info['IssueID'] is None]):


### PR DESCRIPTION
- FIX: History page not showing items snatched via DDL
- FIX: GUI notifications not firing off when snatches are via DDL (usually)