### PR TITLE
FIX:(#1469) incorrect logger reference causing traceback on SAB snatches that are completed quickly

### DIFF
--- a/mylar/sabnzbd.py
+++ b/mylar/sabnzbd.py
@@ -99,7 +99,7 @@ class SABnzbd(object):
                     queueinfo = queueresponse['queue']['slots'][0]
                     logger.info('monitoring ... detected download - %s [%s]' % (queueinfo['filename'], queueinfo['status']))
             except Exception as e:
-                logger.warning('unable to locate item within sabnzbd active queue - it could be finished already?')
+                logger.warn('Unable to locate item within sabnzbd active queue - it could be finished already?')
                 queueinfo = queueresponse['queue']
             try:
                 logger.fdebug('SABnzbd Queued item status : %s' % queueinfo['status'])


### PR DESCRIPTION
``logger.warning`` doesn't exist - should be ``logger.warn`` for non-english locales (stupid but meh).