### PR TITLE
IMP: (#1266) getWanted endpoint, FIX: Manage page not showing full annual titles

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -2196,6 +2196,9 @@ class PostProcessor(object):
                                     t_comicname = ml['AnnualSeries']
                                 except Exception:
                                     pass
+                                else:
+                                    if t_annualtype == 'Annual':
+                                        t_annualtype = None
                             t_issuenumber = ml['IssueNumber']
                         else:
                             t_comicname = dspcname

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -396,7 +396,23 @@ class Api(object):
         return
 
     def _getWanted(self, **kwargs):
-        self.data = self._resultsFromQuery("SELECT * from issues WHERE Status='Wanted'")
+        iss_query = "SELECT a.ComicName, a.ComicYear, a.ComicVersion, a.Type as BookType, a.ComicPublisher, a.publisherImprint, b.Issue_Number, b.IssueName, b.ReleaseDate, b.IssueDate, b.DigitalDate, b.Status, b.ComicID, b.IssueID, b.DateAdded from comics as a INNER JOIN issues as b ON a.ComicID = b.ComicID WHERE b.Status='Wanted'"
+        issues = self._resultsFromQuery(iss_query)
+        tmp_data = {'issues': issues}
+        if 'story_arcs' in kwargs and kwargs['story_arcs'] == 'true':
+            if mylar.CONFIG.UPCOMING_STORYARCS is True:
+                arcs_query = "SELECT Storyarc, StoryArcID, IssueArcID, ComicName, IssueNumber, IssueName, ReleaseDate, IssueDate, DigitalDate, Status, ComicID, IssueID, DateAdded from storyarcs WHERE Status='Wanted'"
+                arclist = self._resultsFromQuery(arcs_query)
+                tmp_data2 = {**tmp_data, **{'story_arcs': arclist}}
+                tmp_data = tmp_data2
+
+        if mylar.CONFIG.ANNUALS_ON:
+            annuals_query = "SELECT b.ReleaseComicName as ComicName, a.ComicYear, a.ComicVersion, a.Type as BookType, a.ComicPublisher, a.publisherImprint, a.ComicName as SeriesName, b.Issue_Number as Issue_Number, b.IssueName, b.ReleaseDate, b.IssueDate, b.DigitalDate, b.Status, b.ComicID, b.IssueID, b.ReleaseComicID as SeriesComicID, b.DateAdded FROM comics as a INNER JOIN annuals as b ON a.ComicID = b.ComicID WHERE NOT b.Deleted and b.Status='Wanted'"
+            annuals_list = self._resultsFromQuery(annuals_query)
+            tmp_data2 = {**tmp_data, **{'annuals': annuals_list}}
+            tmp_data = tmp_data2
+
+        self.data = tmp_data
         return
 
     def _getLogs(self, **kwargs):

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -3255,7 +3255,7 @@ class WebInterface(object):
                                         'dateadded': arc['DateAdded']}
 
         if mylar.CONFIG.ANNUALS_ON:
-            annuals_query = "SELECT ComicName, Issue_Number as Issue_Number, ReleaseDate, Status, ComicID, IssueID, DateAdded FROM annuals WHERE NOT Deleted AND %s" % statline
+            annuals_query = "SELECT ReleaseComicName as ComicName, Issue_Number as Issue_Number, ReleaseDate, Status, ComicID, IssueID, DateAdded FROM annuals WHERE NOT Deleted AND %s" % statline
             annuals_list = myDB.select(annuals_query)
 
             issues += annuals_list


### PR DESCRIPTION
- IMP: (#1266) getWanted API endpoint will now return issues and annuals (and story_arcs when queried for)
- FIX: Manage page would not show full annual titles but just the series it was attached to (ie. ``Series`` as opposed to ``Series Annual``)