### PR TITLE
FIX: rechecking Story-Arc directory fails on missing issue numbers

### DIFF
--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5163,7 +5163,11 @@ class WebInterface(object):
                         for tmpfc in valids: #filelist:
                             haveissue = "no"
                             issuedupe = "no"
-                            temploc = tmpfc['issue_number'].replace('_', ' ')
+                            temploc = tmpfc['issue_number']
+                            if temploc:
+                                temploc = temploc.replace('_', ' ')
+                            else:
+                                logger.debug('could not parse issue number: %r', tmpfc)
                             fcdigit = helpers.issuedigits(arc['IssueNumber'])
                             int_iss = helpers.issuedigits(temploc)
                             if int_iss == fcdigit:


### PR DESCRIPTION
The "Search for Missing Search for Watchlist matches/Recheck Files" button throws an error when a file in the story-arc dir doesn't have an issue number (e.g. one-shots). The exception thrown:

     File "/app/mylar3/mylar/logger.py", line 337, in new_run
       old_run(*args, **kwargs)
     File "/usr/lib/python3.10/threading.py", line 953, in run
       self._target(*self._args, **self._kwargs)
     File "/app/mylar3/mylar/webserve.py", line 1581, in addStoryArc
       self.ArcWatchlist(storyarcid)
     File "/app/mylar3/mylar/webserve.py", line 5166, in ArcWatchlist
       temploc = tmpfc['issue_number'].replace('_', ' ')
    'NoneType' object has no attribute 'replace'