### PR TITLE
IMP: Set generic default docker paths if not set, FIX: CDH query removals not needed

### DIFF
--- a/mylar/config.py
+++ b/mylar/config.py
@@ -220,7 +220,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'SLACK_ENABLED': (bool, 'SLACK', False),
     'SLACK_WEBHOOK_URL': (str, 'SLACK', None),
     'SLACK_ONSNATCH': (bool, 'SLACK', False),
-    
+
     'MATTERMOST_ENABLED': (bool, 'MATTERMOST', False),
     'MATTERMOST_WEBHOOK_URL': (str, 'MATTERMOST', None),
     'MATTERMOST_ONSNATCH': (bool, 'MATTERMOST', False),
@@ -1099,6 +1099,18 @@ class Config(object):
                 logger.fdebug('[Cache Cleanup] Cache Cleanup finished. Cleaned %s items' % cntr)
             else:
                 logger.fdebug('[Cache Cleanup] Cache Cleanup finished. Nothing to clean!')
+
+        d_path = '/proc/self/cgroup'
+        if os.path.exists('/.dockerenv') or os.path.isfile(d_path) and any('docker' in line for line in open(d_path)):
+            logger.info('[DOCKER-AWARE] Docker installation detected.')
+            mylar.INSTALL_TYPE = 'docker'
+            if any([mylar.CONFIG.DESTINATION_DIR is None, mylar.CONFIG.DESTINATION_DIR == '']):
+                logger.info('[DOCKER-AWARE] Setting default comic location path to /comics')
+                mylar.CONFIG.DESTINATION_DIR = '/comics'
+            if all([mylar.CONFIG.NZB_DOWNLOADER == 0, mylar.CONFIG.SABNZBD_DIRECTORY is None, mylar.CONFIG.SAB_TO_MYLAR is False]):
+                logger.info('[DOCKER-AWARE] Setting default sabnzbd download directory location to /downloads')
+                mylar.CONFIG.SAB_TO_MYLAR = True
+                mylar.CONFIG.SABNZBD_DIRECTORY = '/downloads'
 
         if all([self.GRABBAG_DIR is None, self.DESTINATION_DIR is not None]):
             self.GRABBAG_DIR = os.path.join(self.DESTINATION_DIR, 'Grabbag')

--- a/mylar/sabnzbd.py
+++ b/mylar/sabnzbd.py
@@ -119,7 +119,7 @@ class SABnzbd(object):
                     logger.fdebug('status: %s' % queueinfo['status'])
                     logger.fdebug('mbleft: %s' % queueinfo['mbleft'])
                     logger.fdebug('timeleft: %s' % queueinfo['timeleft'])
-                    logger.fdebug('eta: %s' % queueinfo['eta'])
+                    #logger.fdebug('eta: %s' % queueinfo['eta'])
                     time.sleep(5)
             except Exception as e:
                 logger.warn('error: %s' % e)
@@ -130,10 +130,12 @@ class SABnzbd(object):
     def historycheck(self, nzbinfo, roundtwo=False):
         sendresponse = nzbinfo['nzo_id']
         hist_params = {'mode':      'history',
-                       'category':  mylar.CONFIG.SAB_CATEGORY,
                        'failed':    0,
                        'output':    'json',
                        'apikey':    mylar.CONFIG.SAB_APIKEY}
+
+        if mylar.CONFIG.SAB_CATEGORY is not None:
+            hist_params['category'] = mylar.CONFIG.SAB_CATEGORY
 
         sab_check = None
         if mylar.CONFIG.SAB_VERSION is None:

--- a/mylar/versioncheck.py
+++ b/mylar/versioncheck.py
@@ -187,6 +187,9 @@ def getVersion(ptv):
         if os.path.exists('/.dockerenv') or os.path.isfile(d_path) and any('docker' in line for line in open(d_path)):
             logger.info('[DOCKER-AWARE] Docker installation detected.')
             mylar.INSTALL_TYPE = 'docker'
+            if any([mylar.CONFIG.DESTINATION_DIR is None, mylar.CONFIG.DESTINATION_DIR == '']):
+                logger.info('[DOCKER-AWARE] Setting default comic location path to /comics')
+                mylar.CONFIG.DESTINATION_DIR = '/comics'
         else:
             logger.info('Not a Docker installation.')
             mylar.INSTALL_TYPE = 'source'


### PR DESCRIPTION
- IMP: set default docker paths for Comic Location (``/comics``) and SABnzbd Download directory (``/downloads``) (if not set)
- FIX: CDH category removal if not present when querying SABnzbd history
- FIX: remove eta variable from sabnzbd response as no longer supported (and wasn't really used)