### PR TITLE
FIX: When Alternate FileName field is blank, it writes a blank space

### DIFF
--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -392,7 +392,7 @@
                                 %endif
                                 <div class="row">
                                     <label>Volume Number</label>
-                                    <input type="text" name="comic_version" value="${comic['ComicVersion']}" size="20">
+                                    <input type="text" name="comic_version" placeholder="${comic['ComicVersion']}" onfocus="if(this.value==this.defaultValue) this.value='';" value="${comic['ComicVersion']}" size="20">
 				    <small>Format: vN where N is a number 0-infinity</small>
                                 </div>
 
@@ -404,21 +404,21 @@
 
                                    <div class="row">
                                        <label>Alternate Search Names</label>
-                                       <input type="text" name="alt_search" value="${comic['AlternateSearch']}" size="90" />
-                                       <a href="#" title="Seperate multiple entries with ##"><img src="images/info32.png" height="16" alt="" /></a>
+                                       <input type="text" name="alt_search" placeholder="${comic['AlternateSearch']}" onfocus="if(this.value==this.defaultValue) this.value='';" value="${comic['AlternateSearch']}" size="90" />
+                                       <a href="#" title="Seperate multiple entries with ##"><img src="images/info32.png" height="16" alt=""></a>
                                        <small>Alternate comic names to be searched in case naming is different<small>
                                    </div>
 
                                    <div class="row">
                                        <label>Alternate File-Naming</label>
-                                       <input type="text" name="alt_filename" value="${comic['AlternateFileName']}" size="90">
-                                       <a href="#" title="Alternate File Naming"><img src="images/info32.png" height="16" alt="" /></a>
+                                       <input type="text" name="alt_filename" placeholder="${comic['AlternateFileName']}" onfocus="if(this.value==this.defaultValue) this.value='';" value="${comic['AlternateFileName']}" size="90">
+                                       <a href="#" title="Alternate File Naming"><img src="images/info32.png" height="16" alt=""></a>
                                        <small>Use this insetad of CV name during post-processing / renaming</small>
                                    </div>
 
                                    <div class="row">
                                        <label>Publication Imprint</label>
-                                       <input type="text" name="publisher_imprint" value="${comic['PublisherImprint']}" size="90">
+                                       <input type="text" name="publisher_imprint" placeholder="${comic['PublisherImprint']}" onfocus="if(this.value==this.defaultValue) this.value='';" value="${comic['PublisherImprint']}" size="90">
                                    </div>
 
                                    <div class="row">

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6868,7 +6868,10 @@ class WebInterface(object):
             newValues['AgeRating'] = age_rating
 
         if all([publisher_imprint is not None, publisher_imprint != 'None', publisher_imprint != '']):
-            newValues['PublisherImprint'] = publisher_imprint
+            if re.sub(r'\s', '', publisher_imprint) == '':
+                newValues['PublisherImprint'] = 'None'
+            else:
+                newValues['PublisherImprint'] = publisher_imprint
         else:
             newValues['PublisherImprint'] = 'None'
 
@@ -6915,10 +6918,13 @@ class WebInterface(object):
 
         newValues['TorrentID_32P'] = torrentid_32p
 
-        if alt_filename is None or alt_filename == 'None':
-            newValues['AlternateFileName'] = "None"
+        if alt_filename is not None:
+            if re.sub(r'\s', '', alt_filename) == '':
+                newValues['AlternateFileName'] = "None"
+            else:
+                newValues['AlternateFileName'] = str(alt_filename)
         else:
-            newValues['AlternateFileName'] = str(alt_filename)
+            newValues['AlternateFileName'] = "None"
 
         #force the check/creation of directory com_location here
         updatedir = True


### PR DESCRIPTION
Sets a default placeholder for some of the Edit Settings fields to ensure that they're not just blank.

Added blank space check for publisher imprint and alternate filename when saving the settings for a series. Just an attempt to make sure that if it's a space, it's not saved as that.

Also added in some code to throw some additional error logging when running external scripts.