### PR TITLE
FIX:(#1471) Update cheroot and Pillow to use latest if available - fixes pillow error being listed in config page

### DIFF
--- a/mylar/req_test.py
+++ b/mylar/req_test.py
@@ -102,7 +102,7 @@ class Req(object):
             for rq in self.req_list:
                 version_match = False
                 for pl in self.pip_list:
-                    if re.sub('[\-\_]', '', rq['module']).strip() == re.sub('[\-\_]', '', pl['module']).strip():
+                    if re.sub('[\-\_]', '', rq['module'].lower()).strip() == re.sub('[\-\_]', '', pl['module'].lower()).strip():
                         if parse_version(pl['version']) == parse_version(rq['version']):
                             version_match = 'OK'
                         elif parse_version(pl['version']) < parse_version(rq['version']):
@@ -145,6 +145,8 @@ class Req(object):
                             targ = '<'
                         elif x['arg'] == '<=':
                             targ = '>'
+                        else:
+                            targ = '='
                         pip_message = "%s installed %s %s required" % (x['pip_version'], targ, x['req_version'])
                     else:
                         pip_message = "%s %s" % (x['req_version'], x['pip_version'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,13 +7,13 @@
 APScheduler>=3.6.3
 beautifulsoup4>=4.8.2
 cfscrape>=2.0.8
-cheroot==8.2.1
+cheroot>=8.2.1
 CherryPy>=18.5.0
 configparser>=4.0.2
 feedparser>=5.2.1
 Mako>=1.1.0
 natsort>=3.5.2
-Pillow>=8
+Pillow>=10.1
 portend>=2.6
 pystun>=0.1.0
 pytz>=2019.3


### PR DESCRIPTION
- increase versions for cheroot (``>8.2.1``) and pillow (``>10.1`` due to python3.12 not working on less than this verison).
- fix pillow check so it's case-insensitive (went from ``Pillow`` to ``pillow``)