### PR TITLE
FIX:(#1321) imprints would take json naming convention over CV

### DIFF
--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -208,6 +208,13 @@ SSE_KEY = None
 SESSION_ID = None
 UPDATE_VALUE = {}
 REQS = {}
+IMPRINT_MAPPING = {
+    #ComicVine: imprint.json
+    'Homage': 'Homage Comics',
+    'Mailbu': 'Malibu Comics',
+    'Milestone': 'Milestone Comics',
+    'Skybound': 'Skybound Entertainment',
+    'Top Cow': 'Top Cow Productions'}
 SCHED = BackgroundScheduler({
                              'apscheduler.executors.default': {
                                  'class':  'apscheduler.executors.pool:ThreadPoolExecutor',

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -156,6 +156,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'CV_ONETIMER': (bool, 'CV', True),
     'CVINFO': (bool, 'CV', False),
     'CV_USER_AGENT': (str, 'CV', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246'),
+    'IMPRINT_MAPPING_TYPE': (str, 'CV', 'CV'),  # either 'CV' for ComicVine or 'JSON' for imprints.json to choose which naming to use for imprints
 
     'LOG_DIR' : (str, 'Logs', None),
     'MAX_LOGSIZE' : (int, 'Logs', 10000000),

--- a/mylar/cv.py
+++ b/mylar/cv.py
@@ -1579,10 +1579,23 @@ def get_imprint_volume_and_booktype(series, comicyear, publisher, firstissueid, 
                                                 found = True
                                                 break
                                     elif all([f != 'imprints', f != 'publication_run']) and h is not None and found is not True:
-                                        if h.lower() == comic['ComicPublisher'].lower():
-                                            logger.info('imprint matched: %s ---> %s' % (d, h))
-                                            comicPublisher = d
-                                            publisherImprint = h
+                                        imprint_match = False
+                                        for x, y in mylar.IMPRINT_MAPPING.items():
+                                            if all([
+                                                y.lower() == h.lower(),
+                                                x.lower() == comic['ComicPublisher'].lower()
+                                            ]):
+                                                imprint_match = True
+                                                break
+
+                                        if h.lower() == comic['ComicPublisher'].lower() or imprint_match is True:
+                                            if mylar.CONFIG.IMPRINT_MAPPING_TYPE == 'CV':
+                                                comicPublisher = d
+                                                publisherImprint = comic['ComicPublisher']
+                                            else:
+                                                comicPublisher = d
+                                                publisherImprint = h
+                                            logger.fdebug('imprint matching: [PRIORITY:%s] %s ---> %s' % (mylar.CONFIG.IMPRINT_MAPPING_TYPE, comicPublisher, publisherImprint))
                                             chkyear = True
                                             found = True
 


### PR DESCRIPTION
This will set the default behavior for the imprints aspect to take the CV naming convention over the imprints.json naming.

The imprint mappings that can be over-ridden are stored as a global variable in the __init__.py as a dictionary called ``IMPRINT_MAPPING``. If future mappings are needed, just add in the info and things should keep on trucking.

Given that some might want to use one or the other, a config.ini option ``imprint_mapping_type`` is now available. The choices are: ``CV`` - use CV imprint naming convention (this is the default)
``JSON`` - use the imprint.json naming convention over CV

This will only affect things going forward - might revisit it to go retroactively if alot got caught in the wrong naming schematic.
