### PR TITLE
Updated to use glob + logging for output

### DIFF
--- a/utilities/look4untaggedcbzs.py
+++ b/utilities/look4untaggedcbzs.py
@@ -1,14 +1,22 @@
+from lib2to3.pgen2.token import NEWLINE
 import sys
 import zipfile
 import os
 import subprocess
 from zipfile import BadZipFile
+from pathlib import Path
 
-results = subprocess.run(['find', '.', '-iname', '*.cbz'], universal_newlines = True, stdout=subprocess.PIPE)
+results = Path().cwd().glob('**/*.cbz')
+file1 = open("notags.txt", "a")
+file2 = open("badzip.txt", "a")
 
-for result in results.stdout.splitlines():
+
+for result in results:
     tagged = 0
-    target_zip = str(result)
+    # with pathlib your result is always going to be
+    # a path object
+    # making this unnecessary
+    target_zip = result
 #    print("file: %s" % target_zip)
     try:
         with zipfile.ZipFile(target_zip) as zip_file:
@@ -16,12 +24,18 @@ for result in results.stdout.splitlines():
                 if 'ComicInfo.xml' in member:
                     tagged = 1
             if tagged == 0:
-                print("Filename %s is not metatagged" % target_zip)
+                print('Filename %s is not metatagged' % target_zip)
+                stuff= f'Filename {target_zip} is not metatagged' + os.linesep 
+                file1.write(stuff)
             elif tagged == 1:
                 next
 #                print("filename %s is correctly metatagged" % target_zip)
             else:
                 print("Something's not right! %s" % target_zip)
     except BadZipFile:
-        print("%s is a bad zipfile!" % target_zip)        
+        print("%s is a bad zipfile!" % target_zip)      
+        badstuff= f'{target_zip} is a bad zipfile' + os.linesep 
+        file2.write(badstuff)
 
+file1.close()
+file2.close()


### PR DESCRIPTION
Using glob to walk the files now instead of find. Shaved 2+ minutes off running time compared to old script on a library of 100k files. 

Original:
real    3m27.720s
user    1m9.223s
sys     0m14.013s

Updated:
real    1m12.167s
user    1m7.907s
sys     0m4.241s

Also just adds basic texts files for the output so you don't have to watch the terminal output.

