### PR TITLE
FIX: (#1461) MAC OS metadata files would be scanned in mistakingly during series page loads / rechecks

### DIFF
--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -1607,6 +1607,9 @@ class FileChecker(object):
                         #Ignoring MAC OS Finder directory of cached files (/.AppleDouble/<name of file(s)>)
                         continue
 
+                if fname.startswith('._'):
+                    continue
+
                 if all([mylar.CONFIG.ENABLE_TORRENTS is True, self.pp_mode is True]):
                     tcrc = helpers.crc(os.path.join(dirname, fname))
                     crcchk = [x for x in pp_crclist if tcrc == x['crc']]

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -373,6 +373,8 @@ class WebInterface(object):
                                 for file in files:
                                     if run_them_down is True:
                                         break
+                                    if file.startswith('._'):
+                                        continue
                                     if file.endswith(tuple(['cbr', 'cbz', 'cb7'])):
                                         mtime = os.path.getmtime(os.path.join(root, file))
                                         if mylar.OS_DETECT == 'Windows':


### PR DESCRIPTION
fixes #1461 