### PR TITLE
FIX: adding series with legacy numbering (issue number in brackets)

### DIFF
--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -1574,7 +1574,11 @@
                            "targets": [1],
                            "visible": true,
                            "render": function (data,type,full){
-                               return full[0];
+                               if (full[12]){
+                                   return '<span title="Legacy numbering #' + full[12] + '">' + full[0] + '*</span>';
+                               } else {
+                                   return full[0];
+                               }
                            }
                        },
                        {
@@ -1744,6 +1748,7 @@
                          //[9] = digitaldate;
                          //[10] = storedate;
                          //[11] = secondary;
+                         //[12] = alt_issuenumber;
                          return nRow;
                      },
                      "drawCallback": function (settings) {

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -1094,6 +1094,10 @@ def issuedigits(issnum):
                 except ValueError:
                     #logger.fdebug('This has no issue # for me to get - Either a Graphic Novel or one-shot.')
                     int_issnum = 999999999999999
+            elif all([ '[' in issnum, ']' in issnum ]):
+                issnum_tmp = issnum.find('[')
+                int_issnum = int(issnum[:issnum_tmp].strip()) * 1000
+                legacy_num = issnum[issnum_tmp+1:issnum.find(']')]
             else:
                 try:
                     x = float(issnum)

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -1030,6 +1030,7 @@ def issue_collection(issuedata, nostatus, serieslast_updated=None):
                             "ReleaseDate":        issue['ReleaseDate'],
                             "DigitalDate":        issue['DigitalDate'],
                             "Int_IssueNumber":    issue['Int_IssueNumber'],
+                            "AltIssueNumber":     issue['AltIssueNumber'],
                             "ImageURL":           issue['ImageURL'],
                             "ImageURL_ALT":       issue['ImageURL_ALT']
                             #"Status":             "Skipped"  #set this to Skipped by default to avoid NULL entries.
@@ -1254,6 +1255,7 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
     latestissueid = None
     firstiss = "10000000"
     firstdate = "2099-00-00"
+    legacy_num = None
     #print ("total issues:" + str(iscnt))
     logger.info('Now adding/updating issues for ' + comicname)
 
@@ -1337,12 +1339,16 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
                         logger.fdebug('Trailing decimal located within issue number. Irrelevant to numbering. Obliterating.')
                         issaftdec = issaftdec[:-1]
                     try:
-#                        int_issnum = str(issnum)
+                        #int_issnum = str(issnum)
                         int_issnum = (int(issb4dec) * 1000) + (int(issaftdec) * 10)
                     except ValueError:
                         logger.error('This has no issue # for me to get - Either a Graphic Novel or one-shot.')
                         updater.no_searchresults(comicid)
                         return {'status': 'failure'}
+                elif all([ '[' in issnum, ']' in issnum ]):
+                    issnum_tmp = issnum.find('[')
+                    int_issnum = int(issnum[:issnum_tmp].strip()) * 1000
+                    legacy_num = issnum[issnum_tmp+1:issnum.find(']')]
                 else:
                     try:
                         x = float(issnum)
@@ -1479,6 +1485,7 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
                               "ReleaseDate":        storedate,
                               "DigitalDate":        digitaldate,
                               "Int_IssueNumber":    int_issnum,
+                              "AltIssueNumber":     legacy_num,
                               "ImageURL":           firstval['Image'],
                               "ImageURL_ALT":       firstval['ImageALT']})
 

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -704,6 +704,7 @@ class WebInterface(object):
                            'Location': issue_location,
                            'Secondary': secondary,
                            'Issue_Number': x['Issue_Number'],
+                           'AltIssueNumber': x['AltIssueNumber'],
                            'IssueDate': x['IssueDate'],
                            'DigitalDate': x['DigitalDate'],
                            'ReleaseDate': x['ReleaseDate'],
@@ -735,7 +736,7 @@ class WebInterface(object):
                 rows = filtered[iDisplayStart:(iDisplayStart + iDisplayLength)]
             else:
                 rows = filtered
-            rows = [[row['Issue_Number'], row['IssueName'], row['IssueDate'], row['Status'], row['IssueID'], row['Location'], row['ComicSize'], row['ComicID'], row['ComicName'], row['DigitalDate'], row['ReleaseDate'], row['Secondary']] for row in rows]
+            rows = [[row['Issue_Number'], row['IssueName'], row['IssueDate'], row['Status'], row['IssueID'], row['Location'], row['ComicSize'], row['ComicID'], row['ComicName'], row['DigitalDate'], row['ReleaseDate'], row['Secondary'], row['AltIssueNumber']] for row in rows]
         else:
             rows = []
 


### PR DESCRIPTION
Issue table (series detail page) will display issue as per CV (ie. ``9 [5]``) - but will have a ``*`` beside it which will show a hovertip indicating that the issue also has legacy numbering.