### PR TITLE
FIX: various import fixes (overdue school report)

### DIFF
--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -1660,7 +1660,9 @@ def annual_check(ComicName, SeriesYear, comicid, issuetype, issuechk, annualslis
             for manchk in annload:
                 if manchk['ReleaseComicID'] is not None or manchk['ReleaseComicID'] is not None:  #if it exists, then it's a pre-existing add
                     #print str(manchk['ReleaseComicID']), comic['ComicName'], str(SeriesYear), str(comicid)
-                    annualslist += manualAnnual(manchk['ReleaseComicID'], ComicName, SeriesYear, comicid, manualupd=True, deleted=manchk['Deleted'])
+                    tmp_the_annuals = manualAnnual(manchk['ReleaseComicID'], ComicName, SeriesYear, comicid, manualupd=True, deleted=manchk['Deleted'])
+                    if tmp_the_annuals:
+                        annualslist += tmp_the_annuals
                 annualids.append(manchk['ReleaseComicID'])
 
         annualcomicname = re.sub('[\,\:]', '', ComicName)

--- a/mylar/librarysync.py
+++ b/mylar/librarysync.py
@@ -188,7 +188,14 @@ def libraryScan(dir=None, append=False, ComicID=None, ComicName=None, cron=None,
         #use the comicname_filesafe to start
         watchdisplaycomic = watch['ComicName']
         # let's clean up the name, just in case for comparison purposes...
-        watchcomic = re.sub('[\_\#\,\/\:\;\.\-\!\$\%\&\+\'\?\@]', '', watch['ComicName_Filesafe'])
+        try:
+            watchcomic = re.sub('[\_\#\,\/\:\;\.\-\!\$\%\&\+\'\?\@]', '', watch['ComicName_Filesafe'])
+        except Exception as e:
+            logger.warn('[IMPORT] Unable to properly retrieve series name from watchlist.'
+                        ' This is due most likely to previous problems refreshing/adding the seriess %s [error: %s]'
+                         % (watch['ComicName_Filesafe'], e)
+            )
+            continue
         #watchcomic = re.sub('\s+', ' ', str(watchcomic)).strip()
 
         if ' the ' in watchcomic.lower():

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6026,27 +6026,33 @@ class WebInterface(object):
                         comicstoIMP.append(result['ComicLocation']) #.decode(mylar.SYS_ENCODING, 'replace'))
                         getiss = result['IssueNumber']
                         #logger.fdebug('getiss: %s' % getiss)
-                        if 'annual' in getiss.lower():
-                            tmpiss = re.sub('[^0-9]','', getiss).strip()
-                            if any([tmpiss.startswith('19'), tmpiss.startswith('20')]) and len(tmpiss) == 4:
-                                logger.fdebug('[IMPORT] annual detected with no issue [%s]. Skipping this entry for determining series length.' % getiss)
-                                continue
+                        if getiss is None:
+                            logger.fdebug('[IMPORT] Unable to determine a valid issue number. The import process will currrently only work'
+                                          'with filenames that have an issue number in it. Ignoring this filename for import (you should'
+                                          'probably move it manually. [%s]' % result['ComicLocation'])
+                            continue
                         else:
-                            if (result['ComicYear'] not in yearRANGE) or all([yearRANGE is None, yearRANGE == 'None']):
-                                if result['ComicYear'] != "0000" and result['ComicYear'] is not None:
-                                    yearRANGE.append(str(result['ComicYear']))
-                                    yearTOP = str(result['ComicYear'])
-                            getiss_num = helpers.issuedigits(getiss)
-                            miniss_num = helpers.issuedigits(minISSUE)
-                            startiss_num = helpers.issuedigits(startISSUE)
-                            if int(getiss_num) > int(miniss_num):
-                                logger.fdebug('Minimum issue now set to : %s - it was %s' % (getiss, minISSUE))
-                                minISSUE = getiss
-                            if int(getiss_num) < int(startiss_num):
-                                logger.fdebug('Start issue now set to : %s - it was %s' % (getiss, startISSUE))
-                                startISSUE = str(getiss)
-                                if helpers.issuedigits(startISSUE) == 1000 and result['ComicYear'] is not None:  # if it's an issue #1, get the year and assume that's the start.
-                                    startyear = result['ComicYear']
+                            if 'annual' in getiss.lower():
+                                tmpiss = re.sub('[^0-9]','', getiss).strip()
+                                if any([tmpiss.startswith('19'), tmpiss.startswith('20')]) and len(tmpiss) == 4:
+                                    logger.fdebug('[IMPORT] annual detected with no issue [%s]. Skipping this entry for determining series length.' % getiss)
+                                    continue
+                            else:
+                                if (result['ComicYear'] not in yearRANGE) or all([yearRANGE is None, yearRANGE == 'None']):
+                                    if result['ComicYear'] != "0000" and result['ComicYear'] is not None:
+                                        yearRANGE.append(str(result['ComicYear']))
+                                        yearTOP = str(result['ComicYear'])
+                                getiss_num = helpers.issuedigits(getiss)
+                                miniss_num = helpers.issuedigits(minISSUE)
+                                startiss_num = helpers.issuedigits(startISSUE)
+                                if int(getiss_num) > int(miniss_num):
+                                    logger.fdebug('Minimum issue now set to : %s - it was %s' % (getiss, minISSUE))
+                                    minISSUE = getiss
+                                if int(getiss_num) < int(startiss_num):
+                                    logger.fdebug('Start issue now set to : %s - it was %s' % (getiss, startISSUE))
+                                    startISSUE = str(getiss)
+                                    if helpers.issuedigits(startISSUE) == 1000 and result['ComicYear'] is not None:  # if it's an issue #1, get the year and assume that's the start.
+                                        startyear = result['ComicYear']
 
                 #taking this outside of the transaction in an attempt to stop db locking.
                 if mylar.CONFIG.IMP_MOVE and movealreadyonlist == "yes":


### PR DESCRIPTION
Should address / make usable (amongst others): #1336, #1232, #1231, #873
FIX: Import would fail when importing a filename with no issue number
FIX: Incomplete series would cause post-processing to fail if Latest Date and Publication Run were not generated
FIX: If annual gathering failed during generation, would break the add series queue
FIX: Import would fail if a series on the watchlist was being refreshed during, or if it hadn't completed for w/e reason