### PR TITLE
here comes the pain...

### DIFF
--- a/data/interfaces/carbon/css/style.css
+++ b/data/interfaces/carbon/css/style.css
@@ -1816,7 +1816,7 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table th#qsize {
-  max-width: 30px;
+  max-width: 35px;
   text-align: center;
 }
 #queue_table th#qprogress {
@@ -1824,7 +1824,7 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table th#qstatus {
-  max-width: 50px;
+  max-width: 55px;
   text-align: center;
 }
 #queue_table th#qdate {
@@ -1832,7 +1832,7 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table th#qoptions {
-  min-width: 160px;
+  max-width: 160px;
   text-align: center;
 }
 #queue_table td#qcomicid {
@@ -1844,7 +1844,7 @@ div#artistheader h2 a {
   text-align: left;
 }
 #queue_table td#qsize {
-  max-width: 30px;
+  max-width: 35px;
   text-align: center;
 }
 #queue_table td#qprogress {
@@ -1852,7 +1852,7 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table td#qstatus {
-  max-width: 50px;
+  max-width: 55px;
   text-align: center;
 }
 #queue_table td#qdate {
@@ -1860,7 +1860,7 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table td#qoptions {
-  min-width: 160px;
+  max-width: 160px;
   text-align: center;
 }
 

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -868,7 +868,12 @@
                                 <div class="config">
                                    <div id="ddl_providers">
                                         <div class="row checkbox left clearfix">
-                                            <input type="checkbox" id="enable_getcomics" name="enable_getcomics" value="1" ${config['enable_getcomics']} /><label>Enable GetComics</label>
+                                            <input type="checkbox" id="enable_getcomics" onclick="initConfigCheckbox($(this));" name="enable_getcomics" value="1" ${config['enable_getcomics']} /><label>Enable GetComics</label>
+                                       </div>
+                                       <div id="gc_options" style="display:none">
+                                           <div class="row checkbox left clearfix" style="display:block;padding-left:1.5em;">
+                                                <input type="checkbox" id="ddl_prefer_upscaled" name="ddl_prefer_upscaled" value="1" ${config['ddl_prefer_upscaled']} /><label>Prefer HD-Upscale/HD-Digital <small>(if available></small></label>
+                                           </div>
                                        </div>
                                    </div>
                                 </div>
@@ -2019,10 +2024,12 @@
                                     document.getElementById("enable_getcomics").setAttribute("disabled", "disabled");
                                 }
                                 $("#ddl_providers").slideDown();
+                                $("#gc_options").slideDown();
                         }
                 else    {
                                 document.getElementById("enable_getcomics").checked = false;
                                 $("#ddl_providers").slideUp();
+                                $("#gc_options").slideUp();
                         }
 
                 $("#enable_ddl").click(function(){

--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -1716,7 +1716,7 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table th#qsize {
-  max-width: 30px;
+  max-width: 35px;
   text-align: center;
 }
 #queue_table th#qprogress {
@@ -1724,7 +1724,7 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table th#qstatus {
-  max-width: 50px;
+  max-width: 55px;
   text-align: center;
 }
 #queue_table th#qdate {
@@ -1732,7 +1732,7 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table th#qoptions {
-  min-width: 160px;
+  max-width: 160px;
   text-align: center;
 }
 #queue_table td#qcomicid {
@@ -1744,7 +1744,7 @@ div#artistheader h2 a {
   text-align: left;
 }
 #queue_table td#qsize {
-  max-width: 30px;
+  max-width: 35px;
   text-align: center;
 }
 #queue_table td#qprogress {
@@ -1752,7 +1752,7 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table td#qstatus {
-  max-width: 50px;
+  max-width: 55px;
   text-align: center;
 }
 #queue_table td#qdate {
