### PR TITLE
search: fix call of sfs.checker when using DDL RSS search

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -1127,7 +1127,7 @@ def NZB_SEARCH(
             else:
                 if len(bb['entries']) > 0:
                     sfs = search_filer.search_check()
-                    verified_matches = sfs.checker(bb, is_info)
+                    verified_matches = sfs.checker(bb['entries'], is_info)
                 else:
                     verified_matches = 'no results'
 


### PR DESCRIPTION
Specifically, we would see a traceback if there were issues for a search in the RSS feed database: this fixes that codepath to pass the correct values to `checker()`.

(This must be the change I should have made instead of that other change we ended up undoing.)