### PR TITLE
FIX:  imprint field being used within Folder Format string causing extra spaces

### DIFF
--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -167,6 +167,12 @@ class FileHandlers(object):
         ccf = chunk_folder_format.find('\ ')
         if ccf != -1:
             chunk_folder_format = chunk_folder_format[:ccf+1] + chunk_folder_format[ccf+2:]
+        ccf = chunk_folder_format.find(' /')
+        if ccf != -1:
+            chunk_folder_format = chunk_folder_format[:ccf] + chunk_folder_format[ccf+1:]
+        ccf = chunk_folder_format.find(' \\')
+        if ccf != -1:
+            chunk_folder_format = chunk_folder_format[:ccf] + chunk_folder_format[ccf+1:]
 
         chunk_folder_format = re.sub(r'\s+', ' ', chunk_folder_format)
 


### PR DESCRIPTION
if $Imprint is used at the same directory level as other fields (ie. ``$Publisher - $Imprint/$Series...``), and the imprint doesn't exist - an extra space would remain which creates a directory structure that's not the intended one.