### PR TITLE
Tweaked Issue ID parsing on import to handle additional numbers in metadata Notes field

### DIFF
--- a/mylar/librarysync.py
+++ b/mylar/librarysync.py
@@ -363,18 +363,12 @@ def libraryScan(dir=None, append=False, ComicID=None, ComicName=None, cron=None,
                                 # if used by ComicTagger, Notes field will have the IssueID.
                                 issuenotes = issueinfo['metadata']['notes']
                                 logger.fdebug('[IMPORT-CBZ] Notes: ' + issuenotes)
+                                # Attempt to parse the first set of consecutive numbers after either CVDB or Issue ID
                                 if issuenotes is not None and issuenotes != 'None':
-                                    if 'Issue ID' in issuenotes:
-                                        st_find = issuenotes.find('Issue ID')
-                                        tmp_issuenotes_id = re.sub("[^0-9]", " ", issuenotes[st_find:]).strip()
-                                        if tmp_issuenotes_id.isdigit():
-                                            issuenotes_id = tmp_issuenotes_id
-                                            logger.fdebug('[IMPORT-CBZ] Successfully retrieved CV IssueID for ' + comicname + ' #' + issue_number + ' [' + str(issuenotes_id) + ']')
-                                    elif 'CVDB' in issuenotes:
-                                        st_find = issuenotes.find('CVDB')
-                                        tmp_issuenotes_id = re.sub("[^0-9]", " ", issuenotes[st_find:]).strip()
-                                        if tmp_issuenotes_id.isdigit():
-                                            issuenotes_id = tmp_issuenotes_id
+                                    issue_id = re.search("(CVDB|Issue ID)[^0-9]*([0-9]*)", issuenotes)
+                                    if issue_id:
+                                        if issue_id.groups()[1].isdigit():
+                                            issuenotes_id = issue_id.groups()[1]
                                             logger.fdebug('[IMPORT-CBZ] Successfully retrieved CV IssueID for ' + comicname + ' #' + issue_number + ' [' + str(issuenotes_id) + ']')
                                     else:
                                         logger.fdebug('[IMPORT-CBZ] Unable to retrieve IssueID from meta-tagging. If there is other metadata present I will use that.')


### PR DESCRIPTION
My attempt to squash a very niche bug.  I had a bunch of comics with some very old scraper comments where there were numbers (in this case dates) later in the Notes field than the CVDBID / Issue ID.  The current parsing method did not account for this, so would not recognise the Issue ID correctly.  This change just uses a different regex approach to look for the first set of consecutive numbers following either "Issue ID" or "CVDB".  I've allowed it to ignore any characters between those prefixes and the ID in case there's some odd spacing/separators for some reason.

Example of Notes field that would fail on parsing the ID:
`Scraped metadata from ComicVine [CVDB196459] on 2011.05.20 08:41:41.`

The old method would strip this down to `196459 2011 05 20 08 41 41` and decide it wasn't a digit field.