@@ -1760,7 +1760,7 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table td#qoptions {
-  min-width: 160px;
+  max-width: 160px;
   text-align: center;
 }
 

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -99,9 +99,9 @@
                        "visible": true,
                        "render":function (data,type,full) {
                             if (full[3]){
-                               if (full[3].length == 5 || full[3].length == 6){
+                               if (full[3].length == 9){
                                  cn = full[3];
-                               } else if (full[3].length > 6){
+                               } else if (full[3].length > 9){
                                  cn = '<span title="#'+full[3]+'">#</span>';
                                } else {
                                  cn = '#' + full[3];

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -362,6 +362,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'DDL_QUERY_DELAY': (int, 'DDL', 15),
     'DDL_LOCATION': (str, 'DDL', None),
     'DDL_AUTORESUME': (bool, 'DDL', True),
+    'DDL_PREFER_UPSCALED': (bool, 'DDL', True),
     'ENABLE_FLARESOLVERR': (bool, 'DDL', False),
     'FLARESOLVERR_URL': (str, 'DDL', None),
     'ENABLE_PROXY': (bool, 'DDL', False),

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -24,6 +24,9 @@ import urllib.request, urllib.parse, urllib.error
 import logging
 import unicodedata
 import optparse
+import getpass
+from pwd import getpwnam
+from grp import getgrnam
 from fnmatch import fnmatch
 
 import datetime as dt
@@ -1879,41 +1882,57 @@ def setperms(path, dir=False):
             os.umask(0) # this is probably redudant, but it doesn't hurt to clear the umask here.
             if mylar.CONFIG.CHGROUP:
                 if mylar.CONFIG.CHOWNER is None or mylar.CONFIG.CHOWNER == 'None' or mylar.CONFIG.CHOWNER == '':
-                    import getpass
                     mylar.CONFIG.CHOWNER = getpass.getuser()
 
                 if not mylar.CONFIG.CHOWNER.isdigit():
-                    from pwd import getpwnam
-                    chowner = getpwnam(mylar.CONFIG.CHOWNER)[2]
+                    try:
+                        chowner = getpwnam(mylar.CONFIG.CHOWNER)[2]
+                    except Exception as e:
+                        logger.warn('[PERMISSIONS] %s does not exist on this system as a user' % mylar.CONFIG.CHOWNER)
+                        chowner = -1
                 else:
                     chowner = int(mylar.CONFIG.CHOWNER)
 
                 if not mylar.CONFIG.CHGROUP.isdigit():
-                    from grp import getgrnam
-                    chgroup = getgrnam(mylar.CONFIG.CHGROUP)[2]
+                    try:
+                        chgroup = getgrnam(mylar.CONFIG.CHGROUP)[2]
+                    except Exception as e:
+                        logger.warn('[PERMISSIONS] %s does not exist on this system as a group' % mylar.CONFIG.CHGROUP)
+                        chgroup = -1
                 else:
                     chgroup = int(mylar.CONFIG.CHGROUP)
 
+                validity_perm = check_valid_perms(chowner,chgroup)
+                logger.fdebug('validity_perm: %s' % validity_perm)
+                if validity_perm['status']:
+                    chowner = validity_perm['owner']
+                    chgroup = validity_perm['group']
+
                 if dir:
                     permission = int(mylar.CONFIG.CHMOD_DIR, 8)
+                    if validity_perm['status']:
+                        os.chown(path, chowner, chgroup)
                     os.chmod(path, permission)
-                    os.chown(path, chowner, chgroup)
                 elif os.path.isfile(path):
                     permission = int(mylar.CONFIG.CHMOD_FILE, 8)
-                    os.chown(path, chowner, chgroup)
-                    os.chmod(path, permission)   
+                    if validity_perm['status']:
+                        os.chown(path, chowner, chgroup)
+                    os.chmod(path, permission)
                 else:
                     for root, dirs, files in os.walk(path):
                         for momo in dirs:
                             permission = int(mylar.CONFIG.CHMOD_DIR, 8)
-                            os.chown(os.path.join(root, momo), chowner, chgroup)
+                            if validity_perm['status']:
+                                os.chown(os.path.join(root, momo), chowner, chgroup)
                             os.chmod(os.path.join(root, momo), permission)
                         for momo in files:
                             permission = int(mylar.CONFIG.CHMOD_FILE, 8)
-                            os.chown(os.path.join(root, momo), chowner, chgroup)
+                            if validity_perm['status']:
+                                os.chown(os.path.join(root, momo), chowner, chgroup)
                             os.chmod(os.path.join(root, momo), permission)
 
-                logger.fdebug('Successfully changed ownership and permissions [' + str(mylar.CONFIG.CHOWNER) + ':' + str(mylar.CONFIG.CHGROUP) + '] / [' + str(mylar.CONFIG.CHMOD_DIR) + ' / ' + str(mylar.CONFIG.CHMOD_FILE) + ']')
+                logger.fdebug('Successfully changed ownership and permissions [%s:%s] / [%s/%s]' %
+                              (chowner, chgroup, mylar.CONFIG.CHMOD_DIR, mylar.CONFIG.CHMOD_FILE))
 
             elif os.path.isfile(path):
                     permission = int(mylar.CONFIG.CHMOD_FILE, 8)
@@ -1927,16 +1946,33 @@ def setperms(path, dir=False):
                         permission = int(mylar.CONFIG.CHMOD_FILE, 8)
                         os.chmod(os.path.join(root, momo), permission)
 
-                logger.fdebug('Successfully changed permissions [' + str(mylar.CONFIG.CHMOD_DIR) + ' / ' + str(mylar.CONFIG.CHMOD_FILE) + ']')
+                logger.fdebug('Successfully changed permissions [%s/%s]' % (mylar.CONFIG.CHMOD_DIR, mylar.CONFIG.CHMOD_FILE))
 
         except OSError as e:
             logger.error('[ERROR @ path: %s] %s. Exiting...' % (path, e))
 
     return
 
+def check_valid_perms(chowner, chgroup):
+    if all([chowner !=-1, chgroup !=-1]):
+        logger.warn('[PERMISSONS] Unable to set ownership due to both owner:group [%s:5s] being invalid.' % (mylar.CONFIG.CHOWNER, mylar.CONFIG.CHGROUP))
+        return {'status': False,
+                'owner': chowner,
+                'group': chgroup}
+    else:
+        ch_problem = None
+        if chowner == -1:
+            ch_problem = 'owner'
+            chownr = getpass.getuser()
+            chowner = getgrnam(chownr)[1]
+        elif chgroup == -1:
+            ch_problem = 'group'
+            chgp = getpass.getuser()
+            chgroup = getgrnam(chgp)[2]
+        if ch_problem:
+            logger.warn('[PERMISSIONS] Partial enforcement of permissions being done due to invalid %s specified.'
+                        ' Perms set to: %s:%s ' % (ch_problem, chowner, chgroup))
 
-#if __name__ == '__main__':
-#    test = FileChecker()
-#    test.getlist()
-
-
+        return {'status': True,
+                'owner': chowner,
+                'group': chgroup}

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -149,6 +149,8 @@ def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=No
         else:
             if series_status == 'Active' or series_status == 'Loading':
                 newValueDict = {"Status":   "Active"}
+            else:
+                newValueDict = {"Status":   "Paused"}
         myDB.upsert("comics", newValueDict, controlValueDict)
         return {'status': 'incomplete'}
 
@@ -447,7 +449,7 @@ def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=No
 
     #move to own function so can call independently to only refresh issue data
     #issued is from cv.getComic, comic['ComicName'] & comicid would both be already known to do independent call.
-    updateddata = updateissuedata(comicid, comic['ComicName'], issued, comicIssues, calledfrom, SeriesYear=SeriesYear, latestissueinfo=latestissueinfo, serieslast_updated=serieslast_updated)
+    updateddata = updateissuedata(comicid, comic['ComicName'], issued, comicIssues, calledfrom, SeriesYear=SeriesYear, latestissueinfo=latestissueinfo, serieslast_updated=serieslast_updated, series_status=series_status)
     try:
         if updateddata['status'] == 'failure':
             logger.warn('Unable to properly retrieve issue details - this is usually due to either irregular issue numbering, or problems with CV')
@@ -468,7 +470,7 @@ def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=No
         issue_collection(issuedata, nostatus='False', serieslast_updated=serieslast_updated)
         #need to update annuals at this point too....
         if anndata:
-            manualAnnual(annchk=anndata)
+            manualAnnual(annchk=anndata,series_status=series_status)
 
     if mylar.CONFIG.ALTERNATE_LATEST_SERIES_COVERS is True: #, lastissueid != importantdates['LatestIssueID']]):
         cimage = os.path.join(mylar.CONFIG.CACHE_DIR, comicid + '.jpg')
@@ -1005,6 +1007,9 @@ def issue_collection(issuedata, nostatus, serieslast_updated=None):
     except Exception:
         pass
 
+    logger.info('nostatus: %s' % nostatus)
+    logger.info('issuedata: %s' % (issuedata))
+
     myDB = db.DBConnection()
     nowdate = datetime.datetime.now()
     now_week = datetime.datetime.strftime(nowdate, "%Y%U")
@@ -1061,19 +1066,23 @@ def issue_collection(issuedata, nostatus, serieslast_updated=None):
                         datechk = datetime.datetime.strptime(dk, "%Y%m%d")
                         issue_week = datetime.datetime.strftime(datechk, "%Y%U")
                         #logger.info('issue_week: %s' % issue_week)
-                        if mylar.CONFIG.AUTOWANT_ALL:
-                            newValueDict['Status'] = "Wanted"
-                        elif serieslast_updated is None:
-                            #logger.fdebug('serieslast_update is None. Setting to Skipped')
+                        if issue['SeriesStatus']:
                             newValueDict['Status'] = "Skipped"
-                        elif issue_week >= now_week and mylar.CONFIG.AUTOWANT_UPCOMING:
-                            logger.fdebug('[Marking as Wanted] week %s >= week %s' % (now_week, issue_week))
-                            newValueDict['Status'] = "Wanted"
-                        elif all([int(re.sub('-', '', serieslast_updated).strip()) < int(dk), mylar.CONFIG.AUTOWANT_UPCOMING is True]):
-                            logger.info('Autowant upcoming triggered for issue #%s' % issue['Issue_Number'])
-                            newValueDict['Status'] = "Wanted"
+                            logger.fdebug('[PAUSE-CHECK-ISSUE-STATUS] Series is paused, setting status for new issue #%s to Skipped' % (issue['Issue_Number']))
                         else:
-                            newValueDict['Status'] = "Skipped"
+                            if mylar.CONFIG.AUTOWANT_ALL:
+                                newValueDict['Status'] = "Wanted"
+                            elif serieslast_updated is None:
+                                #logger.fdebug('serieslast_update is None. Setting to Skipped')
+                                newValueDict['Status'] = "Skipped"
+                            elif issue_week >= now_week and mylar.CONFIG.AUTOWANT_UPCOMING:
+                                logger.fdebug('[Marking as Wanted] week %s >= week %s' % (now_week, issue_week))
+                                newValueDict['Status'] = "Wanted"
+                            elif all([int(re.sub('-', '', serieslast_updated).strip()) < int(dk), mylar.CONFIG.AUTOWANT_UPCOMING is True]):
+                                logger.info('Autowant upcoming triggered for issue #%s' % issue['Issue_Number'])
+                                newValueDict['Status'] = "Wanted"
+                            else:
+                                newValueDict['Status'] = "Skipped"
                         #logger.fdebug('status is : %s' % (newValueDict,))
                 else:
                     #logger.fdebug('Existing status for issue #%s : %s' % (issue['Issue_Number'], iss_exists['Status']))
@@ -1087,6 +1096,7 @@ def issue_collection(issuedata, nostatus, serieslast_updated=None):
                 #logger.fdebug("Not changing the status at this time - reverting to previous module after to re-append existing status")
                 pass #newValueDict['Status'] = "Skipped"
 
+            logger.info('issue_collection results: [%s] %s' % (controlValueDict, newValueDict))
             try:
                 myDB.upsert(dbwrite, newValueDict, controlValueDict)
             except sqlite3.InterfaceError as e:
@@ -1096,7 +1106,7 @@ def issue_collection(issuedata, nostatus, serieslast_updated=None):
                 return
 
 
-def manualAnnual(manual_comicid=None, comicname=None, comicyear=None, comicid=None, annchk=None, manualupd=False, deleted=False, forceadd=False, serieslast_updated=None):
+def manualAnnual(manual_comicid=None, comicname=None, comicyear=None, comicid=None, annchk=None, manualupd=False, deleted=False, forceadd=False, serieslast_updated=None, series_status=None):
         #called when importing/refreshing an annual that was manually added.
 
     #make sure serieslast_updated is in the correct format
@@ -1150,19 +1160,22 @@ def manualAnnual(manual_comicid=None, comicname=None, comicyear=None, comicid=No
                 else:
                     datechk = datetime.datetime.strptime(dk, "%Y%m%d")
                     issue_week = datetime.datetime.strftime(datechk, "%Y%U")
-                    if mylar.CONFIG.AUTOWANT_ALL:
-                        astatus = "Wanted"
-                    elif serieslast_updated is None:
-                        #logger.fdebug('serieslast_update is None. Setting to Skipped')
+                    if series_status:
                         astatus = "Skipped"
-                    elif issue_week >= now_week and mylar.CONFIG.AUTOWANT_UPCOMING:
-                        logger.fdebug('[Marking as Wanted] week %s >= week %s' % (now_week, issue_week))
-                        astatus = "Wanted"
-                    elif all([int(re.sub('-', '', serieslast_updated).strip()) < int(dk), mylar.CONFIG.AUTOWANT_UPCOMING is True]):
-                        logger.info('Autowant upcoming triggered for issue #%s' % firstval['Issue_Number'])
-                        astatus = "Wanted"
                     else:
-                        astatus = "Skipped"
+                        if mylar.CONFIG.AUTOWANT_ALL:
+                            astatus = "Wanted"
+                        elif serieslast_updated is None:
+                            #logger.fdebug('serieslast_update is None. Setting to Skipped')
+                            astatus = "Skipped"
+                        elif issue_week >= now_week and mylar.CONFIG.AUTOWANT_UPCOMING:
+                            logger.fdebug('[Marking as Wanted] week %s >= week %s' % (now_week, issue_week))
+                            astatus = "Wanted"
+                        elif all([int(re.sub('-', '', serieslast_updated).strip()) < int(dk), mylar.CONFIG.AUTOWANT_UPCOMING is True]):
+                            logger.info('Autowant upcoming triggered for issue #%s' % firstval['Issue_Number'])
+                            astatus = "Wanted"
+                        else:
+                            astatus = "Skipped"
 
                 annchk.append({'IssueID':          str(firstval['Issue_ID']),
                                'ComicID':          comicid,
@@ -1204,7 +1217,7 @@ def manualAnnual(manual_comicid=None, comicname=None, comicyear=None, comicid=No
     return
 
 
-def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, calledfrom=None, issuechk=None, issuetype=None, SeriesYear=None, latestissueinfo=None, serieslast_updated=None):
+def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, calledfrom=None, issuechk=None, issuetype=None, SeriesYear=None, latestissueinfo=None, serieslast_updated=None, series_status=None):
     annualchk = []
     weeklyissue_check = []
     logger.fdebug('issuedata call references...')
@@ -1215,6 +1228,15 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
     logger.fdebug('issuechk: %s' % issuechk)
     logger.fdebug('latestissueinfo: %s' % latestissueinfo)
     logger.fdebug('issuetype: %s' % issuetype)
+
+    if series_status is None and comicid is not None:
+       myDB = db.DBConnection()
+       chk_series_status = myDB.selectone('SELECT Status from comics where ComicID=?', [comicid]).fetchone()
+       if chk_series_status is not None:
+           series_status = chk_series_status
+       else:
+           series_status = 'Active'
+
     #to facilitate independent calls to updateissuedata ONLY, account for data not available and get it.
     #chkType comes from the weeklypulllist - either 'annual' or not to distinguish annuals vs. issues
     if comicIssues is None:
@@ -1236,7 +1258,7 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
             return {'status': 'failure'}
 
     # poll against annuals here - to make sure annuals are uptodate.
-    annualchk = annual_check(comicname, SeriesYear, comicid, issuetype, issuechk, annualchk)
+    annualchk = annual_check(comicname, SeriesYear, comicid, issuetype, issuechk, annualchk, series_status)
     if annualchk is None:
         annualchk = []
     logger.fdebug('Finished Annual checking.')
@@ -1477,6 +1499,7 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
                                               "IssueID":            issid})
 
             issuedata.append({"ComicID":            comicid,
+                              "SeriesStatus":       series_status,
                               "IssueID":            issid,
                               "ComicName":          comicname,
                               "IssueName":          issname,
@@ -1580,9 +1603,13 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
             publishfigure = str(SeriesYear) + ' - ' + str(lastpubdate)
 
 
+    if series_status == 'Loading':
+        #if we're done loading and it's not Paused, set it Active again
+        series_status = 'Active'
+
     controlValueStat = {"ComicID":     comicid}
 
-    newValueStat = {"Status":          "Active",
+    newValueStat = {"Status":          series_status,
                     "Total":           comicIssues,
                     "ComicPublished":  publishfigure,
                     "NewPublish":      newpublish,
@@ -1602,7 +1629,7 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
     importantdates['LatestDate'] = latestdate
     importantdates['LatestStoreDate'] = latest_stdate
     importantdates['LastPubDate'] = lastpubdate
-    importantdates['SeriesStatus'] = 'Active'
+    importantdates['SeriesStatus'] = series_status
     importantdates['ComicPublished'] = publishfigure
     importantdates['NewPublish'] = newpublish
 
@@ -1631,7 +1658,7 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
     else:
         return importantdates
 
-def annual_check(ComicName, SeriesYear, comicid, issuetype, issuechk, annualslist):
+def annual_check(ComicName, SeriesYear, comicid, issuetype, issuechk, annualslist, series_status):
         annualids = []   #to be used to make sure an ID isn't double-loaded
         annload = []
         anncnt = 0
@@ -1660,7 +1687,7 @@ def annual_check(ComicName, SeriesYear, comicid, issuetype, issuechk, annualslis
             for manchk in annload:
                 if manchk['ReleaseComicID'] is not None or manchk['ReleaseComicID'] is not None:  #if it exists, then it's a pre-existing add
                     #print str(manchk['ReleaseComicID']), comic['ComicName'], str(SeriesYear), str(comicid)
-                    tmp_the_annuals = manualAnnual(manchk['ReleaseComicID'], ComicName, SeriesYear, comicid, manualupd=True, deleted=manchk['Deleted'])
+                    tmp_the_annuals = manualAnnual(manchk['ReleaseComicID'], ComicName, SeriesYear, comicid, manualupd=True, deleted=manchk['Deleted'], series_status=series_status)
                     if tmp_the_annuals:
                         annualslist += tmp_the_annuals
                 annualids.append(manchk['ReleaseComicID'])
@@ -1745,12 +1772,15 @@ def annual_check(ComicName, SeriesYear, comicid, issuetype, issuechk, annualslis
                                 else:
                                     datechk = datetime.datetime.strptime(dk, "%Y%m%d")
                                     issue_week = datetime.datetime.strftime(datechk, "%Y%U")
-                                    if mylar.CONFIG.AUTOWANT_ALL:
-                                        astatus = "Wanted"
-                                    elif issue_week >= now_week and mylar.CONFIG.AUTOWANT_UPCOMING is True:
-                                        astatus = "Wanted"
-                                    else:
+                                    if series_status:
                                         astatus = "Skipped"
+                                    else:
+                                        if mylar.CONFIG.AUTOWANT_ALL:
+                                            astatus = "Wanted"
+                                        elif issue_week >= now_week and mylar.CONFIG.AUTOWANT_UPCOMING is True:
+                                            astatus = "Wanted"
+                                        else:
+                                            astatus = "Skipped"
                             else:
                                 astatus = iss_exists['Status']
 
@@ -1781,7 +1811,7 @@ def annual_check(ComicName, SeriesYear, comicid, issuetype, issuechk, annualslis
 
                             n+=1
                 num_res+=1
-            manualAnnual(annchk=annualslist)
+            manualAnnual(annchk=annualslist,series_status=series_status)
             return annualslist
 
         elif sresults is None or len(sresults) == 0:

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -113,24 +113,6 @@ def search_init(
     else:
         logger.fdebug('Issue Title not found. Setting to None.')
 
-    #if smode == 'want_ann':
-    #    logger.info('Annual/Special issue search detected. Appending to issue #')
-    #    # anything for smode other than None indicates an annual.
-    #    #if all(['annual' not in ComicName.lower(), 'special' not in ComicName.lower()]):
-    #    #    ComicName = '%s Annual' % ComicName
-    #    if '2021 annual' in ComicName.lower():
-    #        AlternateSearch= '%s Annual' % re.sub('2021 annual', '', ComicName, flags=re.I).strip()
-    #        logger.info('Setting alternate search to %s because people are gonna people.' % AlternateSearch)
-
-    #    if all(
-    #        [
-    #            AlternateSearch is not None,
-    #            AlternateSearch != "None",
-    #            'special' not in ComicName.lower(),
-    #        ]
-    #    ):
-    #        AlternateSearch = '%s Annual' % AlternateSearch
-
     if smode == 'pullwant' or IssueID is None:
         # one-off the download.
         logger.fdebug('One-Off Search parameters:')
@@ -148,94 +130,6 @@ def search_init(
     findit = {}
     findit['status'] = False
 
-    #torprovider = []
-    #torp = 0
-    #torznabs = 0
-    #torznab_hosts = []
-
-    #logger.fdebug("Checking for torrent enabled.")
-    #if mylar.CONFIG.ENABLE_TORRENT_SEARCH:
-    #    if mylar.CONFIG.ENABLE_32P and not helpers.block_provider_check('32P'):
-    #        torprovider.append('32p')
-    #        torp += 1
-    #    if mylar.CONFIG.ENABLE_PUBLIC and not helpers.block_provider_check(
-    #        'public torrents'
-    #    ):
-    #        torprovider.append('public torrents')
-    #        torp += 1
-    #    if mylar.CONFIG.ENABLE_TORZNAB is True:
-    #        for torznab_host in mylar.CONFIG.EXTRA_TORZNABS:
-    #            if any([torznab_host[5] == '1', torznab_host[5] == 1]):
-    #                if not helpers.block_provider_check(torznab_host[0]):
-    #                    torznab_hosts.append(torznab_host)
-    #                    torprovider.append('torznab: %s' % torznab_host[0])
-    #                    torznabs += 1
-
-    ## nzb provider selection##
-    ## 'dognzb' or 'nzb.su' or 'experimental'
-    #nzbprovider = []
-    #nzbp = 0
-    #if mylar.CONFIG.NZBSU is True and not helpers.block_provider_check('nzb.su'):
-    #    nzbprovider.append('nzb.su')
-    #    nzbp += 1
-    #if mylar.CONFIG.DOGNZB is True and not helpers.block_provider_check('dognzb'):
-    #    nzbprovider.append('dognzb')
-    #    nzbp += 1
-
-    ## --------
-    ##  Xperimental
-    #if mylar.CONFIG.EXPERIMENTAL is True and not helpers.block_provider_check(
-    #    'experimental'
-    #):
-    #    nzbprovider.append('experimental')
-    #    nzbp += 1
-
-    #newznabs = 0
-
-    #newznab_hosts = []
-
-    #if mylar.CONFIG.NEWZNAB is True:
-    #    for newznab_host in mylar.CONFIG.EXTRA_NEWZNABS:
-    #        if any([newznab_host[5] == '1', newznab_host[5] == 1]):
-    #            if not helpers.block_provider_check(newznab_host[0]):
-    #                newznab_hosts.append(newznab_host)
-    #                nzbprovider.append('newznab: %s' % newznab_host[0])
-    #                newznabs += 1
-
-    #ddls = 0
-    #ddlprovider = []
-
-    #if mylar.CONFIG.ENABLE_DDL is True:
-    #    if all(
-    #       [
-    #            mylar.CONFIG.ENABLE_GETCOMICS is True,
-    #            not helpers.block_provider_check('DDL(GetComics)'),
-    #       ]
-    #    ):
-    #        ddlprovider.append('DDL(GetComics)')
-    #        ddls+=1
-
-    #logger.fdebug('nzbprovider(s): %s' % nzbprovider)
-    ## --------
-    #torproviders = torp + torznabs
-    #logger.fdebug('There are %s torrent providers you have selected.' % torproviders)
-    #torpr = torproviders - 1
-    #if torpr < 0:
-    #    torpr = -1
-    #providercount = int(nzbp + newznabs)
-    #logger.fdebug('There are : %s nzb providers you have selected' % providercount)
-    #if providercount > 0:
-    #    logger.fdebug('Usenet Retention : %s days' % mylar.CONFIG.USENET_RETENTION)
-
-    #if ddls > 0:
-    #    logger.fdebug(
-    #        'there are %s Direct Download providers that are currently enabled.' % ddls
-    #    )
-    #findit = {}
-    #findit['status'] = False
-
-    #totalproviders = providercount + torproviders + ddls
-
     if provider_list['totalproviders'] == 0:
         logger.error(
             '[WARNING] You have %s search providers enabled. I need at least ONE'
@@ -247,13 +141,6 @@ def search_init(
         return findit, nzbprov
 
     logger.fdebug('search provider order is %s' % provider_list['prov_order'])
-
-    #prov_order, torznab_info, newznab_info = provider_sequence(
-    #    nzbprovider, torprovider, newznab_hosts, torznab_hosts, ddlprovider
-    #
-    #)
-    # end provider order sequencing
-    #logger.fdebug('search provider order is %s' % prov_order)
 
     # fix for issue dates between Nov-Dec/(Jan-Feb-Mar)
     IssDt = str(IssueDate)[5:7]
@@ -340,24 +227,27 @@ def search_init(
             tmp_prov_count = len(provider_list['prov_order'])
 
         checked_once = []
-        while cmloopit >= 1:
-            prov_count = 0
-            if cmloopit == 4:
-                tmp_IssueNumber = None
-            else:
-                tmp_IssueNumber = IssueNumber
-            while tmp_prov_count > prov_count:
+        prov_count = 0
+
+        while tmp_prov_count > prov_count:
+            logger.info('tmp_prov_count: %s / prov_count: %s' % (tmp_prov_count,prov_count))
+            tmp_cmloopit = cmloopit
+            while tmp_cmloopit >= 1:
+                if tmp_cmloopit == 4:
+                    tmp_IssueNumber = None
+                else:
+                    tmp_IssueNumber = IssueNumber
+
+
                 prov_order = provider_list['prov_order']
                 logger.info('checked_once: %s' %(checked_once,))
                 if checked_once:
                     if prov_order[prov_count] in checked_once:
-                        prov_count +=1
-                        continue
+                        break
                 provider_blocked = helpers.block_provider_check(prov_order[prov_count])
                 if provider_blocked:
                     logger.warn('provider blocked. Ignoring search on this provider.')
-                    prov_count += 1
-                    continue
+                    break
                 send_prov_count = tmp_prov_count - prov_count
                 newznab_host = None
                 torznab_host = None
@@ -370,7 +260,7 @@ def search_init(
                 #should be DDL(GetComics)
                 if prov_order[prov_count] == 'DDL(GetComics)' and not provider_blocked and 'DDL(GetComics)' not in checked_once:
                     if 'DDL(GetComics)' not in searchprov.keys():
-                        searchprov['DDL(GetComics)'] = ({'id': 200, 'type': 'DDL', 'lastrun': 0, 'active': True, 'hits': 0})
+                       searchprov['DDL(GetComics)'] = ({'id': 200, 'type': 'DDL', 'lastrun': 0, 'active': True, 'hits': 0})
                     else:
                         searchprov['DDL(GetComics)']['active'] = True
                 elif prov_order[prov_count] == '32p' and not provider_blocked:
@@ -398,8 +288,7 @@ def search_init(
                                 'there was an error - torznab information was blank and'
                                 ' it should not be.'
                             )
-                            prov_count +=1
-                            continue
+                            break
                         if all(
                                [
                                    nninfo['provider'] == prov_order[prov_count],
@@ -429,8 +318,7 @@ def search_init(
                                 'there was an error - newznab information was blank and it'
                                 ' should not be.'
                             )
-                            prov_count +=1
-                            continue
+                            break
                         if all(
                                [
                                    nninfo['provider'] == prov_order[prov_count],
@@ -471,19 +359,18 @@ def search_init(
                     # since dognzb could hit the 100 daily api limit during the middle
                     # of a search run, check here on each pass to make sure it's not
                     # disabled (it gets auto-disabled on maxing out the API hits)
-                    prov_count += 1
-                    continue
+                    break
                 elif all(
                          [
-                             not provider_blocked,
+                              not provider_blocked,
                              ''.join(current_prov.keys()) in checked_once,
                          ]
                     ):
-                    prov_count += 1
-                    continue
+                    break
+
+                logger.info('tmp_cmloopit: %s [Issue #:%s]' % (tmp_cmloopit, tmp_IssueNumber))
 
                 scarios = {'tmp_IssueNumber': tmp_IssueNumber,
-                           #'ComicName': ComicName,
                            'ComicYear': ComicYear,
                            'SeriesYear': SeriesYear,
                            'Publisher': Publisher,
@@ -500,9 +387,8 @@ def search_init(
                            'IssueArcID': IssueArcID,
                            'ComicID': ComicID,
                            'issuetitle': issuetitle,
-                           #'unaltered_ComicName': unaltered_ComicName,
                            'oneoff':oneoff,
-                           'cmloopit':cmloopit,
+                           'cmloopit':tmp_cmloopit,
                            'manual':manual,
                            'torznab_host': torznab_host,
                            'digitaldate': digitaldate,
@@ -594,28 +480,29 @@ def search_init(
                                 searchmode,
                             )
                         )
-                prov_count += 1
-                logger.info('attempting to set %s to not being the active provider.'% (list(current_prov.keys())[0]))
-                if findit['lastrun'] != 0:
-                   logger.info('setting last run to: %s' % (findit['lastrun']))
-                   last_run_check(write={''.join(current_prov.keys()): {'active': False, 'lastrun': findit['lastrun'], 'type': current_prov[list(current_prov.keys())[0]]['type'], 'hits': current_prov[list(current_prov.keys())[0]]['hits'], 'id': current_prov[list(current_prov.keys())[0]]['id']}})
-                   #current_prov[list(current_prov.keys())[0]]['lastrun'] = findit['lastrun']
-                current_prov[list(current_prov.keys())[0]]['active'] = False
-                logger.info('setting took. Current provider is: %s' % (current_prov,))
+                if findit['status'] is True:
+                    if current_prov.get('newznab'):
+                        current_prov[newznab_host[0].rstrip() + ' (newznab)'] = current_prov.pop('newznab')
+                    elif current_prov.get('torznab'):
+                        current_prov[torznab_host[0].rstrip() + ' (torznab)'] = current_prov.pop('torznab')
+                    srchloop = 4
+                    break
+                elif srchloop == 2 and (tmp_cmloopit - 1 >= 1) and ''.join(current_prov.keys()) not in checked_once:
+                    # don't think this is needed as we do the check_time btwn searches now
+                    pass
 
-            if findit['status'] is True:
-                if current_prov.get('newznab'):
-                    current_prov[newznab_host[0].rstrip() + ' (newznab)'] = current_prov.pop('newznab')
-                elif current_prov.get('torznab'):
-                    current_prov[torznab_host[0].rstrip() + ' (torznab)'] = current_prov.pop('torznab')
-                srchloop = 4
-                break
-            elif srchloop == 2 and (cmloopit - 1 >= 1) and ''.join(current_prov.keys()) not in checked_once:
-                # don't think this is needed as we do the check_time btwn searches now
-                pass
-                #time.sleep(30)  # pause for 30s to not hammmer api's
+                tmp_cmloopit -= 1
 
-            cmloopit -= 1
+
+            prov_count += 1
+            logger.info('attempting to set %s to not being the active provider.'% (list(current_prov.keys())[0]))
+            if findit['lastrun'] != 0:
+               logger.info('setting last run to: %s' % (findit['lastrun']))
+               last_run_check(write={''.join(current_prov.keys()): {'active': False, 'lastrun': findit['lastrun'], 'type': current_prov[list(current_prov.keys())[0]]['type'], 'hits': current_prov[list(current_prov.keys())[0]]['hits'], 'id': current_prov[list(current_prov.keys())[0]]['id']}})
+               #current_prov[list(current_prov.keys())[0]]['lastrun'] = findit['lastrun']
+            current_prov[list(current_prov.keys())[0]]['active'] = False
+            logger.info('setting took. Current provider is: %s' % (current_prov,))
+
 
         srchloop += 1
 
@@ -2488,10 +2375,20 @@ def searchforissue(issueid=None, new=False, rsschecker=None, manual=False):
                     if any([comic['AllowPacks'] == 1, comic['AllowPacks'] == '1']):
                         allow_packs = True
 
-                if IssueDate is None:
+                if all([IssueDate == '0000-00-00', StoreDate == '0000-00-00']):
                     IssueYear = SeriesYear
                 else:
-                    IssueYear = str(IssueDate)[:4]
+                    if StoreDate == '0000-00-00':
+                        if IssueDate != '0000-00-00':
+                            IssueYear = str(IssueDate)[:4]
+                        else:
+                            logger.fdebug('No valid date found for %s issue %s - defaulting to series year.'
+                                          'You may want to edit the date to correct this.'
+                                          % (ComicName, IssueNumber)
+                            )
+                            IssueYear = SeriesYear
+                    else:
+                        IssueYear = str(StoreDate)[:4]
 
                 foundNZB, prov = search_init(
                     ComicName,

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -3525,7 +3525,19 @@ class WebInterface(object):
             oneitem = myDB.selectone("SELECT * FROM DDL_INFO WHERE ID=?", [id]).fetchone()
             items = [oneitem]
 
-        itemlist = [x for x in items]
+        itemlist = []
+        for x in items:
+            itemlist.append({'link': x['link'],
+                             'mainlink': x['mainlink'],
+                             'series': x['series'],
+                             'status': x['status'],
+                             'year': x['year'],
+                             'size': x['size'],
+                             'remote_filesize': x['remote_filesize'],
+                             'comicid': x['comicid'],
+                             'issueid': x['issueid'],
+                             'site': x['site'],
+                             'id': x['id']})
 
         if itemlist is not None:
             for item in itemlist:
@@ -3566,12 +3578,16 @@ class WebInterface(object):
                 linemessage = 'Successfully restarted Queue'
             elif mode == 'restart':
                 logger.info('[DDL-RESTART] Successfully restarted %s [%s] for downloading..' % (seriesname, seriessize))
+                linemessage = 'Successfully restarted %s [%s]' % (seriesname, seriessize)
             elif mode == 'requeue':
                 logger.info('[DDL-REQUEUE] Successfully requeued %s [%s] for downloading..' % (seriesname, seriessize))
+                linemessage = 'Successfully requeued %s [%s]' % (seriesname, seriessize)
             elif mode == 'abort':
                 logger.info('[DDL-ABORT] Successfully aborted downloading of %s [%s]..' % (seriesname, seriessize))
+                linemessage = 'Successfully aborted downloading %s [%s]' % (seriesname, seriessize)
             elif mode == 'remove':
                 logger.info('[DDL-REMOVE] Successfully removed %s [%s]..' % (seriesname, seriessize))
+                linemessage = 'Successfully removed %s [%s] from queue/history' % (seriesname, seriessize)
         else:
             linemessage = "No items to requeue"
         return json.dumps({'status': True, 'message': linemessage})
@@ -3661,8 +3677,8 @@ class WebInterface(object):
 
         myDB = db.DBConnection()
         resultlist = 'There are currently no items waiting in the Direct Download (DDL) Queue for processing.'
-        s_info = myDB.select("SELECT a.ComicName, a.ComicVersion, a.ComicID, a.ComicYear, b.Issue_Number, b.IssueID, c.size, c.status, c.id, c.updated_date, c.issues, c.year FROM comics as a INNER JOIN issues as b ON a.ComicID = b.ComicID INNER JOIN ddl_info as c ON b.IssueID = c.IssueID") # WHERE c.status != 'Downloading'")
-        o_info = myDB.select("Select a.ComicName, b.Issue_Number, a.IssueID, a.ComicID, c.size, c.status, c.id, c.updated_date, c.issues, c.year from oneoffhistory a join snatched b on a.issueid=b.issueid join ddl_info c on b.issueid=c.issueid where b.provider like 'DDL%'")
+        s_info = myDB.select("SELECT a.ComicName, a.ComicVersion, a.ComicID, a.ComicYear, b.Issue_Number, b.IssueID, c.series as filename, c.size, c.status, c.id, c.updated_date, c.issues, c.year, c.pack FROM comics as a INNER JOIN issues as b ON a.ComicID = b.ComicID INNER JOIN ddl_info as c ON b.IssueID = c.IssueID") # WHERE c.status != 'Downloading'")
+        o_info = myDB.select("Select a.ComicName, b.Issue_Number, a.IssueID, a.ComicID, c.series as filename, c.size, c.status, c.id, c.updated_date, c.issues, c.year, c.pack from oneoffhistory a join snatched b on a.issueid=b.issueid join ddl_info c on b.issueid=c.issueid where b.provider like 'DDL%'")
         tmp_list = {}
         if s_info:
             resultlist = []
@@ -3681,16 +3697,19 @@ class WebInterface(object):
                 else:
                     si_status = ''
 
-                if issue is not None:
-                    if si['ComicVersion'] is not None:
-                        series = '%s %s %s (%s)' % (si['ComicName'], si['ComicVersion'], issue, year)
-                    else:
-                        series = '%s %s (%s)' % (si['ComicName'], issue, year)
+                if si['pack']:
+                    series = si['filename']
                 else:
-                    if si['ComicVersion'] is not None:
-                        series = '%s %s (%s)' % (si['ComicName'], si['ComicVersion'], year)
+                    if issue is not None:
+                        if si['ComicVersion'] is not None:
+                            series = '%s %s %s (%s)' % (si['ComicName'], si['ComicVersion'], issue, year)
+                        else:
+                            series = '%s %s (%s)' % (si['ComicName'], issue, year)
                     else:
-                        series = '%s (%s)' % (si['ComicName'], year)
+                        if si['ComicVersion'] is not None:
+                            series = '%s %s (%s)' % (si['ComicName'], si['ComicVersion'], year)
+                        else:
+                            series = '%s (%s)' % (si['ComicName'], year)
 
                 resultlist.append({'series':       series, #i['ComicName'],
                                    'issue':        issue,
@@ -3731,10 +3750,13 @@ class WebInterface(object):
                 else:
                     oi_status = ''
 
-                if issue is not None:
-                    series = '%s %s (%s)' % (oi['ComicName'], issue, year)
+                if oi['pack']:
+                    series = oi['filename']
                 else:
-                    series = '%s (%s)' % (oi['ComicName'], year)
+                    if issue is not None:
+                        series = '%s %s (%s)' % (oi['ComicName'], issue, year)
+                    else:
+                        series = '%s (%s)' % (oi['ComicName'], year)
 
                 resultlist.append({'series':       series,
                                    'issue':        issue,
@@ -6567,6 +6589,7 @@ class WebInterface(object):
                     "extra_newznabs": sorted(mylar.CONFIG.EXTRA_NEWZNABS, key=itemgetter(5), reverse=True),
                     "enable_ddl": helpers.checked(mylar.CONFIG.ENABLE_DDL),
                     "enable_getcomics": helpers.checked(mylar.CONFIG.ENABLE_GETCOMICS),
+                    "ddl_prefer_upscaled": helpers.checked(mylar.CONFIG.DDL_PREFER_UPSCALED),
                     "enable_rss": helpers.checked(mylar.CONFIG.ENABLE_RSS),
                     "rss_checkinterval": mylar.CONFIG.RSS_CHECKINTERVAL,
                     "rss_last": rss_sclast,
@@ -7054,7 +7077,7 @@ class WebInterface(object):
                            'prowl_enabled', 'prowl_onsnatch', 'pushover_enabled', 'pushover_onsnatch', 'pushover_image', 'mattermost_enabled', 'mattermost_onsnatch', 'boxcar_enabled',
                            'boxcar_onsnatch', 'pushbullet_enabled', 'pushbullet_onsnatch', 'telegram_enabled', 'telegram_onsnatch', 'telegram_image', 'discord_enabled', 'discord_onsnatch', 'slack_enabled', 'slack_onsnatch',
                            'email_enabled', 'email_enc', 'email_ongrab', 'email_onpost', 'gotify_enabled', 'gotify_server_url', 'gotify_token', 'gotify_onsnatch', 'opds_enable', 'opds_authentication', 'opds_metainfo', 'opds_pagesize', 'enable_ddl',
-                           'enable_getcomics', 'deluge_pause'] #enable_public
+                           'enable_getcomics', 'ddl_prefer_upscaled', 'deluge_pause'] #enable_public
 
         for checked_config in checked_configs:
             if checked_config not in kwargs:


### PR DESCRIPTION
Bunch of fixes and some improvements mixed in....

**Improvements**
- Prefer HD-Upscale/HD-Digital added as an option under the DDL banner in the config page. 
   - with this enabled and a download now option is available for the HD, it will match that.
   - with this enabled and no download now option is available for HD, will drop down to match the SD version if present
   - not enabling this, it will match to the SD version
- permissions redid to make sure that owner / group values entered are present prior to attempting to enforce. If not available will default to the user running mylar or the group user belong to depending on what is not present.

**Fixes**
- fixed some table overlapping on the Manage DDL page resulting in overflows
- increased last issue table on main page as was cutting off/overlapping on large issue numbers
- when updating series info with new issue data, if a series was paused it would un-pause and mark issues as wanted if the options were enabled (mark all as wanted, mark upcoming as wanted)
- provider order would not be honored if DDL was an available option due to the way the search thru number padding was. Will now search all possible queries in a provider before moving onto the next provider regardless of the issue number
- Searching would take the cover date as the actual search date, not the store date which caused problems around the end of the year
