### PR TITLE
Fall back to webpage for newer ComicTagger versions

### DIFF
--- a/mylar/librarysync.py
+++ b/mylar/librarysync.py
@@ -380,6 +380,17 @@ def libraryScan(dir=None, append=False, ComicID=None, ComicName=None, cron=None,
                                     else:
                                         logger.fdebug('[IMPORT-CBZ] Unable to retrieve IssueID from meta-tagging. If there is other metadata present I will use that.')
 
+                                # If this doesn't work, we can fall back to try and parse from the webpage
+                                webpage = issueinfo['metadata']['webpage']
+                                logger.fdebug('[IMPORT-CBZ] Webpage: ' + webpage)
+                                if webpage is not None and webpage != 'None' and issuenotes_id is None:
+                                    issue_id = webpage.strip('/').split('/')[-1].split('-')[-1]
+                                    if issue_id:
+                                        issuenotes_id = issue_id
+                                        logger.fdebug('[IMPORT-CBZ] Successfully retrieved CV IssueID for ' + comicname + ' #' + issue_number + ' [' + str(issuenotes_id) + ']')
+                                    else:
+                                        logger.fdebug('[IMPORT-CBZ] Unable to retrieve IssueID from meta-tagging. If there is other metadata present I will use that.')
+
                                 logger.fdebug('[IMPORT-CBZ] Adding ' + comicname + ' to the import-queue!')
                                 #impid = comicname + '-' + str(issueyear) + '-' + str(issue_number) #com_NAME + "-" + str(result_comyear) + "-" + str(comiss)
                                 impid = str(random.randint(1000000,99999999))

--- a/mylar/librarysync.py
+++ b/mylar/librarysync.py
@@ -383,7 +383,7 @@ def libraryScan(dir=None, append=False, ComicID=None, ComicName=None, cron=None,
                                 # If this doesn't work, we can fall back to try and parse from the webpage
                                 webpage = issueinfo['metadata']['webpage']
                                 logger.fdebug('[IMPORT-CBZ] Webpage: ' + webpage)
-                                if webpage is not None and webpage != 'None' and issuenotes_id is None:
+                                if webpage is not None and webpage != 'None' and 'comicvine.gamespot.com' in webpage and issuenotes_id is None:
                                     issue_id = webpage.strip('/').split('/')[-1].split('-')[-1]
                                     if issue_id:
                                         issuenotes_id = issue_id


### PR DESCRIPTION
Newer comictagger versions don't add an [Issue ID XXXXXX] to the notes part of metadata. This adds a fallback if not found, to pull the issue ID instead from the webpage (if possible)