### PR TITLE
FIX: When determining match to download, TPB series spanning multiple years would fail to match

### DIFF
--- a/mylar/search_filer.py
+++ b/mylar/search_filer.py
@@ -729,10 +729,19 @@ class search_check(object):
                                    booktype == 'HC',
                                    booktype == 'GN',
                                ]
-                            ) and (
-                                int(F_ComicVersion) == int(findcomiciss)
-                                and filecomic['justthedigits'] is None
-                        ):
+                            ) and any([
+                               all(
+                               [
+                                   int(F_ComicVersion) == int(findcomiciss)
+                                   and filecomic['justthedigits'] is None
+                               ]
+                            ), all(
+                               [
+                                   int(F_ComicVersion) == int(findcomiciss)
+                                   and ComicYear == parsed_comic['issue_year']
+                               ]
+                            )
+                        ]):
                             logger.fdebug(
                                 '%s detected - reassigning volume %s to match as the'
                                 ' issue number based on Volume'


### PR DESCRIPTION
When it determines a search match, and it's a TPB/GN/One-Shot - it takes the series year as being the only acceptable year for a match. 

Which is fine if there's only one volume/issue on CV for that particular comicid. 

However, if multiple volumes are listed under one comicid and it falls under the TPB/GN - it would fail to match if the issue year was different than the series year.

This fix just allows it to match the issue year of the volume of the TPB correctly.