### PR TITLE
FIX #1361: Use shutil.move to support cross-device renames

### DIFF
--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6944,7 +6944,7 @@ class WebInterface(object):
                             logger.fdebug('making directory: %s' % os.path.split(com_location)[0])
                             os.mkdir(os.path.split(com_location)[0])
                         logger.info('Renaming directory: %s --> %s' % (orig_location,com_location))
-                        os.rename(orig_location, com_location)
+                        shutil.move(orig_location, com_location)
                     except Exception as e:
                         if 'No such file or directory' in e:
                             checkdirectory = filechecker.validateAndCreateDirectory(com_location, True)


### PR DESCRIPTION
`os.rename` does not support cross-device renames and `shutil.move` should be used instead to support cross-device renames. 

Relevant documentation: https://docs.python.org/3/library/os.html#os.rename