### PR TITLE
FIX:(#1277) invalid issue numbering with Alpha & Omega during rename

### DIFF
--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -172,7 +172,31 @@ DDL_LOCK = False
 CMTAGGER_PATH = None
 STATIC_COMICRN_VERSION = "1.01"
 STATIC_APC_VERSION = "2.04"
-ISSUE_EXCEPTIONS = ['AU', 'AI', 'INH', 'NOW', 'BEY', 'MU', 'HU', 'LR', 'A', 'B', 'C', 'X', 'O', 'BLACK', 'WHITE', 'SUMMER', 'SPRING', 'FALL', 'WINTER', 'PREVIEW', 'ALPHA', 'OMEGA', "DIRECTOR'S CUT", "(DC)"]
+ISSUE_EXCEPTIONS = [
+    'ALPHA',
+    'OMEGA',
+    'BLACK',
+    'AU',
+    'AI',
+    'INH',
+    'NOW',
+    'BEY',
+    'MU',
+    'HU',
+    'LR',
+    'A',
+    'B',
+    'C',
+    'X',
+    'O',
+    'WHITE',
+    'SUMMER',
+    'SPRING',
+    'FALL',
+    'WINTER',
+    'PREVIEW',
+    "DIRECTOR'S CUT",
+    "(DC)"]
 SAB_PARAMS = None
 EXT_IP = None
 PROVIDER_START_ID=0

--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -510,8 +510,11 @@ class FileHandlers(object):
 #                       issue_except = '.NOW'
 
                     issue_except = iss_space + issexcept
-                    logger.fdebug('issue_except denoted as : ' + issue_except)
-                    issuenum = re.sub("[^0-9]", "", issuenum)
+                    logger.fdebug('issue_except denoted as : %s' % issue_except)
+                    if issuenum.lower() != issue_except.lower():
+                        issuenum = re.sub("[^0-9]", "", issuenum)
+                        if any([issuenum == '', issuenum is None]):
+                            issuenum = issue_except
                     break
 
 #            if 'au' in issuenum.lower() and issuenum[:1].isdigit():

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -426,8 +426,11 @@ def rename_param(comicid, comicname, issue, ofilename, comicyear=None, issueid=N
 #                       issue_except = '.NOW'
 
                     issue_except = iss_space + issexcept
-                    logger.fdebug('issue_except denoted as : ' + issue_except)
-                    issuenum = re.sub("[^0-9]", "", issuenum)
+                    logger.fdebug('issue_except denoted as : %s' % issue_except)
+                    if issuenum.lower() != issue_except.lower():
+                        issuenum = re.sub("[^0-9]", "", issuenum)
+                        if any([issuenum == '', issuenum is None]):
+                            issuenum = issue_except
                     break
 
 #            if 'au' in issuenum.lower() and issuenum[:1].isdigit():


### PR DESCRIPTION
issue_exceptions in ini needs to have longest words starting with single letter matches first as opposed to last (or after, so ALPHA needs to come before A).

Tested with rename in GUI - should be the same for post-processing as it follows the same logistics with matching as above.