### PR TITLE
Expose current queue status at /prometheus_metrics for Prometheus monitoring

### DIFF
--- a/data/interfaces/default/manage.html
+++ b/data/interfaces/default/manage.html
@@ -286,12 +286,12 @@
                            </tr>
                         </thead>
                         <tbody>
-                           %for q_name, (is_up, length) in queues.items():
+                           %for q in queues:
                               <%
-                                    if is_up:
+                                    if q.is_alive:
                                         text = "Up"
                                         grade = '#7AEE52'
-                                    elif is_up is not None:
+                                    elif q.is_alive is not None:
                                         text = "Down"
                                         grade = '#EC7564'
                                     else:
@@ -299,8 +299,8 @@
                                         grade = '#52A9EE'
                                %>
                               <tr>
-                                <td style="width: 50px;text-align: center;">${q_name}</td>
-                                <td style="width: 50px;text-align: center;">${length}</td>
+                                <td style="width: 50px;text-align: center;">${q.name}</td>
+                                <td style="width: 50px;text-align: center;">${q.size}</td>
                                 <td style="width: 50px;text-align: center;color:${grade}">${text}</td>
                               </tr>
                            %endfor

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -34,6 +34,7 @@ import hashlib
 import gzip
 import os, errno
 import urllib
+from collections import namedtuple
 from urllib.parse import urljoin
 from io import StringIO
 from apscheduler.triggers.interval import IntervalTrigger
@@ -3486,9 +3487,12 @@ def cdh_monitor(queue, item, nzstat, readd=False):
     return
 
 
+QueueInfo = namedtuple("QueueInfo", ("name", "is_alive", "size"))
+
+
 def queue_info():
-    return {
-        queue_name: (thread_obj.is_alive() if thread_obj is not None else None, queue.qsize())
+    return [
+        QueueInfo(queue_name, thread_obj.is_alive() if thread_obj is not None else None, queue.qsize())
         for (queue_name, thread_obj, queue) in [
             ("AUTO-COMPLETE-NZB", mylar.NZBPOOL, mylar.NZB_QUEUE),
             ("AUTO-SNATCHER", mylar.SNPOOL, mylar.SNATCHED_QUEUE),
@@ -3496,7 +3500,7 @@ def queue_info():
             ("POST-PROCESS-QUEUE", mylar.PPPOOL, mylar.PP_QUEUE),
             ("SEARCH-QUEUE", mylar.SEARCHPOOL, mylar.SEARCH_QUEUE),
         ]
-    }
+    ]
 
 
 def script_env(mode, vars):

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3491,7 +3491,7 @@ QueueInfo = namedtuple("QueueInfo", ("name", "is_alive", "size"))
 
 
 def queue_info():
-    return [
+    yield from (
         QueueInfo(queue_name, thread_obj.is_alive() if thread_obj is not None else None, queue.qsize())
         for (queue_name, thread_obj, queue) in [
             ("AUTO-COMPLETE-NZB", mylar.NZBPOOL, mylar.NZB_QUEUE),
@@ -3500,7 +3500,7 @@ def queue_info():
             ("POST-PROCESS-QUEUE", mylar.PPPOOL, mylar.PP_QUEUE),
             ("SEARCH-QUEUE", mylar.SEARCHPOOL, mylar.SEARCH_QUEUE),
         ]
-    ]
+    )
 
 
 def script_env(mode, vars):

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3485,6 +3485,20 @@ def cdh_monitor(queue, item, nzstat, readd=False):
             logger.error('process error: %s' % e)
     return
 
+
+def queue_info():
+    return {
+        queue_name: (thread_obj.is_alive() if thread_obj is not None else None, queue.qsize())
+        for (queue_name, thread_obj, queue) in [
+            ("AUTO-COMPLETE-NZB", mylar.NZBPOOL, mylar.NZB_QUEUE),
+            ("AUTO-SNATCHER", mylar.SNPOOL, mylar.SNATCHED_QUEUE),
+            ("DDL-QUEUE", mylar.DDLPOOL, mylar.DDL_QUEUE),
+            ("POST-PROCESS-QUEUE", mylar.PPPOOL, mylar.PP_QUEUE),
+            ("SEARCH-QUEUE", mylar.SEARCHPOOL, mylar.SEARCH_QUEUE),
+        ]
+    }
+
+
 def script_env(mode, vars):
     #mode = on-snatch, pre-postprocess, post-postprocess
     #var = dictionary containing variables to pass

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -3962,16 +3962,7 @@ class WebInterface(object):
                             'jobname': jb['JobName'],
                             'status': status})
             jobresults = tmp
-        queues = {
-            queue_name: (thread_obj.is_alive() if thread_obj is not None else None, queue.qsize())
-            for (queue_name, thread_obj, queue) in [
-                ("AUTO-COMPLETE-NZB", mylar.NZBPOOL, mylar.NZB_QUEUE),
-                ("AUTO-SNATCHER", mylar.SNPOOL, mylar.SNATCHED_QUEUE),
-                ("DDL-QUEUE", mylar.DDLPOOL, mylar.DDL_QUEUE),
-                ("POST-PROCESS-QUEUE", mylar.PPPOOL, mylar.PP_QUEUE),
-                ("SEARCH-QUEUE", mylar.SEARCHPOOL, mylar.SEARCH_QUEUE),
-            ]
-        }
+        queues = helpers.queue_info()
         return serve_template(templatename="manage.html", title="Manage", mylarRoot=mylarRoot, jobs=jobresults, queues=queues, scan_info=scan_info)
     manage.exposed = True
 

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -7367,6 +7367,27 @@ class WebInterface(object):
 
     api.exposed = True
 
+    def prometheus_metrics(self):
+        logger.debug("Responding to Prometheus metrics request")
+        cherrypy.response.headers['Content-Type'] = "text/plain"
+        q_metrics = {name: {} for name in ["alive", "size", "started"]}
+        for q in helpers.queue_info():
+            normalised_name = q.name.replace("-", "_")
+
+            q_metrics["size"][normalised_name] = q.size
+            q_metrics["started"][normalised_name] = "1" if q.is_alive is not None else "0"
+            q_metrics["alive"][normalised_name] = "1" if q.is_alive else "0"
+
+        response = ""
+        for metric, items in q_metrics.items():
+            full_metric = f"mylar_queue_{metric}"
+            response += f"# TYPE {full_metric} gauge\n"
+            for name, value in items.items():
+                response += '%s{queue="%s"} %s\n' % (full_metric, name, value)
+            response += "\n"
+        return response
+
+    prometheus_metrics.exposed = True
 
     def opds(self, *args, **kwargs):
         from mylar.opds import OPDS


### PR DESCRIPTION
Also includes some refactoring to the queue view in Manage, as it's the same data being presented.

This allows people with a Prometheus instance to scrape the current queue status. Here's an example of the queue sizes when downloading 9 issues (from 2 series, hence the staggered initial increase) from GC:

![prometheus](https://github.com/mylar3/mylar3/assets/62736/ca988455-16bf-4ee3-9eb5-8af3f3c64e88)

It also exposes "alive" and "started" metrics which should enable people to add alerting for queues dying, if desired.