### PR TITLE
FIX:(#1179) allow for POST method on pages where large amounts of data is being sent

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -1712,7 +1712,7 @@
              </tr>
         </table>
     </div>	
-        <input type="button" value="Save Changes" onclick="doAjaxCall('configUpdate',$(this),'tabs',true);return false;" data-success="Changes saved successfully">
+        <input type="button" value="Save Changes" onclick="doAjaxCall('configUpdate',$(this),'tabs',true,'post');return false;" data-success="Changes saved successfully">
         <div class="message">
         	<p><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span>Web Interface changes require a restart to take effect</p>
 	</div>

--- a/data/interfaces/default/history.html
+++ b/data/interfaces/default/history.html
@@ -22,9 +22,9 @@
 		<h1 class="clearfix"><img src="images/icon_history.png" alt="History"/>History</h1>
 	</div>
 
-        <form action="markissues" method="get" id="markissues">
+        <form action="markissues" method="post" id="markissues">
             <div id="markissue">Mark selected issues as
-                <select name="action" onChange="doAjaxCall('markissues',$(this),'table',true);" data-success="selected issues marked">
+                <select name="action" onChange="doAjaxCall('markissues',$(this),'table',true,'post');" data-success="selected issues marked">
                         <option disabled="disabled" selected="selected">Choose...</option>
                         <option value="Retry">Retry</option>
                         <option value="Clear">Clear</option>

--- a/data/interfaces/default/importresults.html
+++ b/data/interfaces/default/importresults.html
@@ -65,9 +65,9 @@
           </div>
      <div class="table_wrapper">
 
-        <form action="markImports" method="get" id="markImports">
+        <form action="markImports" method="post" id="markImports">
         <div id="markcomic">
-                <select name="action" onChange="doAjaxCall('markImports',$(this),'table',true);" data-success="Now running background Import" data-error="You didn't select any comics">
+                <select name="action" onChange="doAjaxCall('markImports',$(this),'table',true,'post');" data-success="Now running background Import" data-error="You didn't select any comics">
                         <option disabled="disabled" selected="selected">Choose...</option>
                         <option value="importselected">Start Import</option>
                         <option value="removeimport">Remove</option>

--- a/data/interfaces/default/managecomics.html
+++ b/data/interfaces/default/managecomics.html
@@ -17,9 +17,9 @@
 	<div id="manageheader" class="title">
 		<h1 class="clearfix">Manage comics</h1>
 	</div>
-	<form action="markComics" method="get" id="markComics">
+	<form action="markComics" method="post" id="markComics">
         <div id="markcomics" style="top:0;">
-		<select name="action" onChange="doAjaxCall('markComics',$(this),'table',true);" data-error="You didn't select any comics">
+		<select name="action" onChange="doAjaxCall('markComics',$(this),'table',true,'post');" data-error="You didn't select any comics">
   			<option disabled="disabled" selected="selected">Choose...</option>
   			<option value="delete">Delete Series</option>
                         <option value="metatag">MetaTag Series</option>

--- a/data/interfaces/default/manageissues.html
+++ b/data/interfaces/default/manageissues.html
@@ -18,7 +18,7 @@
 		<h1 class="clearfix">Manage Issues</h1>
 	</div>
 
-        <form action="manageIssues" method="get">
+        <form action="manageIssues" method="post">
         <div>
             <label>Manage Issues with Status&nbsp&nbsp</label><select name="status">
                         %for curStatus in ['Wanted', 'Downloaded', 'Snatched', 'Skipped', 'Archived', 'Ignored', 'Failed']:
@@ -35,9 +35,9 @@
         </div>
         </form>
         </br></br>
-	<form action="markissues" method="get" id="markissues">
+	<form action="markissues" method="post" id="markissues">
         <div id="markissues" style="top:0;">
-		<select name="action" onChange="doAjaxCall('markissues',$(this),'table',true);" data-error="You didn't select any issues">
+		<select name="action" onChange="doAjaxCall('markissues',$(this),'table',true,'post');" data-error="You didn't select any issues">
   			<option disabled="disabled" selected="selected">Choose...</option>
   			<option value="Wanted">Wanted</option>
   			<option value="Archived">Archived</option>

--- a/data/js/script.js
+++ b/data/js/script.js
@@ -138,7 +138,7 @@ function showMsg(msg,loader,timeout,ms) {
 	}
 }
 
-function doAjaxCall(url,elem,reload,form) {
+function doAjaxCall(url,elem,reload,form,method) {
 	// Set Message
 	feedback = $("#ajaxMsg");
 	update = $("#updatebar");
@@ -154,7 +154,13 @@ function doAjaxCall(url,elem,reload,form) {
 	var formID = "#"+url;
 	if ( form == true ) {
 		var dataString = $(formID).serialize();
+                if ( !method ) {
+                    method = 'get';
+                }
+                // jquery > 1.9.0 has 'type' set as an alias for 'method' for backwards compatibility.
+                //alert('method used:'+method);
 	}
+
 	// Loader Image
 	var loader = $("<img src='images/loader_black.gif' alt='loading' class='loader'/>");
 	// Data Success Message
@@ -194,6 +200,7 @@ function doAjaxCall(url,elem,reload,form) {
 	// Ajax Call
 	$.ajax({
 	  url: url,
+          type: method,
 	  data: dataString,
 	  beforeSend: function(jqXHR, settings) {
 	  	// Start loader etc.


### PR DESCRIPTION
This allows for the last variable in the doAjaxCall method in script.js to hold either ``'post'`` or ``'get'`` to indicate the type of ajax request to be made. 

If no method is provided (as most of the calls don't need to change), it will default to ``'get'`` (which is what it is currently).

ie. ``doAjaxCall('markissues',$(this),'table',true,'post')``.

jQuery > 1.9 has an alias for ``method``, which is ``type`` and is used by jQuery < 1.9  - so using ``type`` should be good enough to not break anything until we upgrade jQuery everywhere (and then we should switch to using ``method``).
