### PR TITLE
getcomics: handle literal-HTML descriptions which occasionally occur

### DIFF
--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -462,10 +462,18 @@ class GC(object):
                 ):
                     continue
 
-            option_find = f.find("p", {"style": "text-align: center;"})
+            needle_style = "text-align: center;"
+            option_find = f.find("p", {"style": needle_style})
             i = 0
             if option_find is None:
-                continue
+                # Some search results have the "option_find" HTML as escaped
+                # text instead of actual HTML: try to salvage a option_find in
+                # that case
+                excerpt = f.find("p", class_="post-excerpt")
+                if excerpt is not None and needle_style in excerpt.text:
+                    option_find = BeautifulSoup(excerpt.text, "html.parser").find("p", {"style": needle_style})
+                else:
+                    continue
             while i <= 2 and option_find is not None:
                 option_find = option_find.findNext(text=True)
                 if 'Year' in option_find:

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -466,44 +466,43 @@ class GC(object):
             i = 0
             if option_find is None:
                 continue
-            else:
-                while i <= 2 and option_find is not None:
-                    option_find = option_find.findNext(text=True)
-                    if 'Year' in option_find:
-                        year = option_find.findNext(text=True)
-                        year = re.sub(r'\|', '', year).strip()
-                        if pack is True:
-                            title = re.sub(r'\(' + year + r'\)', '', title).strip()
-                    else:
-                        size = option_find.findNext(text=True)
+            while i <= 2 and option_find is not None:
+                option_find = option_find.findNext(text=True)
+                if 'Year' in option_find:
+                    year = option_find.findNext(text=True)
+                    year = re.sub(r'\|', '', year).strip()
+                    if pack is True:
+                        title = re.sub(r'\(' + year + r'\)', '', title).strip()
+                else:
+                    size = option_find.findNext(text=True)
+                    if all(
+                        [
+                            re.sub(':', '', size).strip() != 'Size',
+                            len(re.sub(r'[^0-9]', '', size).strip()) > 0,
+                        ]
+                    ):
                         if all(
-                            [
-                                re.sub(':', '', size).strip() != 'Size',
-                                len(re.sub(r'[^0-9]', '', size).strip()) > 0,
-                            ]
+                                  [
+                                      '-' in size,
+                                      re.sub(r'[^0-9]', '', size).strip() == '',
+                                  ]
                         ):
-                            if all(
-                                      [
-                                          '-' in size,
-                                          re.sub(r'[^0-9]', '', size).strip() == '',
-                                      ]
-                            ):
-                                size = None
-                            if 'MB' in size:
-                                size = re.sub('MB', 'M', size).strip()
-                            if 'GB' in size:
-                                size = re.sub('GB', 'G', size).strip()
-                            if '//' in size:
-                                nwsize = size.find('//')
-                                size = re.sub(r'\[', '', size[:nwsize]).strip()
-                            elif '/' in size:
-                                nwsize = size.find('/')
-                                size = re.sub(r'\[', '', size[:nwsize]).strip()
-                            if '-' in size:
-                                size = None
-                        else:
-                            size = '0M'
-                    i += 1
+                            size = None
+                        if 'MB' in size:
+                            size = re.sub('MB', 'M', size).strip()
+                        if 'GB' in size:
+                            size = re.sub('GB', 'G', size).strip()
+                        if '//' in size:
+                            nwsize = size.find('//')
+                            size = re.sub(r'\[', '', size[:nwsize]).strip()
+                        elif '/' in size:
+                            nwsize = size.find('/')
+                            size = re.sub(r'\[', '', size[:nwsize]).strip()
+                        if '-' in size:
+                            size = None
+                    else:
+                        size = '0M'
+                i += 1
             dateline = f.find('time')
             datefull = dateline['datetime']
             datestamp = time.mktime(time.strptime(datefull, "%Y-%m-%d"))


### PR DESCRIPTION
I've run into issues on GC which have the short description HTML escaped
and so appearing as normal text: this means that it isn't queryable
using `.find`.  This commit detects that case and creates a new
`BeautifulSoup` object for the escaped HTML, and then searches it.

I've seen this fix searching for Batman (2016) issue 12, as it has such a
description.

(This is another PR with a dedent, so I recommend reviewing this with `?w=1` appended to the GitHub URL or `-w` passed to `git diff`.)