### PR TITLE
getcomics: fix missing lock release/return value in downloadit

### DIFF
--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -956,6 +956,7 @@ class GC(object):
                     new_path = dst_path
                 return {"success": True, "filename": filename, "path": new_path}
 
+        mylar.DDL_LOCK = False
         return {"success": False, "filename": filename, "path": None}
 
     def issue_list(self, pack):

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -956,6 +956,8 @@ class GC(object):
                     new_path = dst_path
                 return {"success": True, "filename": filename, "path": new_path}
 
+        return {"success": False, "filename": filename, "path": None}
+
     def issue_list(self, pack):
         # packlist = [x.strip() for x in pack.split(',)]
         packlist = pack.replace('+', ' ').replace(',', ' ').split()


### PR DESCRIPTION
I saw an exception like this in my log, and the DDL queue stopped being processed:
```
Aug 30 18:46:41 X mylar3[3028235]: Traceback (most recent call last):
Aug 30 18:46:41 X mylar3[3028235]:   File "/app/mylar3/mylar/logger.py", line 337, in new_run
Aug 30 18:46:41 X mylar3[3028235]:     old_run(*args, **kwargs)
Aug 30 18:46:41 X mylar3[3028235]:   File "/usr/lib/python3.11/threading.py", line 975, in run
Aug 30 18:46:41 X mylar3[3028235]:     self._target(*self._args, **self._kwargs)
Aug 30 18:46:41 X mylar3[3028235]:   File "/app/mylar3/mylar/helpers.py", line 3244, in ddl_downloader
Aug 30 18:46:41 X mylar3[3028235]:     if ddzstat['success'] is True:
Aug 30 18:46:41 X mylar3[3028235]:        ~~~~~~~^^^^^^^^^^^
Aug 30 18:46:41 X mylar3[3028235]: TypeError: 'NoneType' object is not subscriptable
```
I believe these changes will avoid a recurrence.