### PR TITLE
config: remove unused ALLOW_PACKS configuration options

### DIFF
--- a/mylar/config.py
+++ b/mylar/config.py
@@ -353,13 +353,11 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'ENABLE_TORRENTS': (bool, 'Torrents', False),
     'ENABLE_TORRENT_SEARCH': (bool, 'Torrents', False),
     'MINSEEDS': (int, 'Torrents', 0),
-    'ALLOW_PACKS': (bool, 'Torrents', False),
     'ENABLE_PUBLIC': (bool, 'Torrents', False),
     'PUBLIC_VERIFY': (bool, 'Torrents', True),
 
     'ENABLE_DDL': (bool, 'DDL', False),
     'ENABLE_GETCOMICS': (bool, 'DDL', False),
-    'ALLOW_PACKS': (bool, 'DDL', False),
     'PACK_PRIORITY': (bool, 'DDL', False),
     'DDL_QUERY_DELAY': (int, 'DDL', 15),
     'DDL_LOCATION': (str, 'DDL', None),


### PR DESCRIPTION
These are not referenced anywhere, and the DDL definition overrides the Torrents definition.

Furthermore, as they default to false, they give a confusing impression of what Mylar will do by examining the config file, where you will see:

```
[DDL]
allow_packs = False
```

but Mylar will happily download packs regardless.  (Guess who was just confused by this while making my other pack-related change. :p)