### PR TITLE
getcomics: correct logging call

### DIFF
--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -920,7 +920,7 @@ class GC(object):
                                 f.flush()
 
         except requests.exceptions.Timeout as e:
-            logger.error('[ERROR] download has timed out due to inactivity...' % e)
+            logger.error('[ERROR] download has timed out due to inactivity...: %s', e)
             mylar.DDL_LOCK = False
             return {"success": False, "filename": filename, "path": None}
 


### PR DESCRIPTION
When hitting a `ConnectionError`, I observed the following in my log:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/mylar3/mylar/logger.py", line 337, in new_run
    old_run(*args, **kwargs)
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/app/mylar3/mylar/helpers.py", line 3241, in ddl_downloader
    ddzstat = ddz.downloadit(item['id'], item['link'], item['mainlink'], item['resume'], item['issueid'], remote_filesize)
  File "/app/mylar3/mylar/getcomics.py", line 923, in downloadit
    logger.error('[ERROR] download has timed out due to inactivity...' % e)
TypeError: not all arguments converted during string formatting
```

This caused the DDL lock to never be released, requiring me to restart Mylar3 for any direct downloads to occur.

This commit corrects that `TypeError`, allowing exception handling to continue as it should (and so releasing the lock).