### PR TITLE
FIX: Update configuration screen to allow for requests[socks] in requirements.txt

### DIFF
--- a/mylar/req_test.py
+++ b/mylar/req_test.py
@@ -78,7 +78,11 @@ class Req(object):
                                 p_version = str(line[p_test+2:]).strip()
                                 if p_version == '':
                                     continue
-                                self.req_list.append({'module': p_mod, 'version': p_version, 'arg': p_arg})
+                                if p_mod == 'requests[socks]':
+                                    self.req_list.append({'module': 'requests', 'version': '2.22', 'arg': '>='})
+                                    self.req_list.append({'module': 'PySocks', 'version': '1.5', 'arg': '>='})
+                                else:
+                                    self.req_list.append({'module': p_mod, 'version': p_version, 'arg': p_arg})
                                 break
 
         self.pip_load()


### PR DESCRIPTION
Configuration screen would indicate pip failure due to requests[socks] requirement change regardless of if it was installed or not.