### PR TITLE
IMP:(#1285) Change StoryArc base folder location via config.ini (storyarc_location)

### DIFF
--- a/data/interfaces/default/storyarc.html
+++ b/data/interfaces/default/storyarc.html
@@ -54,7 +54,7 @@
                      <legend>Global StoryArc Options</legend>
                          <div class="row checkbox left clearfix">
                          <%
-                             storyarcdest = os.path.join(mylar.CONFIG.DESTINATION_DIR, 'StoryArcs')
+                             storyarcdest = mylar.CONFIG.STORYARC_LOCATION
                          %>
                              <input type="checkbox" style="vertical-align: middle; margin: 3px; margin-top: -1px;" onclick="getOption(this)" name="storyarcdir" id="storyarcdir" value="1" ${checked(mylar.CONFIG.STORYARCDIR)} /><label>Arcs in StoryArc Directory </br><small>(${storyarcdest})</small></label>
                          </div>

--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -2158,6 +2158,7 @@ class PostProcessor(object):
                             dspcyear = ml['SeriesYear']
                             annualtype = ml['AnnualType']
                             issuenumOG = ml['IssueNumber']
+                            logger.info('%s[STORY-ARC] Manual post-processing completed for %s issue belonging to %s' % (module, len(manual_arclist), ml['StoryArc']))
                     except Exception:
                         dspcname = None
                         dspcyear = None
@@ -2237,8 +2238,11 @@ class PostProcessor(object):
                                 logger.info('%s direct post-processing of issue completed for %s.' % (module, t_comicname))
                                 global_line = 'Successfully post-processed</br> %s' % (t_comicname)
                     else:
-                        logger.info('%s Manual post-processing completed for %s issues.' % (module, i))
-                        global_line = 'Manual post-processing completed for %s issues' % (i)
+                        if i == 0 and len(manual_arclist) >=1:
+                            global_line = 'Successfully post-processed</br> %s storyarc issues' % len(manual_arclist)
+                        else:
+                            logger.info('%s Manual post-processing completed for %s issues.' % (module, i))
+                            global_line = 'Manual post-processing completed for %s issues' % (i)
                         m_event = 'scheduler_message'
                         dspcname = None
                         dspcyear = None

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -324,6 +324,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'TAB_DIRECTORY': (str, 'Tablet', None),
 
     'STORYARCDIR': (bool, 'StoryArc', False),
+    'STORYARC_LOCATION': (str, 'StoryArc', None),
     'COPY2ARCDIR': (bool, 'StoryArc', False),
     'ARC_FOLDERFORMAT': (str, 'StoryArc', '$arc ($spanyears)'),
     'ARC_FILEOPS': (str, 'StoryArc', 'copy'),
@@ -1070,6 +1071,19 @@ class Config(object):
                 os.makedirs(self.BACKUP_LOCATION)
             except OSError:
                 logger.error('[Backup Location Check] Could not create backup directory. Check permissions for creation of : %s' % self.BACKUP_LOCATION)
+
+
+        if self.STORYARCDIR is True:
+            if not self.STORYARC_LOCATION:
+                self.STORYARC_LOCATION = os.path.join(self.DESTINATION_DIR, 'StoryArcs')
+
+            if not os.path.exists(self.STORYARC_LOCATION):
+                try:
+                    os.makedirs(self.STORYARC_LOCATION)
+                except OSError as e:
+                    logger.error('[STORYARC LOCATION] Could not create storyarcs directory @ %s. Error returned: %s' % (self.STORYARC_LOCATION, e))
+
+            logger.info('[STORYARC LOCATION] Storyarc Base directory location set to: %s' % (self.STORYARC_LOCATION))
 
         #make sure the cookies.dat file is not in cache
         for f in glob.glob(os.path.join(self.CACHE_DIR, '.32p_cookies.dat')):

--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -452,7 +452,10 @@ class FileHandlers(object):
                 if mylar.CONFIG.REPLACE_SPACES:
                     arcdir = arcdir.replace(' ', mylar.CONFIG.REPLACE_CHAR)
                 if mylar.CONFIG.STORYARCDIR:
-                    storyarcd = os.path.join(mylar.CONFIG.DESTINATION_DIR, "StoryArcs", arcdir)
+                    if mylar.CONFIG.STORYARC_LOCATION is None:
+                        storyarcd = os.path.join(mylar.CONFIG.DESTINATION_DIR, "StoryArcs", arcdir)
+                    else:
+                        storyarcd = os.path.join(mylar.CONFIG.STORYARC_LOCATION, arcdir)
                     logger.fdebug('Story Arc Directory set to : ' + storyarcd)
                 else:
                     logger.fdebug('Story Arc Directory set to : ' + mylar.CONFIG.GRABBAG_DIR)

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -367,7 +367,10 @@ def rename_param(comicid, comicname, issue, ofilename, comicyear=None, issueid=N
                 if mylar.CONFIG.REPLACE_SPACES:
                     arcdir = arcdir.replace(' ', mylar.CONFIG.REPLACE_CHAR)
                 if mylar.CONFIG.STORYARCDIR:
-                    storyarcd = os.path.join(mylar.CONFIG.DESTINATION_DIR, "StoryArcs", arcdir)
+                    if mylar.CONFIG.STORYARC_LOCATION is None:
+                        storyarcd = os.path.join(mylar.CONFIG.DESTINATION_DIR, "StoryArcs", arcdir)
+                    else:
+                        storyarcd = os.path.join(mylar.CONFIG.STORYARC_LOCATION, arcdir)
                     logger.fdebug('Story Arc Directory set to : ' + storyarcd)
                 else:
                     logger.fdebug('Story Arc Directory set to : ' + mylar.CONFIG.GRABBAG_DIR)
@@ -2815,7 +2818,10 @@ def arcformat(arc, spanyears, publisher):
         arcpath = arcpath[2:]
 
     if mylar.CONFIG.STORYARCDIR is True:
-        dstloc = os.path.join(mylar.CONFIG.DESTINATION_DIR, 'StoryArcs', arcpath)
+        if mylar.CONFIG.STORYARC_LOCATION is None:
+            dstloc = os.path.join(mylar.CONFIG.DESTINATION_DIR, 'StoryArcs', arcpath)
+        else:
+            dstloc = os.path.join(mylar.CONFIG.STORYARC_LOCATION, arcpath)
     elif mylar.CONFIG.COPY2ARCDIR is True:
         logger.warn('Story arc directory is not configured. Defaulting to grabbag directory: ' + mylar.CONFIG.GRABBAG_DIR)
         dstloc = os.path.join(mylar.CONFIG.GRABBAG_DIR, arcpath)

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -994,8 +994,8 @@ class WebInterface(object):
             try:
                 searchresults = mb.findComic(name, smode, issue=issue)
                 searchline = {'findComic': True, 'name': name, 'mode': smode, 'issue': issue, 'searchtype': 'comic'}
-            except TypeError:
-                logger.error('Unable to perform required pull-list search for : [name: ' + name + '][issue: ' + issue + '][mode: ' + smode + ']')
+            except TypeError as e:
+                logger.error('[%s] Unable to perform required pull-list search for : [name: %s][issue: %s][mode:%s]' % (e, name, issue, smode))
                 return
         elif search_type == 'comic' and smode == 'series':
             if name.startswith('4050-'):
@@ -7004,7 +7004,10 @@ class WebInterface(object):
 
         #force the check/creation of directory com_location here
         if mylar.CONFIG.STORYARCDIR is True:
-            arcdir = os.path.join(mylar.CONFIG.DESTINATION_DIR, 'StoryArcs')
+            if mylar.CONFIG.STORYARC_LOCATION is not None:
+                arcdir = mylar.CONFIG.STORYARC_LOCATION
+            else:
+                arcdir = os.path.join(mylar.CONFIG.DESTINATION_DIR, 'StoryArcs')
             if os.path.isdir(arcdir):
                 logger.info('Validating Directory (%s). Already exists! Continuing...' % arcdir)
             else:


### PR DESCRIPTION
This is not a retroactive option, if enabled it takes effect from the change point forward.

If you manually change the ``storyarc_location`` variable in the config.ini to a different location, you will have to:
- manually move the storyarc folder in it's entirety to the new location specified in the ini
- refresh each storyarc so that it can pull in the new location (otherwise it will report the wrong file locations to issues belonging to an arc)
** this last part I might try to automate a patch for, but atm - it has to be manual