### PR TITLE
FIX:urllib3 breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,5 @@ requests>=2.22.0
 simplejson>=3.17.0
 six>=1.13.0
 tzlocal>=2.0.0
-urllib3>=1.25.7
+urllib3<2
 user_agent2>=2021.12.11


### PR DESCRIPTION
Urllib3 recently had some breaking changes that breaks installation on docker (and possibly others).

This forces urllib3 to use the latest build under v2, since v2 has the breaking changes. 

This all might be caused by cfscrape which is used, but not in any capacity outside of mimicking requests (since the CF aspect is broken and the module is abandoned) 