### PR TITLE
fix(search): Skip searching for an issue if it's not 'Wanted'

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -2415,7 +2415,9 @@ def searchforissue(issueid=None, new=False, rsschecker=None, manual=False):
                                 )
                                 mylar.SEARCHLOCK = False
                                 return
-
+                if result['Status'] != 'Wanted':
+                    logger.info('Issue is not in wanted status, ignoring search.')
+                    return
                 allow_packs = False
                 ComicID = result['ComicID']
                 if smode == 'story_arc':


### PR DESCRIPTION
This will prevent the search of issues that are marked snatched because mylar found a pack for them.