### PR TITLE
FIX: 2024 / 2023 search problem matching, FIX: Mark all issues as Wanted being too literal

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -143,24 +143,32 @@ def search_init(
     logger.fdebug('search provider order is %s' % provider_list['prov_order'])
 
     # fix for issue dates between Nov-Dec/(Jan-Feb-Mar)
-    IssDt = str(IssueDate)[5:7]
-    if any([IssDt == "12", IssDt == "11", IssDt == "01", IssDt == "02", IssDt == "03"]):
-        IssDateFix = IssDt
+    IssDateFix = "no"
+    if StoreDate is not None:
+        StDt = str(StoreDate)[5:7]
+        if any(
+            [
+                StDt == "10",
+                StDt == "12",
+                StDt == "11",
+                StDt == "01",
+                StDt == "02",
+                StDt == "03",
+             ]
+        ):
+            IssDateFix = StDt
     else:
-        IssDateFix = "no"
-        if StoreDate is not None:
-            StDt = str(StoreDate)[5:7]
-            if any(
-                [
-                    StDt == "10",
-                    StDt == "12",
-                    StDt == "11",
-                    StDt == "01",
-                    StDt == "02",
-                    StDt == "03",
-                ]
-            ):
-                IssDateFix = StDt
+        IssDt = str(IssueDate)[5:7]
+        if any(
+            [
+                IssDt == "12",
+                IssDt == "11",
+                IssDt == "01",
+                IssDt == "02",
+                IssDt == "03"
+            ]
+        ):
+            IssDateFix = IssDt
 
     searchcnt = 0
     srchloop = 1

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -1751,14 +1751,14 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                     issStatus = old_status
                     logger.fdebug('[PAUSE_ISSUE_CHECK_STATUS_CHECK] series is paused, keeping status of %s for issue #%s' % (issStatus, chk['Issue_Number']))
                 else:
-                    if old_status == "Skipped":
-                        if mylar.CONFIG.AUTOWANT_ALL:
-                            issStatus = "Wanted"
-                        else:
-                            issStatus = "Skipped"
+                    #if old_status == "Skipped":
+                    #    if mylar.CONFIG.AUTOWANT_ALL:
+                    #        issStatus = "Wanted"
+                    #    else:
+                    #        issStatus = "Skipped"
                     #elif old_status == "Archived":
                     #    issStatus = "Archived"
-                    elif old_status == "Downloaded":
+                    if old_status == "Downloaded":
                         issStatus = "Archived"
                     else:
                         continue
@@ -1788,12 +1788,12 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                     issStatus = old_status
                     logger.fdefbug('[PAUSE_ANNUAL_CHECK_STATUS_CHECK] series is paused, keeping status of %s for issue #%s' % (issStatus, chk['Issue_Number']))
                 else:
-                    if old_status == "Skipped":
-                        if mylar.CONFIG.AUTOWANT_ALL:
-                            issStatus = "Wanted"
-                        else:
-                            issStatus = "Skipped"
-                    elif old_status == "Downloaded":
+                    #if old_status == "Skipped":
+                    #    if mylar.CONFIG.AUTOWANT_ALL:
+                    #        issStatus = "Wanted"
+                    #    else:
+                    #        issStatus = "Skipped"
+                    if old_status == "Downloaded":
                         issStatus = "Archived"
                     else:
                         continue


### PR DESCRIPTION
- FIX: when searching for issues published in late 2023, wouldn't match to 2024 filenames due to invalid date comparison
- FIX: mark all issues as wanted config option would mark every issue of a series as Wanted after each recheck/refresh that was not in a Downloaded status, regardless of previous state (ie. manually marking an issue as Skipped)