### PR TITLE
manage: correct wording about worker repair

### DIFF
--- a/data/interfaces/default/manage.html
+++ b/data/interfaces/default/manage.html
@@ -306,7 +306,7 @@
                            %endfor
                         </tbody>
            </table>
-           </br><small><center>Workers are only started if your config requires them. The DDL worker can be restarted <a href="/queueManage">here</a>: other workers require a restart of Mylar to repair.</center></small>
+           </br><small><center>Workers are only started if your config requires them.  Down workers require a restart of Mylar to repair.</center></small>
         </div>
 
 


### PR DESCRIPTION
I misunderstood what the DDL "restart" button does: it requeues items, but it does not restart the worker itself.