### PR TITLE
FIX: pwd/grp modules not available on windows

### DIFF
--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -25,8 +25,6 @@ import logging
 import unicodedata
 import optparse
 import getpass
-from pwd import getpwnam
-from grp import getgrnam
 from fnmatch import fnmatch
 
 import datetime as dt
@@ -1877,6 +1875,9 @@ def validateAndCreateDirectory(dir, create=False, module=None, dmode=None):
 def setperms(path, dir=False):
 
     if 'windows' not in mylar.OS_DETECT.lower():
+        #since these aren't available in windows, we import them now...
+        from pwd import getpwnam
+        from grp import getgrnam
 
         try:
             os.umask(0) # this is probably redudant, but it doesn't hurt to clear the umask here.


### PR DESCRIPTION
the pwd and grp python modules are not available on windows platforms - so only load the modules if it's non-windows.