### PR TITLE
FIX:(#1267) invalid library reference for utorrent module

### DIFF
--- a/mylar/torrent/clients/utorrent.py
+++ b/mylar/torrent/clients/utorrent.py
@@ -1,6 +1,6 @@
 import os
 
-from libs.utorrent.client import UTorrentClient
+from utorrent.client import UTorrentClient
 
 # Only compatible with uTorrent 3.0+
 


### PR DESCRIPTION
seems to be an issue with python version > 3.10.x (reported with 3.10.6)
lower versions of python either ignore the invalid reference or ignore the error and still load the module from the lib folder.