### PR TITLE
manage: add Queues section to Activity/Jobs tab

### DIFF
--- a/data/interfaces/default/manage.html
+++ b/data/interfaces/default/manage.html
@@ -306,6 +306,7 @@
                            %endfor
                         </tbody>
            </table>
+           </br><small><center>Workers are only started if your config requires them. The DDL worker can be restarted <a href="/queueManage">here</a>: other workers require a restart of Mylar to repair.</center></small>
         </div>
 
 

--- a/data/interfaces/default/manage.html
+++ b/data/interfaces/default/manage.html
@@ -281,11 +281,12 @@
                         <thead>
                            <tr border="1">
                                 <th style="width: 50px;text-align: center;">Queue Name</th>
+                                <th style="width: 50px;text-align: center;">Queue Length</th>
                                 <th style="width: 50px;text-align: center;">Worker Up/Down</th>
                            </tr>
                         </thead>
                         <tbody>
-                           %for q_name, is_up in queues.items():
+                           %for q_name, (is_up, length) in queues.items():
                               <%
                                     if is_up:
                                         text = "Up"
@@ -299,6 +300,7 @@
                                %>
                               <tr>
                                 <td style="width: 50px;text-align: center;">${q_name}</td>
+                                <td style="width: 50px;text-align: center;">${length}</td>
                                 <td style="width: 50px;text-align: center;color:${grade}">${text}</td>
                               </tr>
                            %endfor

--- a/data/interfaces/default/manage.html
+++ b/data/interfaces/default/manage.html
@@ -286,17 +286,20 @@
                         </thead>
                         <tbody>
                            %for q_name, is_up in queues.items():
+                              <%
+                                    if is_up:
+                                        text = "Up"
+                                        grade = '#7AEE52'
+                                    elif is_up is not None:
+                                        text = "Down"
+                                        grade = '#EC7564'
+                                    else:
+                                        text = "Never Started"
+                                        grade = '#52A9EE'
+                               %>
                               <tr>
                                 <td style="width: 50px;text-align: center;">${q_name}</td>
-                                <td style="width: 50px;text-align: center;">
-                                %if is_up:
-                                    Up
-                                %elif is_up is not None:
-                                    Down
-                                %else:
-                                    Never Started
-                                %endif
-                                </td>
+                                <td style="width: 50px;text-align: center;color:${grade}">${text}</td>
                               </tr>
                            %endfor
                         </tbody>

--- a/data/interfaces/default/manage.html
+++ b/data/interfaces/default/manage.html
@@ -274,6 +274,33 @@
                         </tbody>
            </table>
            </br><small><center>There could be up to a 60s delay in a given scheduler running due to other processes currently running</center></small>
+           <br/>
+           <table summary="Queue Status" width="100%" cellpadding="6px" cellspacing="2px">
+                      <legend><center><h1>Queues<h1><center></legend>
+                      <br />
+                        <thead>
+                           <tr border="1">
+                                <th style="width: 50px;text-align: center;">Queue Name</th>
+                                <th style="width: 50px;text-align: center;">Worker Up/Down</th>
+                           </tr>
+                        </thead>
+                        <tbody>
+                           %for q_name, is_up in queues.items():
+                              <tr>
+                                <td style="width: 50px;text-align: center;">${q_name}</td>
+                                <td style="width: 50px;text-align: center;">
+                                %if is_up:
+                                    Up
+                                %elif is_up is not None:
+                                    Down
+                                %else:
+                                    Never Started
+                                %endif
+                                </td>
+                              </tr>
+                           %endfor
+                        </tbody>
+           </table>
         </div>
 
 

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -3963,13 +3963,13 @@ class WebInterface(object):
                             'status': status})
             jobresults = tmp
         queues = {
-            queue_name: thread_obj.is_alive() if thread_obj is not None else None
-            for (queue_name, thread_obj) in [
-                ("AUTO-COMPLETE-NZB", mylar.NZBPOOL),
-                ("AUTO-SNATCHER", mylar.SNPOOL),
-                ("DDL-QUEUE", mylar.DDLPOOL),
-                ("POST-PROCESS-QUEUE", mylar.PPPOOL),
-                ("SEARCH-QUEUE", mylar.SEARCHPOOL),
+            queue_name: (thread_obj.is_alive() if thread_obj is not None else None, queue.qsize())
+            for (queue_name, thread_obj, queue) in [
+                ("AUTO-COMPLETE-NZB", mylar.NZBPOOL, mylar.NZB_QUEUE),
+                ("AUTO-SNATCHER", mylar.SNPOOL, mylar.SNATCHED_QUEUE),
+                ("DDL-QUEUE", mylar.DDLPOOL, mylar.DDL_QUEUE),
+                ("POST-PROCESS-QUEUE", mylar.PPPOOL, mylar.PP_QUEUE),
+                ("SEARCH-QUEUE", mylar.SEARCHPOOL, mylar.SEARCH_QUEUE),
             ]
         }
         return serve_template(templatename="manage.html", title="Manage", mylarRoot=mylarRoot, jobs=jobresults, queues=queues, scan_info=scan_info)

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -3962,7 +3962,17 @@ class WebInterface(object):
                             'jobname': jb['JobName'],
                             'status': status})
             jobresults = tmp
-        return serve_template(templatename="manage.html", title="Manage", mylarRoot=mylarRoot, jobs=jobresults, scan_info=scan_info)
+        queues = {
+            queue_name: thread_obj.is_alive() if thread_obj is not None else None
+            for (queue_name, thread_obj) in [
+                ("AUTO-COMPLETE-NZB", mylar.NZBPOOL),
+                ("AUTO-SNATCHER", mylar.SNPOOL),
+                ("DDL-QUEUE", mylar.DDLPOOL),
+                ("POST-PROCESS-QUEUE", mylar.PPPOOL),
+                ("SEARCH-QUEUE", mylar.SEARCHPOOL),
+            ]
+        }
+        return serve_template(templatename="manage.html", title="Manage", mylarRoot=mylarRoot, jobs=jobresults, queues=queues, scan_info=scan_info)
     manage.exposed = True
 
     def jobmanage(self, job, mode):


### PR DESCRIPTION
This doesn't enable performing any actions on the queues or workers, but does make it easier to understand what the current status is (and perhaps gives us a place to put actions in future).

![queue](https://github.com/mylar3/mylar3/assets/62736/99fba1cf-3f45-4c1d-b443-f73caa308662)

I've tested this by locally modifying `helpers.search_queue` to raise an Exception after 10s (so I didn't have to figure out how to trigger a legit error). The screenshot above is taken after searching for a single issue after the 10s has elapsed, hence the queue length.