### PR TITLE
FIX: During import, if title contained One-Shot - would not find the match on CV

### DIFF
--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6090,7 +6090,8 @@ class WebInterface(object):
 
                 mode='series'
                 displaycomic = helpers.filesafe(ComicName)
-                displaycomic = re.sub('[\-]','', displaycomic).strip()
+                if 'one-shot' not in displaycomic.lower():
+                    displaycomic = re.sub('[\-]','', displaycomic).strip()
                 displaycomic = re.sub('\s+', ' ', displaycomic).strip()
                 logger.fdebug('[IMPORT] displaycomic : %s' % displaycomic)
                 logger.fdebug('[IMPORT] comicname : %s' % ComicName)


### PR DESCRIPTION
basically if series title contained ``One-Shot``, the ``-`` in the title was being stripped and because the query to CV to find matches is somewhat strict it was failing to match against ``One-Shot``. 

Stupid, but fixed now.