### PR TITLE
getcomics: support fetching all search results using pagination

### DIFF
--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -372,9 +372,7 @@ class GC(object):
         resultlist = []
         soup = BeautifulSoup(page_html, 'html.parser')
 
-        resultline = soup.find("span", {"class": "cover-article-count"}).get_text(
-            strip=True
-        )
+        articles = soup.findAll("article")
         page_list = soup.find("ul", {"class": "page-numbers"})
         # A single-page result has "NO MORE ARTICLES" instead of numbers
         page_no = total_pages = "1"
@@ -386,9 +384,9 @@ class GC(object):
             if current_page_span is not None:
                 page_no = current_page_span.text
 
-        logger.info('There are %s results on page %s (of %s)', re.sub('Articles', '', resultline).strip(), page_no, total_pages)
+        logger.info('There are %d results on page %s (of %s)', len(articles), page_no, total_pages)
 
-        for f in soup.findAll("article"):
+        for f in articles:
             id = f['id']
             lk = f.find('a')
             link = lk['href']

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -345,7 +345,7 @@ class GC(object):
         next_url = self.url
         results = []
         while next_url is not None:
-            pause_the_search = mylar.CONFIG.DDL_QUERY_DELAY #mylar.search.check_the_search_delay()
+            pause_the_search = mylar.CONFIG.DDL_QUERY_DELAY
             diff = mylar.search.check_time(self.provider_stat['lastrun']) # only limit the search queries - the other calls should be direct and not as intensive
             if diff < pause_the_search:
                 logger.warn('[PROVIDER-SEARCH-DELAY][DDL] Waiting %s seconds before we search again...' % (pause_the_search - int(diff)))
@@ -524,7 +524,12 @@ class GC(object):
 
             logger.fdebug('%s [%s]' % (title, size))
 
-        return resultlist, None
+        older_posts_a = soup.find("a", class_="pagination-older")
+        next_page = None
+        if older_posts_a is not None:
+            next_page = older_posts_a.get("href")
+
+        return resultlist, next_page
 
     def parse_downloadresults(self, id, mainlink, comicinfo=None):
         try:

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -255,7 +255,7 @@ class GC(object):
 
                 page_html = fetch_page()
 
-                for x in self.search_results(page_html)['entries']:
+                for x in self.parse_search_result(page_html):
                     bb = next((item for item in resultset if item['link'] == x['link']), None)
                     try:
                         if 'Weekly' not in self.query['comicname'] and 'Weekly' in x['title']:
@@ -366,8 +366,7 @@ class GC(object):
                     f.write(chunk)
                     f.flush()
 
-    def search_results(self, page_html):
-        results = {}
+    def parse_search_result(self, page_html):
         resultlist = []
         soup = BeautifulSoup(page_html, 'html.parser')
 
@@ -523,8 +522,7 @@ class GC(object):
 
             logger.fdebug('%s [%s]' % (title, size))
 
-        results['entries'] = resultlist
-        return results
+        return resultlist
 
     def parse_downloadresults(self, id, mainlink, comicinfo=None):
         try:

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -229,26 +229,31 @@ class GC(object):
                     continue
 
                 logger.fdebug('[DDL-QUERY] Query set to: %s' % queryline)
-                pause_the_search = mylar.CONFIG.DDL_QUERY_DELAY #mylar.search.check_the_search_delay()
-                diff = mylar.search.check_time(self.provider_stat['lastrun']) # only limit the search queries - the other calls should be direct and not as intensive
-                if diff < pause_the_search:
-                    logger.warn('[PROVIDER-SEARCH-DELAY][DDL] Waiting %s seconds before we search again...' % (pause_the_search - int(diff)))
-                    time.sleep(pause_the_search - int(diff))
-                else:
-                    logger.fdebug('[PROVIDER-SEARCH-DELAY][DDL] Last search took place %s seconds ago. We\'re clear...' % (int(diff)))
 
-                gc_url = self.url
-                page_html = self.session.get(
-                    gc_url + '/',
-                    params={'s': queryline},
-                    verify=True,
-                    headers=self.headers,
-                    timeout=(30,10)
-                ).text
+                def fetch_page():
+                    pause_the_search = mylar.CONFIG.DDL_QUERY_DELAY #mylar.search.check_the_search_delay()
+                    diff = mylar.search.check_time(self.provider_stat['lastrun']) # only limit the search queries - the other calls should be direct and not as intensive
+                    if diff < pause_the_search:
+                        logger.warn('[PROVIDER-SEARCH-DELAY][DDL] Waiting %s seconds before we search again...' % (pause_the_search - int(diff)))
+                        time.sleep(pause_the_search - int(diff))
+                    else:
+                        logger.fdebug('[PROVIDER-SEARCH-DELAY][DDL] Last search took place %s seconds ago. We\'re clear...' % (int(diff)))
 
