### PR TITLE
weeklypull: handle invalid annuallink values gracefully

### DIFF
--- a/mylar/weeklypull.py
+++ b/mylar/weeklypull.py
@@ -1033,7 +1033,14 @@ def new_pullcheck(weeknumber, pullyear, comic1off_name=None, comic1off_id=None, 
                 if mylar.CONFIG.ANNUALS_ON is True:
                     annualidmatch = [x for x in weeklylist if week['comicid'] is not None and ([xa for xa in x['AnnualIDs'] if int(xa['ComicID']) == int(week['comicid'])])]
                     if not annualidmatch:
-                        annualidmatch = [x for x in weeklylist if week['annuallink'] is not None and (int(x['ComicID']) == int(week['annuallink']))]
+                        annual_link = week['annuallink']
+                        if annual_link is not None:
+                            try:
+                                annual_link = int(annual_link)
+                            except ValueError:
+                                logger.warn("[WEEKLY-PULL] %s #%s has an invalid annuallink value (%s): walksoftly data may be invalid; skipping", week['ComicName'], week['ISSUE'], week['annuallink'])
+                                continue
+                        annualidmatch = [x for x in weeklylist if annual_link is not None and (int(x['ComicID']) == annual_link)]
 
                 #The above will auto-match against ComicID if it's populated on the pullsite, otherwise do name-matching.
                 namematch = [ab for ab in weeklylist if ab['DynamicName'] == week['dynamicname']]


### PR DESCRIPTION
Emit a WARNING log message instead of a traceback.