-                write_time = time.time()
-                mylar.search.last_run_check(write={'DDL(GetComics)': {'id': 200, 'active': True, 'lastrun': write_time, 'type': 'DDL', 'hits': self.provider_stat['hits']+1}})
-                self.provider_stat['lastrun'] = write_time
+                    gc_url = self.url
+                    page_html = self.session.get(
+                        gc_url + '/',
+                        params={'s': queryline},
+                        verify=True,
+                        headers=self.headers,
+                        timeout=(30,10)
+                    ).text
+
+                    write_time = time.time()
+                    mylar.search.last_run_check(write={'DDL(GetComics)': {'id': 200, 'active': True, 'lastrun': write_time, 'type': 'DDL', 'hits': self.provider_stat['hits']+1}})
+                    self.provider_stat['lastrun'] = write_time
+                    return page_html
+
+                page_html = fetch_page()
 
                 for x in self.search_results(page_html)['entries']:
                     bb = next((item for item in resultset if item['link'] == x['link']), None)

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -154,8 +154,6 @@ class GC(object):
 
         self.oneoff = oneoff
 
-        self.local_filename = os.path.join(mylar.CONFIG.CACHE_DIR, "getcomics.html")
-
         self.search_format = ['"%s #%s (%s)"', '%s #%s (%s)', '%s #%s', '%s %s']
 
         self.headers = {
@@ -227,6 +225,9 @@ class GC(object):
                             else:
                                 queryline = sf % (self.query['comicname'])
 
+                if not queryline:
+                    continue
+
                 logger.fdebug('[DDL-QUERY] Query set to: %s' % queryline)
                 pause_the_search = mylar.CONFIG.DDL_QUERY_DELAY #mylar.search.check_the_search_delay()
                 diff = mylar.search.check_time(self.provider_stat['lastrun']) # only limit the search queries - the other calls should be direct and not as intensive
@@ -236,29 +237,20 @@ class GC(object):
                 else:
                     logger.fdebug('[PROVIDER-SEARCH-DELAY][DDL] Last search took place %s seconds ago. We\'re clear...' % (int(diff)))
 
-                if queryline:
-                    gc_url = self.url
-                    #logger.fdebug('session cookies: %s' % (self.session.cookies,))
-                    t = self.session.get(
-                        gc_url + '/',
-                        params={'s': queryline},
-                        verify=True,
-                        headers=self.headers,
-                        stream=True,
-                        timeout=(30,10)
-                    )
+                gc_url = self.url
+                page_html = self.session.get(
+                    gc_url + '/',
+                    params={'s': queryline},
+                    verify=True,
+                    headers=self.headers,
+                    timeout=(30,10)
+                ).text
 
-                    write_time = time.time()
-                    mylar.search.last_run_check(write={'DDL(GetComics)': {'id': 200, 'active': True, 'lastrun': write_time, 'type': 'DDL', 'hits': self.provider_stat['hits']+1}})
-                    self.provider_stat['lastrun'] = write_time
+                write_time = time.time()
+                mylar.search.last_run_check(write={'DDL(GetComics)': {'id': 200, 'active': True, 'lastrun': write_time, 'type': 'DDL', 'hits': self.provider_stat['hits']+1}})
+                self.provider_stat['lastrun'] = write_time
 
-                    with open(self.local_filename, 'wb') as f:
-                        for chunk in t.iter_content(chunk_size=1024):
-                           if chunk:  # filter out keep-alive new chunks
-                                f.write(chunk)
-                                f.flush()
-
-                for x in self.search_results()['entries']:
+                for x in self.search_results(page_html)['entries']:
                     bb = next((item for item in resultset if item['link'] == x['link']), None)
                     try:
                         if 'Weekly' not in self.query['comicname'] and 'Weekly' in x['title']:
@@ -369,10 +361,10 @@ class GC(object):
                     f.write(chunk)
                     f.flush()
 
-    def search_results(self):
+    def search_results(self, page_html):
         results = {}
         resultlist = []
-        soup = BeautifulSoup(open(self.local_filename, encoding='utf-8'), 'html.parser')
+        soup = BeautifulSoup(page_html, 'html.parser')
 
         resultline = soup.find("span", {"class": "cover-article-count"}).get_text(
             strip=True


### PR DESCRIPTION
This series of commits refactors the fetching of getcomics results pages into a separate method, and implements iterating through all of the search result pages.

I've tested this locally using Fantastic Four (2018) #3. It has a year mismatch between Mylar and GC, so the query which returns it is "Fantastic Four #3" which has enough results that it falls onto the second page. With trunk, the issue isn't found; with this branch, it is.

(I've broken the refactor down into logical commits, so reviewing commit-by-commit may make your life easier!)