### PR TITLE
way bigger...

### DIFF
--- a/data/interfaces/carbon/css/style.css
+++ b/data/interfaces/carbon/css/style.css
@@ -1807,20 +1807,20 @@ div#artistheader h2 a {
   min-width: 95px;
   vertical-align: middle;
 }
-#queue_table th#qcomicid {
-  max-width: 10px;
-  text-align: center;
-}
 #queue_table th#qseries {
-  max-width: 475px;
+  max-width: 200px;
   text-align: center;
 }
 #queue_table th#qsize {
-  max-width: 35px;
+  max-width: 40px;
+  text-align: center;
+}
+#queue_table th#qlinktype {
+  max-width: 45px;
   text-align: center;
 }
 #queue_table th#qprogress {
-  max-width: 25px;
+  max-width: 20px;
   text-align: center;
 }
 #queue_table th#qstatus {
@@ -1828,27 +1828,27 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table th#qdate {
-  max-width: 90px;
+  max-width: 75px;
   text-align: center;
 }
 #queue_table th#qoptions {
-  max-width: 160px;
+  max-width: 100px;
   text-align: center;
 }
-#queue_table td#qcomicid {
-  max-width: 10px;
-  text-align: left;
-}
 #queue_table td#qseries {
-  max-width: 475px;
+  max-width: 200px;
   text-align: left;
 }
 #queue_table td#qsize {
-  max-width: 35px;
+  max-width: 40px;
+  text-align: center;
+}
+#queue_table td#qlinktype {
+  max-width: 45px;
   text-align: center;
 }
 #queue_table td#qprogress {
-  max-width: 25px;
+  max-width: 20px;
   text-align: center;
 }
 #queue_table td#qstatus {
@@ -1856,11 +1856,11 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table td#qdate {
-  min-width: 90px;
+  max-width: 75px;
   text-align: center;
 }
 #queue_table td#qoptions {
-  max-width: 160px;
+  max-width: 100px;
   text-align: center;
 }
 

--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -1936,9 +1936,9 @@
                          } else if (aData[3] === "Snatched") {
                             $('td', nRow).closest('tr').addClass("Snatched gradeC");
                          } else if (aData[3] === "Archived") {
-                            $('td', nRow).closest('tr').addClass("Archived gradeA");
+                            $('td', nRow).closest('tr').addClass("Archived gradeI");
                          } else if (aData[3] === "Ignored") {
-                            $('td', nRow).closest('tr').addClass("Ignored gradeA");
+                            $('td', nRow).closest('tr').addClass("Ignored gradeZ");
                          } else if (aData[3] === "Failed") {
                             $('td', nRow).closest('tr').addClass("Failed gradeF");
                          } else {

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -875,6 +875,28 @@
                                                 <input type="checkbox" id="ddl_prefer_upscaled" name="ddl_prefer_upscaled" value="1" ${config['ddl_prefer_upscaled']} /><label>Prefer HD-Upscale/HD-Digital <small>(if available></small></label>
                                            </div>
                                        </div>
+                                       %if mylar.EXT_SERVER:
+                                       <div class="row checkbox left clearfix">
+                                            <input type="checkbox" id="enable_external_server" onclick="initConfigCheckbox($this));" name="enable_external_server" value="1" ${config['enable_external_server']} /><label>Enable External Server</label>
+                                       </div>
+                                       <div class="config">
+                                           <div id="external_options">
+                                               <div class="row">
+                                                  <label>External Api server</label>
+                                                  <input type="text" name="external_server" id="external_server" value="${config['external_server']}" size="30">
+                                                  <small>(ie. http://private.server)</small>
+                                               </div>
+                                               <div class="row">
+                                                   <label>Username</label>
+                                                   <input type="text" name="external_username" id="external_username" value="${config['external_username']}" size="20">
+                                               </div>
+                                               <div class="row">
+                                                   <label>ApiKey</label>
+                                                   <input type="text" name="external_apikey" id="external_apikey" value="${config['external_apikey']}" size="20">
+                                               </div>
+                                          </div>
+                                       </div>
+                                       %endif
                                    </div>
                                 </div>
                         </fieldset>
@@ -2020,14 +2042,16 @@
                 if ($("#enable_ddl").is(":checked"))
                         {
                                 if ( document.getElementById("enable_getcomics").checked == false ){
-                                    document.getElementById("enable_getcomics").checked = true;
-                                    document.getElementById("enable_getcomics").setAttribute("disabled", "disabled");
+                                //    document.getElementById("enable_getcomics").checked = true;
+                                //    document.getElementById("enable_getcomics").setAttribute("disabled", "disabled");
+                                    $("#gc_options").slideUp();
+                                } else {
+                                    $("#gc_options").slideDown();
                                 }
                                 $("#ddl_providers").slideDown();
-                                $("#gc_options").slideDown();
                         }
                 else    {
-                                document.getElementById("enable_getcomics").checked = false;
+                                //document.getElementById("enable_getcomics").checked = false;
                                 $("#ddl_providers").slideUp();
                                 $("#gc_options").slideUp();
                         }
@@ -2036,15 +2060,49 @@
                         if ($("#enable_ddl").is(":checked"))
                         {
                                 if ( document.getElementById("enable_getcomics").checked == false ){
-                                    document.getElementById("enable_getcomics").checked = true;
-                                    document.getElementById("enable_getcomics").setAttribute("disabled", "disabled");
+                                //    document.getElementById("enable_getcomics").checked = true;
+                                //    document.getElementById("enable_getcomics").setAttribute("disabled", "disabled");
+                                //}
+                                    $("#gc_options").slideUp();
+                                } else {
+                                    $("#gc_options").slideDown();
                                 }
                                 $("#ddl_providers").slideDown();
                         }
                         else
                         {
-                                document.getElementById("enable_getcomics").checked = false;
+                                //document.getElementById("enable_getcomics").checked = false;
                                 $("#ddl_providers").slideUp();
+                                $("#gc_options").slideUp();
+                        }
+                });
+
+                if ($("#enable_external_server").is(":checked"))
+                        {
+                                //if ( document.getElementById("enable_getcomics").checked == false ){
+                                //    document.getElementById("enable_getcomics").checked = true;
+                                //    document.getElementById("enable_getcomics").setAttribute("disabled", "disabled");
+                                //}
+                                $("#external_options").slideDown();
+                        }
+                else    {
+                                //document.getElementById("enable_getcomics").checked = false;
+                                $("#external_options").slideUp();
+                        }
+
+                $("#enable_external_server").click(function(){
+                        if ($("#enable_external_server").is(":checked"))
+                        {
+                                //if ( document.getElementById("enable_getcomics").checked == false ){
+                                //    document.getElementById("enable_getcomics").checked = true;
+                                //    document.getElementById("enable_getcomics").setAttribute("disabled", "disabled");
+                                //}
+                                $("#external_options").slideDown();
+                        }
+                        else
+                        {
+                                //document.getElementById("enable_getcomics").checked = false;
+                                $("#external_options").slideUp();
                         }
                 });
 

--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -1707,20 +1707,20 @@ div#artistheader h2 a {
   min-width: 95px;
   vertical-align: middle;
 }
-#queue_table th#qcomicid {
-  max-width: 10px;
-  text-align: center;
-}
 #queue_table th#qseries {
-  max-width: 475px;
+  max-width: 200px;
   text-align: center;
 }
 #queue_table th#qsize {
-  max-width: 35px;
+  max-width: 40px;
+  text-align: center;
+}
+#queue_table th#qlinktype {
+  max-width: 45px;
   text-align: center;
 }
 #queue_table th#qprogress {
-  max-width: 25px;
+  max-width: 20px;
   text-align: center;
 }
 #queue_table th#qstatus {
@@ -1728,27 +1728,27 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table th#qdate {
-  max-width: 90px;
+  max-width: 75px;
   text-align: center;
 }
 #queue_table th#qoptions {
-  max-width: 160px;
+  max-width: 100px;
   text-align: center;
 }
-#queue_table td#qcomicid {
-  max-width: 10px;
-  text-align: left;
-}
 #queue_table td#qseries {
-  max-width: 475px;
+  max-width: 200px;
   text-align: left;
 }
 #queue_table td#qsize {
-  max-width: 35px;
+  max-width: 40px;
+  text-align: center;
+}
+#queue_table td#qlinktype {
+  max-width: 45px;
   text-align: center;
 }
 #queue_table td#qprogress {
-  max-width: 25px;
+  max-width: 20px;
   text-align: center;
 }
 #queue_table td#qstatus {
@@ -1756,11 +1756,11 @@ div#artistheader h2 a {
   text-align: center;
 }
 #queue_table td#qdate {
-  min-width: 90px;
+  max-width: 75px;
   text-align: center;
 }
 #queue_table td#qoptions {
-  max-width: 160px;
+  max-width: 100px;
   text-align: center;
 }
 

--- a/data/interfaces/default/queue_management.html
+++ b/data/interfaces/default/queue_management.html
@@ -59,9 +59,9 @@
               <table class="display" id="queue_table">
                <thead>
                  <tr>
-                  <th id="qcomicid">ComicID</th>
                   <th id="qseries">Series</th>
                   <th id="qsize">Size</th>
+                  <th id="qlinktype">Link</th>
                   <th id="qprogress">%</th>
                   <th id="qstatus">Status</th>
                   <th id="qdate">Updated</th>
@@ -193,26 +193,69 @@
                 $('#queue_table').DataTable().ajax.reload(null, false);
             } else {
                 $('#queue_table').DataTable( {
+                    "preDrawCallback": function (settings){
+                        pageScrollPos = $('#queue_table div.datatables_scrollBody').scrollTop();
+                    },
                     "processing": true,
                     "serverSide": true,
                     "ajaxSource": 'queueManageIt',
                     "paginationType": "full_numbers",
                     "displayLength": 25,
                     "sorting": [[5, 'desc']],
-                    "stateSave": false,
+                    "stateSave": true,
                     "columnDefs": [
+//                        {
+//                           "sortable": false,
+//                           "targets": [ 0 ],
+//                           "visible": false,
+//                        },
                         {
-                           "sortable": false,
+                           "sortable": true,
                            "targets": [ 0 ],
-                           "visible": false,
+                           "visible": true,
+                           "data": "Series",
+                           "render":function (data,type,full) {
+                                return '<span title="' + full[0] + '"></span><a href="comicDetails?ComicID=' + full[7] + '">' + full[0] + '</a>';
+                           }
                         },
                         {
                            "sortable": true,
                            "targets": [ 1 ],
                            "visible": true,
-                           "data": "Series",
                            "render":function (data,type,full) {
-                                return '<span title="' + full[1] + '"></span><a href="comicDetails?ComicID=' + full[0] + '">' + full[1] + '</a>';
+                                return full[1];
+                           }
+                        },
+                        {
+                           "sortable": true,
+                           "targets": [ 2 ],
+                           "visible": true,
+                           "render":function (data,type,full) {
+                                return full[8];
+                           }
+                        },
+                        {
+                           "sortable": true,
+                           "targets": [ 3 ],
+                           "visible": true,
+                           "render":function (data,type,full) {
+                                return full[2];
+                           }
+                        },
+                        {
+                           "sortable": true,
+                           "targets": [ 4 ],
+                           "visible": true,
+                           "render":function (data,type,full) {
+                                return full[3];
+                           }
+                        },
+                        {
+                           "sortable": true,
+                           "targets": [ 5 ],
+                           "visible": true,
+                           "render":function (data,type,full) {
+                                return full[4];
                            }
                         },
                         {
@@ -220,10 +263,10 @@
                            "targets": [ 6 ],
                            "visible": true,
                            "render":function (data,type,full) {
-                                    val = full[4]
-                                    var restartline = "('ddl_requeue?mode=restart&id="+String(full[6])+"',$(this));"
-                                    var resumeline = "('ddl_requeue?mode=resume&id="+String(full[6])+"',$(this));"
-                                    var removeline = "('ddl_requeue?mode=remove&id="+String(full[6])+"',$(this));"
+                                    val = full[3]
+                                    var restartline = "('ddl_requeue?mode=restart&id="+String(full[5])+"',$(this));"
+                                    var resumeline = "('ddl_requeue?mode=resume&id="+String(full[5])+"',$(this));"
+                                    var removeline = "('ddl_requeue?mode=remove&id="+String(full[5])+"',$(this));"
                                     if (val == 'Completed' || val == 'Failed' || val == 'Downloading'){
                                         return '<span title="Restart"></span><a href="#" onclick="doAjaxCall'+restartline+'">Restart</a><span title="Remove"></span><a href="#" onclick="doAjaxCall'+removeline+'"><span class="ui-icon ui-icon-plus"></span>Remove</a>';
                                     } else if (val == 'Incomplete') {
@@ -243,24 +286,25 @@
                          "infoFiltered":"(filtered from _MAX_ total items)"
                      },
                     "rowCallback": function (nRow, aData, iDisplayIndex, iDisplayIndexFull) {
-                         if (aData[4] === "Completed") {
+                         if (aData[3] === "Completed") {
                             $('td', nRow).closest('tr').addClass("gradeA");
-                         } else if (aData[4] === "Queued") {
+                         } else if (aData[3] === "Queued") {
                             $('td', nRow).closest('tr').addClass("gradeC");
-                         } else if (aData[4] === "Incomplete" || aData[4] == "Failed") {
+                         } else if (aData[3] === "Incomplete" || aData[3] == "Failed") {
                             $('td', nRow).closest('tr').addClass("gradeX");
                          }
-                         nRow.children[0].id = 'qcomicid';
-                         nRow.children[1].id = 'qseries';
-                         nRow.children[2].id = 'qsize';
-                         nRow.children[3].id = 'qprogress';
-                         nRow.children[4].id = 'qstatus';
-                         nRow.children[5].id = 'qdate';
+                         //nRow.children[0].id = 'qcomicid';
+                         nRow.children[0].id = 'qseries';
+                         nRow.children[1].id = 'qsize';
+                         nRow.children[2].id = 'qprogress';
+                         nRow.children[3].id = 'qstatus';
+                         nRow.children[4].id = 'qdate';
                          return nRow;
                      },
                      "drawCallback": function (o) {
                          // Jump to top of page
                          $('html,body').scrollTop(0);
+                         $('#queue_table div.dataTables_scrollBody').scrollTop(pageScrollPos);
                      },
                      "serverData": function ( sSource, aoData, fnCallback ) {
                                 /* Add some extra data to the sender */

--- a/data/interfaces/default/searchresults.html
+++ b/data/interfaces/default/searchresults.html
@@ -217,11 +217,11 @@
                                 }
                             }
 
-                            var dropdown = "<select name='booktype' id='booktype' onchange='update_location("+comicid+",null, booktype)' style='font-size:14px;'>"+
+                            var dropdown = "<select name='booktype' id='booktype' onChange='update_location("+comicid+",null, booktype)' style='font-size:14px;'>"+
                                "<option value='Print' selected='selected'>Print</option>" +
                                "<option value='TPB'>TPB</option>" +
                                "<option value='HC'>HC</option>" +
-                               "<option value='GC'>GC</option>" +
+                               "<option value='GN'>GN</option>" +
                                "<option value='One-Shot'>One-Shot</option>" +
                                "<option value='Digital'>Digital</option>" +
                                "</select>";
@@ -255,7 +255,6 @@
             var bktype = document.getElementById("booktype");
             var booktype = bktype.options[bktype.selectedIndex];
             var query_id = retrieve_searchquery();
-            console.log(location.value + ' --- '+ booktype.text);
             if (comlocation){
                 cloc = location.value;
             } else {
@@ -275,6 +274,7 @@
                 }
                 if (btype) {
                     bktype.text = dc.booktype;
+                    location.value = dc.comlocation;
                 }
            });
         }

--- a/lib/mega/__init__.py
+++ b/lib/mega/__init__.py
@@ -1,0 +1,1 @@
+from .mega import Mega  # noqa

--- a/lib/mega/crypto.py
+++ b/lib/mega/crypto.py
@@ -1,0 +1,168 @@
+from Crypto.Cipher import AES
+import json
+import base64
+import struct
+import binascii
+import random
+import sys
+
+# Python3 compatibility
+if sys.version_info < (3, ):
+
+    def makebyte(x):
+        return x
+
+    def makestring(x):
+        return x
+else:
+    import codecs
+
+    def makebyte(x):
+        return codecs.latin_1_encode(x)[0]
+
+    def makestring(x):
+        return codecs.latin_1_decode(x)[0]
+
+
+def aes_cbc_encrypt(data, key):
+    aes_cipher = AES.new(key, AES.MODE_CBC, makebyte('\0' * 16))
+    return aes_cipher.encrypt(data)
+
+
+def aes_cbc_decrypt(data, key):
+    aes_cipher = AES.new(key, AES.MODE_CBC, makebyte('\0' * 16))
+    return aes_cipher.decrypt(data)
+
+
+def aes_cbc_encrypt_a32(data, key):
+    return str_to_a32(aes_cbc_encrypt(a32_to_str(data), a32_to_str(key)))
+
+
+def aes_cbc_decrypt_a32(data, key):
+    return str_to_a32(aes_cbc_decrypt(a32_to_str(data), a32_to_str(key)))
+
+
+def stringhash(str, aeskey):
+    s32 = str_to_a32(str)
+    h32 = [0, 0, 0, 0]
+    for i in range(len(s32)):
+        h32[i % 4] ^= s32[i]
+    for r in range(0x4000):
+        h32 = aes_cbc_encrypt_a32(h32, aeskey)
+    return a32_to_base64((h32[0], h32[2]))
+
+
+def prepare_key(arr):
+    pkey = [0x93C467E3, 0x7DB0C7A4, 0xD1BE3F81, 0x0152CB56]
+    for r in range(0x10000):
+        for j in range(0, len(arr), 4):
+            key = [0, 0, 0, 0]
+            for i in range(4):
+                if i + j < len(arr):
+                    key[i] = arr[i + j]
+            pkey = aes_cbc_encrypt_a32(pkey, key)
+    return pkey
+
+
+def encrypt_key(a, key):
+    return sum((aes_cbc_encrypt_a32(a[i:i + 4], key)
+                for i in range(0, len(a), 4)), ())
+
+
+def decrypt_key(a, key):
+    return sum((aes_cbc_decrypt_a32(a[i:i + 4], key)
+                for i in range(0, len(a), 4)), ())
+
+
+def encrypt_attr(attr, key):
+    attr = makebyte('MEGA' + json.dumps(attr))
+    if len(attr) % 16:
+        attr += b'\0' * (16 - len(attr) % 16)
+    return aes_cbc_encrypt(attr, a32_to_str(key))
+
+
+def decrypt_attr(attr, key):
+    attr = aes_cbc_decrypt(attr, a32_to_str(key))
+    attr = makestring(attr)
+    attr = attr.rstrip('\0')
+    return json.loads(attr[4:]) if attr[:6] == 'MEGA{"' else False
+
+
+def a32_to_str(a):
+    return struct.pack('>%dI' % len(a), *a)
+
+
+def str_to_a32(b):
+    if isinstance(b, str):
+        b = makebyte(b)
+    if len(b) % 4:
+        # pad to multiple of 4
+        b += b'\0' * (4 - len(b) % 4)
+    return struct.unpack('>%dI' % (len(b) / 4), b)
+
+
+def mpi_to_int(s):
+    """
+    A Multi-precision integer is encoded as a series of bytes in big-endian
+    order. The first two bytes are a header which tell the number of bits in
+    the integer. The rest of the bytes are the integer.
+    """
+    return int(binascii.hexlify(s[2:]), 16)
+
+
+def extended_gcd(a, b):
+    if a == 0:
+        return (b, 0, 1)
+    else:
+        g, y, x = extended_gcd(b % a, a)
+        return (g, x - (b // a) * y, y)
+
+
+def modular_inverse(a, m):
+    g, x, y = extended_gcd(a, m)
+    if g != 1:
+        raise Exception('modular inverse does not exist')
+    else:
+        return x % m
+
+
+def base64_url_decode(data):
+    data += '=='[(2 - len(data) * 3) % 4:]
+    for search, replace in (('-', '+'), ('_', '/'), (',', '')):
+        data = data.replace(search, replace)
+    return base64.b64decode(data)
+
+
+def base64_to_a32(s):
+    return str_to_a32(base64_url_decode(s))
+
+
+def base64_url_encode(data):
+    data = base64.b64encode(data)
+    data = makestring(data)
+    for search, replace in (('+', '-'), ('/', '_'), ('=', '')):
+        data = data.replace(search, replace)
+    return data
+
+
+def a32_to_base64(a):
+    return base64_url_encode(a32_to_str(a))
+
+
+def get_chunks(size):
+    p = 0
+    s = 0x20000
+    while p + s < size:
+        yield (p, s)
+        p += s
+        if s < 0x100000:
+            s += 0x20000
+    yield (p, size - p)
+
+
+def make_id(length):
+    text = ''
+    possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    for i in range(length):
+        text += random.choice(possible)
+    return text

--- a/lib/mega/errors.py
+++ b/lib/mega/errors.py
@@ -1,0 +1,62 @@
+class ValidationError(Exception):
+    """
+    Error in validation stage
+    """
+    pass
+
+
+_CODE_TO_DESCRIPTIONS = {
+    -1: ('EINTERNAL',
+         ('An internal error has occurred. Please submit a bug report, '
+          'detailing the exact circumstances in which this error occurred')),
+    -2: ('EARGS', 'You have passed invalid arguments to this command'),
+    -3: ('EAGAIN',
+         ('(always at the request level) A temporary congestion or server '
+          'malfunction prevented your request from being processed. '
+          'No data was altered. Retry. Retries must be spaced with '
+          'exponential backoff')),
+    -4: ('ERATELIMIT',
+         ('You have exceeded your command weight per time quota. Please '
+          'wait a few seconds, then try again (this should never happen '
+          'in sane real-life applications)')),
+    -5: ('EFAILED', 'The upload failed. Please restart it from scratch'),
+    -6:
+    ('ETOOMANY',
+     'Too many concurrent IP addresses are accessing this upload target URL'),
+    -7:
+    ('ERANGE', ('The upload file packet is out of range or not starting and '
+                'ending on a chunk boundary')),
+    -8: ('EEXPIRED',
+         ('The upload target URL you are trying to access has expired. '
+          'Please request a fresh one')),
+    -9: ('ENOENT', 'Object (typically, node or user) not found'),
+    -10: ('ECIRCULAR', 'Circular linkage attempted'),
+    -11: ('EACCESS',
+          'Access violation (e.g., trying to write to a read-only share)'),
+    -12: ('EEXIST', 'Trying to create an object that already exists'),
+    -13: ('EINCOMPLETE', 'Trying to access an incomplete resource'),
+    -14: ('EKEY', 'A decryption operation failed (never returned by the API)'),
+    -15: ('ESID', 'Invalid or expired user session, please relogin'),
+    -16: ('EBLOCKED', 'User blocked'),
+    -17: ('EOVERQUOTA', 'Request over quota'),
+    -18: ('ETEMPUNAVAIL',
+          'Resource temporarily not available, please try again later'),
+    -19: ('ETOOMANYCONNECTIONS', 'many connections on this resource'),
+    -20: ('EWRITE', 'Write failed'),
+    -21: ('EREAD', 'Read failed'),
+    -22: ('EAPPKEY', 'Invalid application key; request not processed'),
+}
+
+
+class RequestError(Exception):
+    """
+    Error in API request
+    """
+    def __init__(self, message):
+        code = message
+        self.code = code
+        code_desc, long_desc = _CODE_TO_DESCRIPTIONS[code]
+        self.message = f'{code_desc}, {long_desc}'
+
+    def __str__(self):
+        return self.message

--- a/lib/mega/mega.py
+++ b/lib/mega/mega.py
@@ -1,0 +1,1090 @@
+import math
+import re
+import json
+import logging
+import secrets
+from pathlib import Path
+import hashlib
+from Crypto.Cipher import AES
+from Crypto.PublicKey import RSA
+from Crypto.Util import Counter
+import os
+import random
+import binascii
+import tempfile
+import shutil
+
+import requests
+from tenacity import retry, wait_exponential, retry_if_exception_type
+
+from .errors import ValidationError, RequestError
+from .crypto import (a32_to_base64, encrypt_key, base64_url_encode,
+                     encrypt_attr, base64_to_a32, base64_url_decode,
+                     decrypt_attr, a32_to_str, get_chunks, str_to_a32,
+                     decrypt_key, mpi_to_int, stringhash, prepare_key, make_id,
+                     makebyte, modular_inverse)
+
+logger = logging.getLogger(__name__)
+
+
+class Mega:
+    def __init__(self, options=None):
+        self.schema = 'https'
+        self.domain = 'mega.co.nz'
+        self.timeout = 160  # max secs to wait for resp from api requests
+        self.sid = None
+        self.sequence_num = random.randint(0, 0xFFFFFFFF)
+        self.request_id = make_id(10)
+        self._trash_folder_node_id = None
+
+        if options is None:
+            options = {}
+        self.options = options
+
+    def login(self, email=None, password=None):
+        if email:
+            self._login_user(email, password)
+        else:
+            self.login_anonymous()
+        self._trash_folder_node_id = self.get_node_by_type(4)[0]
+        logger.info('Login complete')
+        return self
+
+    def _login_user(self, email, password):
+        logger.info('Logging in user...')
+        email = email.lower()
+        get_user_salt_resp = self._api_request({'a': 'us0', 'user': email})
+        user_salt = None
+        try:
+            user_salt = base64_to_a32(get_user_salt_resp['s'])
+        except KeyError:
+            # v1 user account
+            password_aes = prepare_key(str_to_a32(password))
+            user_hash = stringhash(email, password_aes)
+        else:
+            # v2 user account
+            pbkdf2_key = hashlib.pbkdf2_hmac(hash_name='sha512',
+                                             password=password.encode(),
+                                             salt=a32_to_str(user_salt),
+                                             iterations=100000,
+                                             dklen=32)
+            password_aes = str_to_a32(pbkdf2_key[:16])
+            user_hash = base64_url_encode(pbkdf2_key[-16:])
+        resp = self._api_request({'a': 'us', 'user': email, 'uh': user_hash})
+        if isinstance(resp, int):
+            raise RequestError(resp)
+        self._login_process(resp, password_aes)
+
+    def login_anonymous(self):
+        logger.info('Logging in anonymous temporary user...')
+        master_key = [random.randint(0, 0xFFFFFFFF)] * 4
+        password_key = [random.randint(0, 0xFFFFFFFF)] * 4
+        session_self_challenge = [random.randint(0, 0xFFFFFFFF)] * 4
+
+        user = self._api_request({
+            'a':
+            'up',
+            'k':
+            a32_to_base64(encrypt_key(master_key, password_key)),
+            'ts':
+            base64_url_encode(
+                a32_to_str(session_self_challenge) +
+                a32_to_str(encrypt_key(session_self_challenge, master_key)))
+        })
+
+        resp = self._api_request({'a': 'us', 'user': user})
+        if isinstance(resp, int):
+            raise RequestError(resp)
+        self._login_process(resp, password_key)
+
+    def _login_process(self, resp, password):
+        encrypted_master_key = base64_to_a32(resp['k'])
+        self.master_key = decrypt_key(encrypted_master_key, password)
+        if 'tsid' in resp:
+            tsid = base64_url_decode(resp['tsid'])
+            key_encrypted = a32_to_str(
+                encrypt_key(str_to_a32(tsid[:16]), self.master_key))
+            if key_encrypted == tsid[-16:]:
+                self.sid = resp['tsid']
+        elif 'csid' in resp:
+            encrypted_rsa_private_key = base64_to_a32(resp['privk'])
+            rsa_private_key = decrypt_key(encrypted_rsa_private_key,
+                                          self.master_key)
+
+            private_key = a32_to_str(rsa_private_key)
+            # The private_key contains 4 MPI integers concatenated together.
+            rsa_private_key = [0, 0, 0, 0]
+            for i in range(4):
+                # An MPI integer has a 2-byte header which describes the number
+                # of bits in the integer.
+                bitlength = (private_key[0] * 256) + private_key[1]
+                bytelength = math.ceil(bitlength / 8)
+                # Add 2 bytes to accommodate the MPI header
+                bytelength += 2
+                rsa_private_key[i] = mpi_to_int(private_key[:bytelength])
+                private_key = private_key[bytelength:]
+
+            first_factor_p = rsa_private_key[0]
+            second_factor_q = rsa_private_key[1]
+            private_exponent_d = rsa_private_key[2]
+            # In MEGA's webclient javascript, they assign [3] to a variable
+            # called u, but I do not see how it corresponds to pycryptodome's
+            # RSA.construct and it does not seem to be necessary.
+            rsa_modulus_n = first_factor_p * second_factor_q
+            phi = (first_factor_p - 1) * (second_factor_q - 1)
+            public_exponent_e = modular_inverse(private_exponent_d, phi)
+
+            rsa_components = (
+                rsa_modulus_n,
+                public_exponent_e,
+                private_exponent_d,
+                first_factor_p,
+                second_factor_q,
+            )
+            rsa_decrypter = RSA.construct(rsa_components)
+
+            encrypted_sid = mpi_to_int(base64_url_decode(resp['csid']))
+
+            sid = '%x' % rsa_decrypter._decrypt(encrypted_sid)
+            sid = binascii.unhexlify('0' + sid if len(sid) % 2 else sid)
+            self.sid = base64_url_encode(sid[:43])
+
+    @retry(retry=retry_if_exception_type(RuntimeError),
+           wait=wait_exponential(multiplier=2, min=2, max=60))
+    def _api_request(self, data):
+        params = {'id': self.sequence_num}
+        self.sequence_num += 1
+
+        if self.sid:
+            params.update({'sid': self.sid})
+
+        # ensure input data is a list
+        if not isinstance(data, list):
+            data = [data]
+
+        url = f'{self.schema}://g.api.{self.domain}/cs'
+        response = requests.post(
+            url,
+            params=params,
+            data=json.dumps(data),
+            timeout=self.timeout,
+        )
+        json_resp = json.loads(response.text)
+        int_resp = None
+        try:
+            if isinstance(json_resp, list):
+                int_resp = json_resp[0] if isinstance(json_resp[0],
+                                                      int) else None
+            elif isinstance(json_resp, int):
+                int_resp = json_resp
+        except IndexError:
+            int_resp = None
+        if int_resp is not None:
+            if int_resp == 0:
+                return int_resp
+            if int_resp == -3:
+                msg = 'Request failed, retrying'
+                logger.info(msg)
+                raise RuntimeError(msg)
+            raise RequestError(int_resp)
+        return json_resp[0]
+
+    def _parse_url(self, url):
+        """Parse file id and key from url."""
+        if 'getcomics' in url.lower():
+            r = requests.head(url, verify=True)
+            if r.status_code == 302:
+                # 302 is redirect from CF so this is needed
+                url = r.headers['Location']
+        if '/file/' in url:
+            # V2 URL structure
+            url = url.replace(' ', '')
+            file_id = re.findall(r'\W\w\w\w\w\w\w\w\w\W', url)[0][1:-1]
+            id_index = re.search(file_id, url).end()
+            key = url[id_index + 1:]
+            return f'{file_id}!{key}'
+        elif '!' in url:
+            # V1 URL structure
+            match = re.findall(r'/#!(.*)', url)
+            path = match[0]
+            return path
+        else:
+            raise RequestError('Url key missing')
+
+    def _process_file(self, file, shared_keys):
+        if file['t'] == 0 or file['t'] == 1:
+            keys = dict(
+                keypart.split(':', 1) for keypart in file['k'].split('/')
+                if ':' in keypart)
+            uid = file['u']
+            key = None
+            # my objects
+            if uid in keys:
+                key = decrypt_key(base64_to_a32(keys[uid]), self.master_key)
+            # shared folders
+            elif 'su' in file and 'sk' in file and ':' in file['k']:
+                shared_key = decrypt_key(base64_to_a32(file['sk']),
+                                         self.master_key)
+                key = decrypt_key(base64_to_a32(keys[file['h']]), shared_key)
+                if file['su'] not in shared_keys:
+                    shared_keys[file['su']] = {}
+                shared_keys[file['su']][file['h']] = shared_key
+            # shared files
+            elif file['u'] and file['u'] in shared_keys:
+                for hkey in shared_keys[file['u']]:
+                    shared_key = shared_keys[file['u']][hkey]
+                    if hkey in keys:
+                        key = keys[hkey]
+                        key = decrypt_key(base64_to_a32(key), shared_key)
+                        break
+            if file['h'] and file['h'] in shared_keys.get('EXP', ()):
+                shared_key = shared_keys['EXP'][file['h']]
+                encrypted_key = str_to_a32(
+                    base64_url_decode(file['k'].split(':')[-1]))
+                key = decrypt_key(encrypted_key, shared_key)
+                file['shared_folder_key'] = shared_key
+            if key is not None:
+                # file
+                if file['t'] == 0:
+                    k = (key[0] ^ key[4], key[1] ^ key[5], key[2] ^ key[6],
+                         key[3] ^ key[7])
+                    file['iv'] = key[4:6] + (0, 0)
+                    file['meta_mac'] = key[6:8]
+                # folder
+                else:
+                    k = key
+                file['key'] = key
+                file['k'] = k
+                attributes = base64_url_decode(file['a'])
+                attributes = decrypt_attr(attributes, k)
+                file['a'] = attributes
+            # other => wrong object
+            elif file['k'] == '':
+                file['a'] = False
+        elif file['t'] == 2:
+            self.root_id = file['h']
+            file['a'] = {'n': 'Cloud Drive'}
+        elif file['t'] == 3:
+            self.inbox_id = file['h']
+            file['a'] = {'n': 'Inbox'}
+        elif file['t'] == 4:
+            self.trashbin_id = file['h']
+            file['a'] = {'n': 'Rubbish Bin'}
+        return file
+
+    def _init_shared_keys(self, files, shared_keys):
+        """
+        Init shared key not associated with a user.
+        Seems to happen when a folder is shared,
+        some files are exchanged and then the
+        folder is un-shared.
+        Keys are stored in files['s'] and files['ok']
+        """
+        ok_dict = {}
+        for ok_item in files['ok']:
+            shared_key = decrypt_key(base64_to_a32(ok_item['k']),
+                                     self.master_key)
+            ok_dict[ok_item['h']] = shared_key
+        for s_item in files['s']:
+            if s_item['u'] not in shared_keys:
+                shared_keys[s_item['u']] = {}
+            if s_item['h'] in ok_dict:
+                shared_keys[s_item['u']][s_item['h']] = ok_dict[s_item['h']]
+        self.shared_keys = shared_keys
+
+    def find_path_descriptor(self, path, files=()):
+        """
+        Find descriptor of folder inside a path. i.e.: folder1/folder2/folder3
+        Params:
+            path, string like folder1/folder2/folder3
+        Return:
+            Descriptor (str) of folder3 if exists, None otherwise
+        """
+        paths = path.split('/')
+
+        files = files or self.get_files()
+        parent_desc = self.root_id
+        found = False
+        for foldername in paths:
+            if foldername != '':
+                for file in files.items():
+                    if (file[1]['a'] and file[1]['t']
+                            and file[1]['a']['n'] == foldername):
+                        if parent_desc == file[1]['p']:
+                            parent_desc = file[0]
+                            found = True
+                if found:
+                    found = False
+                else:
+                    return None
+        return parent_desc
+
+    def find(self, filename=None, handle=None, exclude_deleted=False):
+        """
+        Return file object from given filename
+        """
+        files = self.get_files()
+        if handle:
+            return files[handle]
+        path = Path(filename)
+        filename = path.name
+        parent_dir_name = path.parent.name
+        for file in list(files.items()):
+            parent_node_id = None
+            try:
+                if parent_dir_name:
+                    parent_node_id = self.find_path_descriptor(parent_dir_name,
+                                                               files=files)
+                    if (filename and parent_node_id and file[1]['a']
+                            and file[1]['a']['n'] == filename
+                            and parent_node_id == file[1]['p']):
+                        if (exclude_deleted and self._trash_folder_node_id
+                                == file[1]['p']):
+                            continue
+                        return file
+                elif (filename and file[1]['a']
+                      and file[1]['a']['n'] == filename):
+                    if (exclude_deleted
+                            and self._trash_folder_node_id == file[1]['p']):
+                        continue
+                    return file
+            except TypeError:
+                continue
+
+    def get_files(self):
+        logger.info('Getting all files...')
+        files = self._api_request({'a': 'f', 'c': 1, 'r': 1})
+        files_dict = {}
+        shared_keys = {}
+        self._init_shared_keys(files, shared_keys)
+        for file in files['f']:
+            processed_file = self._process_file(file, shared_keys)
+            # ensure each file has a name before returning
+            if processed_file['a']:
+                files_dict[file['h']] = processed_file
+        return files_dict
+
+    def get_upload_link(self, file):
+        """
+        Get a files public link inc. decrypted key
+        Requires upload() response as input
+        """
+        if 'f' in file:
+            file = file['f'][0]
+            public_handle = self._api_request({'a': 'l', 'n': file['h']})
+            file_key = file['k'][file['k'].index(':') + 1:]
+            decrypted_key = a32_to_base64(
+                decrypt_key(base64_to_a32(file_key), self.master_key))
+            return (f'{self.schema}://{self.domain}'
+                    f'/#!{public_handle}!{decrypted_key}')
+        else:
+            raise ValueError('''Upload() response required as input,
+                            use get_link() for regular file input''')
+
+    def get_link(self, file):
+        """
+        Get a file public link from given file object
+        """
+        file = file[1]
+        if 'h' in file and 'k' in file:
+            public_handle = self._api_request({'a': 'l', 'n': file['h']})
+            if public_handle == -11:
+                raise RequestError("Can't get a public link from that file "
+                                   "(is this a shared file?)")
+            decrypted_key = a32_to_base64(file['key'])
+            return (f'{self.schema}://{self.domain}'
+                    f'/#!{public_handle}!{decrypted_key}')
+        else:
+            raise ValidationError('File id and key must be present')
+
+    def _node_data(self, node):
+        try:
+            return node[1]
+        except (IndexError, KeyError):
+            return node
+
+    def get_folder_link(self, file):
+        try:
+            file = file[1]
+        except (IndexError, KeyError):
+            pass
+        if 'h' in file and 'k' in file:
+            public_handle = self._api_request({'a': 'l', 'n': file['h']})
+            if public_handle == -11:
+                raise RequestError("Can't get a public link from that file "
+                                   "(is this a shared file?)")
+            decrypted_key = a32_to_base64(file['shared_folder_key'])
+            return (f'{self.schema}://{self.domain}'
+                    f'/#F!{public_handle}!{decrypted_key}')
+        else:
+            raise ValidationError('File id and key must be present')
+
+    def get_user(self):
+        user_data = self._api_request({'a': 'ug'})
+        return user_data
+
+    def get_node_by_type(self, type):
+        """
+        Get a node by it's numeric type id, e.g:
+        0: file
+        1: dir
+        2: special: root cloud drive
+        3: special: inbox
+        4: special trash bin
+        """
+        nodes = self.get_files()
+        for node in list(nodes.items()):
+            if node[1]['t'] == type:
+                return node
+
+    def get_files_in_node(self, target):
+        """
+        Get all files in a given target, e.g. 4=trash
+        """
+        if type(target) == int:
+            # convert special nodes (e.g. trash)
+            node_id = self.get_node_by_type(target)
+        else:
+            node_id = [target]
+
+        files = self._api_request({'a': 'f', 'c': 1})
+        files_dict = {}
+        shared_keys = {}
+        self._init_shared_keys(files, shared_keys)
+        for file in files['f']:
+            processed_file = self._process_file(file, shared_keys)
+            if processed_file['a'] and processed_file['p'] == node_id[0]:
+                files_dict[file['h']] = processed_file
+        return files_dict
+
+    def get_id_from_public_handle(self, public_handle):
+        # get node data
+        node_data = self._api_request({'a': 'f', 'f': 1, 'p': public_handle})
+        node_id = self.get_id_from_obj(node_data)
+        return node_id
+
+    def get_id_from_obj(self, node_data):
+        """
+        Get node id from a file object
+        """
+        node_id = None
+
+        for i in node_data['f']:
+            if i['h'] != '':
+                node_id = i['h']
+        return node_id
+
+    def get_quota(self):
+        """
+        Get current remaining disk quota in MegaBytes
+        """
+        json_resp = self._api_request({
+            'a': 'uq',
+            'xfer': 1,
+            'strg': 1,
+            'v': 1
+        })
+        # convert bytes to megabyes
+        return json_resp['mstrg'] / 1048576
+
+    def get_storage_space(self, giga=False, mega=False, kilo=False):
+        """
+        Get the current storage space.
+        Return a dict containing at least:
+          'used' : the used space on the account
+          'total' : the maximum space allowed with current plan
+        All storage space are in bytes unless asked differently.
+        """
+        if sum(1 if x else 0 for x in (kilo, mega, giga)) > 1:
+            raise ValueError("Only one unit prefix can be specified")
+        unit_coef = 1
+        if kilo:
+            unit_coef = 1024
+        if mega:
+            unit_coef = 1048576
+        if giga:
+            unit_coef = 1073741824
+        json_resp = self._api_request({'a': 'uq', 'xfer': 1, 'strg': 1})
+        return {
+            'used': json_resp['cstrg'] / unit_coef,
+            'total': json_resp['mstrg'] / unit_coef,
+        }
+
+    def get_balance(self):
+        """
+        Get account monetary balance, Pro accounts only
+        """
+        user_data = self._api_request({"a": "uq", "pro": 1})
+        if 'balance' in user_data:
+            return user_data['balance']
+
+    def delete(self, public_handle):
+        """
+        Delete a file by its public handle
+        """
+        return self.move(public_handle, 4)
+
+    def delete_url(self, url):
+        """
+        Delete a file by its url
+        """
+        path = self._parse_url(url).split('!')
+        public_handle = path[0]
+        file_id = self.get_id_from_public_handle(public_handle)
+        return self.move(file_id, 4)
+
+    def destroy(self, file_id):
+        """
+        Destroy a file by its private id
+        """
+        return self._api_request({
+            'a': 'd',
+            'n': file_id,
+            'i': self.request_id
+        })
+
+    def destroy_url(self, url):
+        """
+        Destroy a file by its url
+        """
+        path = self._parse_url(url).split('!')
+        public_handle = path[0]
+        file_id = self.get_id_from_public_handle(public_handle)
+        return self.destroy(file_id)
+
+    def empty_trash(self):
+        # get list of files in rubbish out
+        files = self.get_files_in_node(4)
+
+        # make a list of json
+        if files != {}:
+            post_list = []
+            for file in files:
+                post_list.append({"a": "d", "n": file, "i": self.request_id})
+            return self._api_request(post_list)
+
+    def download(self, file, dest_path=None, dest_filename=None):
+        """
+        Download a file by it's file object
+        """
+        return self._download_file(file_handle=None,
+                                   file_key=None,
+                                   file=file[1],
+                                   dest_path=dest_path,
+                                   dest_filename=dest_filename,
+                                   is_public=False)
+
+    def _export_file(self, node):
+        node_data = self._node_data(node)
+        self._api_request([{
+            'a': 'l',
+            'n': node_data['h'],
+            'i': self.request_id
+        }])
+        return self.get_link(node)
+
+    def export(self, path=None, node_id=None):
+        nodes = self.get_files()
+        if node_id:
+            node = nodes[node_id]
+        else:
+            node = self.find(path)
+
+        node_data = self._node_data(node)
+        is_file_node = node_data['t'] == 0
+        if is_file_node:
+            return self._export_file(node)
+        if node:
+            try:
+                # If already exported
+                return self.get_folder_link(node)
+            except (RequestError, KeyError):
+                pass
+
+        master_key_cipher = AES.new(a32_to_str(self.master_key), AES.MODE_ECB)
+        ha = base64_url_encode(
+            master_key_cipher.encrypt(node_data['h'].encode("utf8") +
+                                      node_data['h'].encode("utf8")))
+
+        share_key = secrets.token_bytes(16)
+        ok = base64_url_encode(master_key_cipher.encrypt(share_key))
+
+        share_key_cipher = AES.new(share_key, AES.MODE_ECB)
+        node_key = node_data['k']
+        encrypted_node_key = base64_url_encode(
+            share_key_cipher.encrypt(a32_to_str(node_key)))
+
+        node_id = node_data['h']
+        request_body = [{
+            'a':
+            's2',
+            'n':
+            node_id,
+            's': [{
+                'u': 'EXP',
+                'r': 0
+            }],
+            'i':
+            self.request_id,
+            'ok':
+            ok,
+            'ha':
+            ha,
+            'cr': [[node_id], [node_id], [0, 0, encrypted_node_key]]
+        }]
+        self._api_request(request_body)
+        nodes = self.get_files()
+        return self.get_folder_link(nodes[node_id])
+
+    def download_url(self, url, dest_path=None, dest_filename=None, progress_hook=None, progress_args=None):
+        """
+        Download a file by it's public url
+        """
+        path = self._parse_url(url).split('!')
+        file_id = path[0]
+        file_key = path[1]
+        return self._download_file(
+            file_handle=file_id,
+            file_key=file_key,
+            dest_path=dest_path,
+            dest_filename=dest_filename,
+            is_public=True,
+            progress_hook=progress_hook,
+            progress_args=progress_args,
+        )
+
+    def _download_file(self,
+                       file_handle,
+                       file_key,
+                       dest_path=None,
+                       dest_filename=None,
+                       is_public=False,
+                       file=None,
+                       progress_hook=None,
+                       progress_args=None):
+        if file is None:
+            if is_public:
+                file_key = base64_to_a32(file_key)
+                file_data = self._api_request({
+                    'a': 'g',
+                    'g': 1,
+                    'p': file_handle
+                })
+            else:
+                file_data = self._api_request({
+                    'a': 'g',
+                    'g': 1,
+                    'n': file_handle
+                })
+
+            k = (file_key[0] ^ file_key[4], file_key[1] ^ file_key[5],
+                 file_key[2] ^ file_key[6], file_key[3] ^ file_key[7])
+            iv = file_key[4:6] + (0, 0)
+            meta_mac = file_key[6:8]
+        else:
+            file_data = self._api_request({'a': 'g', 'g': 1, 'n': file['h']})
+            k = file['k']
+            iv = file['iv']
+            meta_mac = file['meta_mac']
+
+        # Seems to happens sometime... When this occurs, files are
+        # inaccessible also in the official also in the official web app.
+        # Strangely, files can come back later.
+        if 'g' not in file_data:
+            raise RequestError('File not accessible anymore')
+        file_url = file_data['g']
+        file_size = file_data['s']
+        attribs = base64_url_decode(file_data['at'])
+        attribs = decrypt_attr(attribs, k)
+
+        if dest_filename is not None:
+            file_name = dest_filename
+        else:
+            file_name = attribs['n']
+
+        input_file = requests.get(file_url, stream=True).raw
+
+        if dest_path is None:
+            dest_path = ''
+        else:
+            dest_path += '/'
+
+        with tempfile.NamedTemporaryFile(mode='w+b',
+                                         prefix='megapy_',
+                                         delete=False) as temp_output_file:
+            k_str = a32_to_str(k)
+            counter = Counter.new(128,
+                                  initial_value=((iv[0] << 32) + iv[1]) << 64)
+            aes = AES.new(k_str, AES.MODE_CTR, counter=counter)
+
+            mac_str = '\0' * 16
+            mac_encryptor = AES.new(k_str, AES.MODE_CBC,
+                                    mac_str.encode("utf8"))
+            iv_str = a32_to_str([iv[0], iv[1], iv[0], iv[1]])
+
+            for chunk_start, chunk_size in get_chunks(file_size):
+                chunk = input_file.read(chunk_size)
+                chunk = aes.decrypt(chunk)
+                temp_output_file.write(chunk)
+
+                encryptor = AES.new(k_str, AES.MODE_CBC, iv_str)
+                for i in range(0, len(chunk) - 16, 16):
+                    block = chunk[i:i + 16]
+                    encryptor.encrypt(block)
+
+                # fix for files under 16 bytes failing
+                if file_size > 16:
+                    i += 16
+                else:
+                    i = 0
+
+                block = chunk[i:i + 16]
+                if len(block) % 16:
+                    block += b'\0' * (16 - (len(block) % 16))
+                mac_str = mac_encryptor.encrypt(encryptor.encrypt(block))
+
+                file_info = os.stat(temp_output_file.name)
+                logger.info('%s of %s downloaded', file_info.st_size,
+                            file_size)
+                if progress_hook:
+                    progress_hook({
+                        'current': file_info.st_size,
+                        'total': file_size,
+                        'name': file_name,
+                        'tmp_filename': temp_output_file.name,
+                        'status': 'downloading',
+                        'args': progress_args
+                    })
+            file_mac = str_to_a32(mac_str)
+            # check mac integrity
+            if (file_mac[0] ^ file_mac[1],
+                    file_mac[2] ^ file_mac[3]) != meta_mac:
+                raise ValueError('Mismatched mac')
+            output_path = Path(dest_path + file_name)
+            file_info = os.stat(temp_output_file.name)
+            temp_output_file.close()
+            shutil.move(temp_output_file.name, output_path)
+            if progress_hook:
+                progress_hook({
+                    'current': file_info.st_size,
+                    'total': file_size,
+                    'name': file_name,
+                    'tmp_filename': temp_output_file.name,
+                    'status': 'finished',
+                    'args': progress_args
+                })
+            return output_path
+
+    def upload(self, filename, dest=None, dest_filename=None):
+        # determine storage node
+        if dest is None:
+            # if none set, upload to cloud drive node
+            if not hasattr(self, 'root_id'):
+                self.get_files()
+            dest = self.root_id
+
+        # request upload url, call 'u' method
+        with open(filename, 'rb') as input_file:
+            file_size = os.path.getsize(filename)
+            ul_url = self._api_request({'a': 'u', 's': file_size})['p']
+
+            # generate random aes key (128) for file
+            ul_key = [random.randint(0, 0xFFFFFFFF) for _ in range(6)]
+            k_str = a32_to_str(ul_key[:4])
+            count = Counter.new(
+                128, initial_value=((ul_key[4] << 32) + ul_key[5]) << 64)
+            aes = AES.new(k_str, AES.MODE_CTR, counter=count)
+
+            upload_progress = 0
+            completion_file_handle = None
+
+            mac_str = '\0' * 16
+            mac_encryptor = AES.new(k_str, AES.MODE_CBC,
+                                    mac_str.encode("utf8"))
+            iv_str = a32_to_str([ul_key[4], ul_key[5], ul_key[4], ul_key[5]])
+            if file_size > 0:
+                for chunk_start, chunk_size in get_chunks(file_size):
+                    chunk = input_file.read(chunk_size)
+                    upload_progress += len(chunk)
+
+                    encryptor = AES.new(k_str, AES.MODE_CBC, iv_str)
+                    for i in range(0, len(chunk) - 16, 16):
+                        block = chunk[i:i + 16]
+                        encryptor.encrypt(block)
+
+                    # fix for files under 16 bytes failing
+                    if file_size > 16:
+                        i += 16
+                    else:
+                        i = 0
+
+                    block = chunk[i:i + 16]
+                    if len(block) % 16:
+                        block += makebyte('\0' * (16 - len(block) % 16))
+                    mac_str = mac_encryptor.encrypt(encryptor.encrypt(block))
+
+                    # encrypt file and upload
+                    chunk = aes.encrypt(chunk)
+                    output_file = requests.post(ul_url + "/" +
+                                                str(chunk_start),
+                                                data=chunk,
+                                                timeout=self.timeout)
+                    completion_file_handle = output_file.text
+                    logger.info('%s of %s uploaded', upload_progress,
+                                file_size)
+            else:
+                output_file = requests.post(ul_url + "/0",
+                                            data='',
+                                            timeout=self.timeout)
+                completion_file_handle = output_file.text
+
+            logger.info('Chunks uploaded')
+            logger.info('Setting attributes to complete upload')
+            logger.info('Computing attributes')
+            file_mac = str_to_a32(mac_str)
+
+            # determine meta mac
+            meta_mac = (file_mac[0] ^ file_mac[1], file_mac[2] ^ file_mac[3])
+
+            dest_filename = dest_filename or os.path.basename(filename)
+            attribs = {'n': dest_filename}
+
+            encrypt_attribs = base64_url_encode(
+                encrypt_attr(attribs, ul_key[:4]))
+            key = [
+                ul_key[0] ^ ul_key[4], ul_key[1] ^ ul_key[5],
+                ul_key[2] ^ meta_mac[0], ul_key[3] ^ meta_mac[1], ul_key[4],
+                ul_key[5], meta_mac[0], meta_mac[1]
+            ]
+            encrypted_key = a32_to_base64(encrypt_key(key, self.master_key))
+            logger.info('Sending request to update attributes')
+            # update attributes
+            data = self._api_request({
+                'a':
+                'p',
+                't':
+                dest,
+                'i':
+                self.request_id,
+                'n': [{
+                    'h': completion_file_handle,
+                    't': 0,
+                    'a': encrypt_attribs,
+                    'k': encrypted_key
+                }]
+            })
+            logger.info('Upload complete')
+            return data
+
+    def _mkdir(self, name, parent_node_id):
+        # generate random aes key (128) for folder
+        ul_key = [random.randint(0, 0xFFFFFFFF) for _ in range(6)]
+
+        # encrypt attribs
+        attribs = {'n': name}
+        encrypt_attribs = base64_url_encode(encrypt_attr(attribs, ul_key[:4]))
+        encrypted_key = a32_to_base64(encrypt_key(ul_key[:4], self.master_key))
+
+        # update attributes
+        data = self._api_request({
+            'a':
+            'p',
+            't':
+            parent_node_id,
+            'n': [{
+                'h': 'xxxxxxxx',
+                't': 1,
+                'a': encrypt_attribs,
+                'k': encrypted_key
+            }],
+            'i':
+            self.request_id
+        })
+        return data
+
+    def _root_node_id(self):
+        if not hasattr(self, 'root_id'):
+            self.get_files()
+        return self.root_id
+
+    def create_folder(self, name, dest=None):
+        dirs = tuple(dir_name for dir_name in str(name).split('/') if dir_name)
+        folder_node_ids = {}
+        for idx, directory_name in enumerate(dirs):
+            existing_node_id = self.find_path_descriptor(directory_name)
+            if existing_node_id:
+                folder_node_ids[idx] = existing_node_id
+                continue
+            if idx == 0:
+                if dest is None:
+                    parent_node_id = self._root_node_id()
+                else:
+                    parent_node_id = dest
+            else:
+                parent_node_id = folder_node_ids[idx - 1]
+            created_node = self._mkdir(name=directory_name,
+                                       parent_node_id=parent_node_id)
+            node_id = created_node['f'][0]['h']
+            folder_node_ids[idx] = node_id
+        return dict(zip(dirs, folder_node_ids.values()))
+
+    def rename(self, file, new_name):
+        file = file[1]
+        # create new attribs
+        attribs = {'n': new_name}
+        # encrypt attribs
+        encrypt_attribs = base64_url_encode(encrypt_attr(attribs, file['k']))
+        encrypted_key = a32_to_base64(encrypt_key(file['key'],
+                                                  self.master_key))
+        # update attributes
+        return self._api_request([{
+            'a': 'a',
+            'attr': encrypt_attribs,
+            'key': encrypted_key,
+            'n': file['h'],
+            'i': self.request_id
+        }])
+
+    def move(self, file_id, target):
+        """
+        Move a file to another parent node
+        params:
+        a : command
+        n : node we're moving
+        t : id of target parent node, moving to
+        i : request id
+
+        targets
+        2 : root
+        3 : inbox
+        4 : trash
+
+        or...
+        target's id
+        or...
+        target's structure returned by find()
+        """
+
+        # determine target_node_id
+        if type(target) == int:
+            target_node_id = str(self.get_node_by_type(target)[0])
+        elif type(target) in (str, ):
+            target_node_id = target
+        else:
+            file = target[1]
+            target_node_id = file['h']
+        return self._api_request({
+            'a': 'm',
+            'n': file_id,
+            't': target_node_id,
+            'i': self.request_id
+        })
+
+    def add_contact(self, email):
+        """
+        Add another user to your mega contact list
+        """
+        return self._edit_contact(email, True)
+
+    def remove_contact(self, email):
+        """
+        Remove a user to your mega contact list
+        """
+        return self._edit_contact(email, False)
+
+    def _edit_contact(self, email, add):
+        """
+        Editing contacts
+        """
+        if add is True:
+            l = '1'  # add command
+        elif add is False:
+            l = '0'  # remove command
+        else:
+            raise ValidationError('add parameter must be of type bool')
+
+        if not re.match(r"[^@]+@[^@]+\.[^@]+", email):
+            ValidationError('add_contact requires a valid email address')
+        else:
+            return self._api_request({
+                'a': 'ur',
+                'u': email,
+                'l': l,
+                'i': self.request_id
+            })
+
+    def get_public_url_info(self, url):
+        """
+        Get size and name from a public url, dict returned
+        """
+        file_handle, file_key = self._parse_url(url).split('!')
+        return self.get_public_file_info(file_handle, file_key)
+
+    def import_public_url(self, url, dest_node=None, dest_name=None):
+        """
+        Import the public url into user account
+        """
+        file_handle, file_key = self._parse_url(url).split('!')
+        return self.import_public_file(file_handle,
+                                       file_key,
+                                       dest_node=dest_node,
+                                       dest_name=dest_name)
+
+    def get_public_file_info(self, file_handle, file_key):
+        """
+        Get size and name of a public file
+        """
+        data = self._api_request({'a': 'g', 'p': file_handle, 'ssm': 1})
+        if isinstance(data, int):
+            raise RequestError(data)
+
+        if 'at' not in data or 's' not in data:
+            raise ValueError("Unexpected result", data)
+
+        key = base64_to_a32(file_key)
+        k = (key[0] ^ key[4], key[1] ^ key[5], key[2] ^ key[6],
+             key[3] ^ key[7])
+
+        size = data['s']
+        unencrypted_attrs = decrypt_attr(base64_url_decode(data['at']), k)
+        if not unencrypted_attrs:
+            return None
+        result = {'size': size, 'name': unencrypted_attrs['n']}
+        return result
+
+    def import_public_file(self,
+                           file_handle,
+                           file_key,
+                           dest_node=None,
+                           dest_name=None):
+        """
+        Import the public file into user account
+        """
+        # Providing dest_node spare an API call to retrieve it.
+        if dest_node is None:
+            # Get '/Cloud Drive' folder no dest node specified
+            dest_node = self.get_node_by_type(2)[1]
+
+        # Providing dest_name spares an API call to retrieve it.
+        if dest_name is None:
+            pl_info = self.get_public_file_info(file_handle, file_key)
+            dest_name = pl_info['name']
+
+        key = base64_to_a32(file_key)
+        k = (key[0] ^ key[4], key[1] ^ key[5], key[2] ^ key[6],
+             key[3] ^ key[7])
+
+        encrypted_key = a32_to_base64(encrypt_key(key, self.master_key))
+        encrypted_name = base64_url_encode(encrypt_attr({'n': dest_name}, k))
+        return self._api_request({
+            'a':
+            'p',
+            't':
+            dest_node['h'],
+            'n': [{
+                'ph': file_handle,
+                't': 0,
+                'a': encrypted_name,
+                'k': encrypted_key
+            }]
+        })

--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -83,6 +83,9 @@ class PostProcessor(object):
 
         self.valreturn = []
         self.extensions = ('.cbr', '.cbz', '.pdf', '.cb7')
+
+        self.extensions = tuple(x for x in self.extensions if x not in mylar.CONFIG.IGNORE_SEARCH_WORDS)
+
         self.failed_files = 0
         self.log = ''
         if issueid is not None:
@@ -249,7 +252,7 @@ class PostProcessor(object):
                 logger.fdebug('odir: %s [filename: %s][self.nzb_folder: %s]' % (odir, filename, self.nzb_folder))
                 logger.fdebug('sub_path: %s [cacheonly: %s][del_nzbdir: %s]' % (sub_path, cacheonly, del_nzbdir))
                 #if sub_path exists, then we need to use that in place of self.nzb_folder since the file was in a sub-directory within self.nzb_folder
-                if all([sub_path is not None, sub_path != self.nzb_folder]): #, self.issueid is not None]):
+                if all([sub_path is not None, sub_path != self.nzb_folder, sub_path != os.path.join(self.nzb_folder, 'mega')]): #, self.issueid is not None]):
                     if self.issueid is None:
                         logger.fdebug('Sub-directory detected during cleanup. Will attempt to remove if empty: %s' % sub_path)
                         orig_folder = sub_path
@@ -325,14 +328,17 @@ class PostProcessor(object):
                                     logger.warn('%s [%s] Unable to remove file : %s' % (self.module, e, os.path.join(tmp_folder, filename)))
                                 else:
                                     if not os.listdir(tmp_folder):
-                                       logger.fdebug('%s Tidying up. Deleting original folder location : %s' % (self.module, tmp_folder))
-                                       try:
-                                           shutil.rmtree(tmp_folder)
-                                       except Exception as e:
-                                           logger.warn('%s [%s] Unable to delete original folder location: %s' % (self.module, e, tmp_folder))
+                                       if os.path.join(mylar.CONFIG.DDL_LOCATION, 'mega') == tmp_folder:
+                                           logger.fdebug('%s Tidying up. %s sub-directory not being removed as is required for mega ddl' % (self.module, tmp_folder))
                                        else:
-                                           logger.fdebug('%s Removed original folder location: %s' % (self.module, tmp_folder))
-                                           self._log("Removed temporary directory : " + tmp_folder)
+                                           logger.fdebug('%s Tidying up. Deleting original folder location : %s' % (self.module, tmp_folder))
+                                           try:
+                                               shutil.rmtree(tmp_folder)
+                                           except Exception as e:
+                                               logger.warn('%s [%s] Unable to delete original folder location: %s' % (self.module, e, tmp_folder))
+                                           else:
+                                               logger.fdebug('%s Removed original folder location: %s' % (self.module, tmp_folder))
+                                               self._log("Removed temporary directory : " + tmp_folder)
                                     else:
                                         self._log('Failed to remove temporary directory: ' + tmp_folder)
                                         logger.error('%s %s not empty. Skipping removal of directory - this will either be caught in further post-processing or it will have to be manually deleted.' % (self.module, tmp_folder))
@@ -646,7 +652,7 @@ class PostProcessor(object):
                                                self.nzb_folder = clocation   # this is needed in order to delete after moving.
                                         else:
                                             try:
-                                                if all([pathlib.Path(tpath) != pathlib.Path(mylar.CACHE_DIR), pathlib.Path(tpath) != pathlib.Path(mylar.CONFIG.DDL_LOCATION)]):
+                                                if all([pathlib.Path(tpath) != pathlib.Path(mylar.CACHE_DIR), pathlib.Path(tpath) != pathlib.Path(mylar.CONFIG.DDL_LOCATION), pathlib.Path(tpath) != pathlib.Path(mylar.CONFIG.DDL_LOCATION).joinpath('mega')]):
                                                    if pathlib.Path(tpath).is_file():
                                                         try:
                                                             cloct = pathlib.Path(tpath).with_name(nfilename)
@@ -3542,6 +3548,9 @@ class FolderCheck():
             mylar.MONITOR_STATUS = 'Paused'
             helpers.job_management(write=True)
         else:
+            if mylar.API_LOCK is True:
+                logger.info('%s Unable to initiate folder monitor as another process is currently using it or using post-processing.' % self.module)
+                return
             helpers.job_management(write=True, job='Folder Monitor', current_run=helpers.utctimestamp(), status='Running')
             mylar.MONITOR_STATUS = 'Running'
             logger.info('%s Checking folder %s for newly snatched downloads' % (self.module, mylar.CONFIG.CHECK_FOLDER))

--- a/mylar/carepackage.py
+++ b/mylar/carepackage.py
@@ -176,8 +176,8 @@ class carePackage(object):
         f.close()
 
     def cleaned_config(self):
-        tmpconfig = configparser.SafeConfigParser()
-        tmpconfig.readfp(codecs.open(self.configpath, 'r', 'utf8'))
+        tmpconfig = configparser.ConfigParser()
+        tmpconfig.read_file(codecs.open(self.configpath, 'r', 'utf8'))
 
         if self.maintenance is True:
             self.log_dir = tmpconfig['Logs']['log_dir']

--- a/mylar/cdh_mapping.py
+++ b/mylar/cdh_mapping.py
@@ -16,7 +16,7 @@
 import requests
 import pathlib
 import re
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 import mylar
 from mylar import logger
 

--- a/mylar/cmtagmylar.py
+++ b/mylar/cmtagmylar.py
@@ -12,6 +12,7 @@ import shutil
 import time
 import zipfile
 import subprocess
+from packaging.version import parse as parse_version
 from subprocess import CalledProcessError, check_output
 import mylar
 
@@ -146,7 +147,6 @@ def run(dirName, nzbName=None, issueid=None, comversion=None, manual=None, filen
     logger.info('ct_check: %s' % ct_check)
     ctend = str(ct_check).find('[')
     ct_version = re.sub("[^0-9]", "", str(ct_check)[:ctend])
-    from pkg_resources import parse_version
     if parse_version(ct_version) >= parse_version('1.3.1'):
         if any([mylar.CONFIG.COMICVINE_API == 'None', mylar.CONFIG.COMICVINE_API is None]):
             logger.fdebug('%s ComicTagger v.%s being used - no personal ComicVine API Key supplied. Take your chances.' % (module, ct_version))

--- a/mylar/cv.py
+++ b/mylar/cv.py
@@ -939,11 +939,11 @@ def GetSeriesYears(dom):
                     #sometimes it's volume 5 and ocassionally it's fifth volume.
                     if i == 0:
                         vfind = comicDes[v_find:v_find +15]   #if it's volume 5 format
-                        basenums = {'zero': '0', 'one': '1', 'two': '2', 'three': '3', 'four': '4', 'five': '5', 'six': '6', 'seven': '7', 'eight': '8', 'nine': '9', 'ten': '10', 'i': '1', 'ii': '2', 'iii': '3', 'iv': '4', 'v': '5'}
+                        basenums = basenum_mapping(ordinal=False)
                         logger.fdebug('volume X format - %s: %s' % (i, vfind))
                     else:
                         vfind = comicDes[:v_find]   # if it's fifth volume format
-                        basenums = {'zero': '0', 'first': '1', 'second': '2', 'third': '3', 'fourth': '4', 'fifth': '5', 'sixth': '6', 'seventh': '7', 'eighth': '8', 'nineth': '9', 'tenth': '10', 'i': '1', 'ii': '2', 'iii': '3', 'iv': '4', 'v': '5'}
+                        basenums = basenum_mapping(ordinal=True)
                         logger.fdebug('X volume format - %s: %s' % (i, vfind))
                     for nums in basenums:
                         if nums in vfind.lower():
@@ -1263,7 +1263,7 @@ def get_imprint_volume_and_booktype(series, comicyear, publisher, firstissueid, 
 
     #sometimes the deck has volume labels
     try:
-        comic_deck = deck
+        comic_deck = deck.strip()
         desdeck +=1
     except:
         comic_deck = 'None'
@@ -1357,17 +1357,20 @@ def get_imprint_volume_and_booktype(series, comicyear, publisher, firstissueid, 
                         # check to see if it matches the existing volume and if so replace it with any new
                         # values since the incorrect volume is incorrect.
                         incorrect_volume = comicDes[v_find:v_find+15]
-                if comicDes[v_find+7:comicDes.find(' ', v_find+7)].isdigit():
-                    comic['ComicVersion'] = re.sub("[^0-9]", "", comicDes[v_find+7:comicDes.find(' ', v_find+7)]).strip()
+                cbd = comicDes.find(' ', v_find+7)
+                if comicDes.find(' ', v_find+7) == -1:
+                    cbd = len(comicDes)
+                if comicDes[v_find+7:cbd].isdigit():
+                    comic['ComicVersion'] = re.sub("[^0-9]", "", comicDes[v_find+7:cbd]).strip()
                     break
                 elif i == 0:
                     vfind = comicDes[v_find:v_find +15]   #if it's volume 5 format
-                    basenums = {'zero': '0', 'one': '1', 'two': '2', 'three': '3', 'four': '4', 'five': '5', 'six': '6', 'seven': '7', 'eight': '8', 'nine': '9', 'ten': '10', 'i': '1', 'ii': '2', 'iii': '3', 'iv': '4', 'v': '5'}
-                    logger.fdebug('volume X format - ' + str(i) + ': ' + vfind)
+                    basenums = basenum_mapping(ordinal=False)
+                    logger.fdebug('volume X format - %s: %s' % (i, vfind))
                 else:
-                    vfind = comicDes[:v_find]   # if it's fifth volume format
-                    basenums = {'zero': '0', 'first': '1', 'second': '2', 'third': '3', 'fourth': '4', 'fifth': '5', 'sixth': '6', 'seventh': '7', 'eighth': '8', 'nineth': '9', 'tenth': '10', 'i': '1', 'ii': '2', 'iii': '3', 'iv': '4', 'v': '5'}
-                    logger.fdebug('X volume format - ' + str(i) + ': ' + vfind)
+                    vfind = comicDes[:v_find] # if it's fifth volume format
+                    basenums = basenum_mapping(ordinal=True)
+                    logger.fdebug('X volume format - %s: %s' % (i, vfind))
                 og_vfind = vfind
                 for nums in basenums:
                     if nums in vfind.lower():
@@ -1417,3 +1420,59 @@ def get_imprint_volume_and_booktype(series, comicyear, publisher, firstissueid, 
     logger.info('comic_values: %s' % (comic,))
 
     return comic
+
+def basenum_mapping(ordinal=False):
+    if not ordinal:
+        basenums = {'zero': '0',
+                    'one': '1',
+                    'two': '2',
+                    'three': '3',
+                    'four': '4',
+                    'five': '5',
+                    'six': '6',
+                    'seven': '7',
+                    'eight': '8',
+                    'nine': '9',
+                    'ten': '10',
+                    'eleven': '11',
+                    'twelve': '12',
+                    'thirteen': '13',
+                    'fourteen': '14',
+                    'fifteen': '15',
+                    'i': '1',
+                    'ii': '2',
+                    'iii': '3',
+                    'iv': '4',
+                    'v': '5',
+                    'vi': '6',
+                    'vii': '7',
+                    'viii': '8',
+                    'xi': '9'}
+    else:
+        basenums = {'zero': '0',
+                    'first': '1',
+                    'second': '2',
+                    'third': '3',
+                    'fourth': '4',
+                    'fifth': '5',
+                    'sixth': '6',
+                    'seventh': '7',
+                    'eighth': '8',
+                    'nineth': '9',
+                    'tenth': '10',
+                    'eleventh': '11',
+                    'twelfth': '12',
+                    'thirteenth': '13',
+                    'fourteenth': '14',
+                    'fifteenth': '15',
+                    'i': '1',
+                    'ii': '2',
+                    'iii': '3',
+                    'iv': '4',
+                    'v': '5',
+                    'vi': '6',
+                    'vii': '7',
+                    'viii': '8',
+                    'xi': '9'}
+
+    return basenums

--- a/mylar/downloaders/external_server.py
+++ b/mylar/downloaders/external_server.py
@@ -1,0 +1,2 @@
+#placeholder
+EXT_SERVER=False

--- a/mylar/downloaders/mediafire.py
+++ b/mylar/downloaders/mediafire.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+
+#  This file is part of Mylar.
+#
+#  Mylar is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Mylar is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import os.path as osp
+import urllib
+import re
+import shutil
+import sys
+import requests
+import mylar
+from mylar import db, helpers, logger, search, search_filer
+
+class MediaFire(object):
+
+    def __init__(self):
+        self.dl_location = os.path.join(mylar.CONFIG.DDL_LOCATION)
+        self.headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.5481.178 Safari/537.36"
+        }
+        self.session = requests.Session()
+
+    def extractDownloadLink(self, contents):
+        for line in contents.splitlines():
+            m = re.search(r'href="((http|https)://download[^"]+)', line)
+            if m:
+                return m.groups()[0]
+
+    def ddl_download(self, url, id, issueid):
+        url_origin = url
+
+        while True:
+            t = self.session.get(
+                    url,
+                    verify=True,
+                    headers=self.headers,
+                    stream=True,
+                    timeout=(30,30)
+                )
+
+            if 'Content-Disposition' in t.headers:
+                # This is the file
+                break
+
+            # Need to redirect with confiramtion
+            url = self.extractDownloadLink(t.text)
+
+            if url is None:
+                #link no longer valid
+                return {"success": False, "filename": None, "path": None, "link_type_failure": 'GC-Media'}
+
+        m = re.search(
+            'filename="(.*)"', t.headers['Content-Disposition']
+        )
+        filename = m.groups()[0]
+        filename = filename.encode('iso8859').decode('utf-8')
+
+        file, ext = os.path.splitext(filename)
+        filename = '%s[__%s__]%s' % (file, issueid, ext)
+
+        try:
+            filesize = int(t.headers['Content-Length'])
+        except Exception:
+            filesize = 0
+
+        fileinfo = {'filename': filename,
+                    'filesize': filesize}
+
+        logger.fdebug('Downloading...')
+        logger.fdebug('%s [%s bytes]' % (filename, filesize))
+        logger.fdebug('From: %s' % url_origin)
+        logger.fdebug('To: %s' % os.path.join(self.dl_location, filename))
+
+        myDB = db.DBConnection()
+        ## write the filename to the db for tracking purposes...
+        logger.fdebug('[Writing to db: %s' % (filename))
+        myDB.upsert(
+            'ddl_info',
+            {'filename': str(filename), 'remote_filesize': str(filesize), 'size': helpers.human_size(filesize)},
+            {'id': id},
+        )
+        return self.mediafire_dl(url, id, fileinfo, issueid)
+
+    def mediafire_dl(self, url, id, fileinfo, issueid):
+        filepath = os.path.join(self.dl_location, fileinfo['filename'])
+
+        myDB = db.DBConnection()
+        myDB.upsert(
+            'ddl_info',
+            {'tmp_filename': fileinfo['filename']},  # tmp_filename should be all that's needed to be updated at this point...
+            {'id': id},
+        )
+
+        try:
+            response = self.session.get(
+                    url,
+                    verify=True,
+                    headers=self.headers,
+                    stream=True,
+                    timeout=(30,30)
+                )
+
+            logger.fdebug('[MediaFire] now writing....')
+            with open(filepath, 'wb') as f:
+                for chunk in response.iter_content(chunk_size=4096):
+                    if chunk:
+                        f.write(chunk)
+                        f.flush()
+
+        except Exception as e:
+            logger.fdebug('[MediaFire][ERROR] %s' % e)
+            if 'EBLOCKED' in str(e):
+                logger.fdebug('[MediaFire] Content has been removed - we should move on to the next one at this point.')
+            return {"success": False, "filename": None, "path": None, "link_type_failure": 'GC-Media'}
+
+        logger.fdebug('[MediaFire] download completed - donwloaded %s / %s' % (os.stat(filepath).st_size, fileinfo['filesize']))
+
+        logger.fdebug('[MediaFire] ddl_linked - filename: %s' % fileinfo['filename'])
+
+        file, ext = os.path.splitext(fileinfo['filename'])
+        if ext == '.zip':
+            ggc = mylar.getcomics.GC()
+            return ggc.zip_zip(id, str(filepath), fileinfo['filename'])
+        else:
+            return {"success": True, "filename": fileinfo['filename'], "path": str(filepath)}
+

--- a/mylar/downloaders/mega.py
+++ b/mylar/downloaders/mega.py
@@ -1,0 +1,131 @@
+
+#  This file is part of Mylar.
+#
+#  Mylar is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Mylar is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
+
+import requests
+import sys
+import os
+import datetime
+import time
+from pathlib import Path
+from mega import Mega
+import mylar
+from mylar import db, helpers, logger
+
+class MegaNZ(object):
+
+    def __init__(self, query=None):
+        # if query is None, it's downloading not searching.
+        self.query = query
+        self.dl_location = os.path.join(mylar.CONFIG.DDL_LOCATION, 'mega')
+        self.wrote_tmp = False
+
+    def ddl_download(self, link, filename, id, issueid=None, site=None):
+        self.id = id
+        if self.dl_location is not None and not os.path.isdir(
+            self.dl_location
+        ):
+            checkdirectory = mylar.filechecker.validateAndCreateDirectory(
+                self.dl_location, True
+            )
+            if not checkdirectory:
+                logger.warn(
+                    '[ABORTING] Error trying to validate/create DDL download'
+                    ' directory: %s.' % self.dl_location
+                )
+                return {"success": False, "filename": filename, "path": None}
+
+
+        logger.info('trying link: %s' % (link,))
+        logger.info('dl_location: %s / filename: %s' % (self.dl_location, filename))
+
+        mega = Mega()
+        try:
+            m = mega.login()
+            # ddl -mega from gc filename isn't known until AFTER file begins downloading
+            # try to get it using the pulic_url_info endpoint
+            pui = m.get_public_url_info(link)
+            if pui:
+                filesize = pui['size']
+                filename = pui['name']
+
+                myDB = db.DBConnection()
+                # write the filename to the db for tracking purposes...
+                logger.info('[get-public-url-info resolved] Writing to db: %s [%s]' % (filename, filesize))
+                myDB.upsert(
+                    'ddl_info',
+                    {'filename': str(filename), 'remote_filesize': str(filesize), 'size': helpers.human_size(str(filesize))},
+                    {'id': self.id},
+                )
+
+            if filename is None:
+                # so null filename now, and it'll be assigned in self.testing
+                filename = m.download_url(link, self.dl_location, progress_hook=self.testing)
+            else:
+                filename = m.download_url(link, self.dl_location, filename, self.testing)
+        except Exception as e:
+            logger.warn('[MEGA][ERROR] %s' % e)
+            if 'EBLOCKED' in str(e):
+                logger.warn('Content has been removed - we should move on to the next one at this point.')
+            return {"success": False, "filename": filename, "path": None, "link_type_failure": site}
+        else:
+            og_filepath = os.path.join(self.dl_location, filename) # just default
+            if filename is not None:
+                og_filepath = filename
+                #filepath = filename.parent.absolute()
+                file, ext = os.path.splitext(os.path.basename( filename ) )
+                filename = '%s[__%s__]%s' % (file, issueid, ext)
+                filepath = og_filepath.with_name(filename)
+                try:
+                    filepath = og_filepath.replace(filepath)
+                except Exception as e:
+                    logger.warn('unable to rename/replace %s with %s' % (og_filepath, filepath))
+                else:
+                    logger.info('ddl_linked - filename: %s' % filename)
+                if ext == '.zip':
+                    ggc = mylar.getcomics.GC()
+                    return ggc.zip_zip(id, str(filepath), filename)
+                else:
+                    return {"success": True, "filename": filename, "path": str(filepath)}
+            else:
+                logger.warn('filename returned from download has a None value')
+                return {"success": False, "filename": filename, "path": None, "link_type_failure": site}
+
+    def testing(self, data):
+        mth = ( data['current'] / data['total'] ) * 100
+
+        if data['tmp_filename'] is not None and self.wrote_tmp is False:
+            myDB = db.DBConnection()
+            # write the filename to the db for tracking purposes...
+            logger.info('writing to db: %s [%s][%s]' % (data['name'], data['total'], data['tmp_filename']))
+            myDB.upsert(
+                'ddl_info',
+                {'tmp_filename': str(data['tmp_filename'])},  # tmp_filename should be all that's needed to be updated at this point...
+                #{'filename': str(data['name']), 'tmp_filename': str(data['tmp_filename']), 'remote_filesize': str(data['total'])},
+                {'id': self.id},
+            )
+            self.wrote_tmp = True
+
+        #logger.info('%s%s' % (mth, '%'))
+        #logger.info('data: %s' % (data,))
+
+        if mth >= 100.0:
+            logger.info('status: %s' % (data['status']))
+            logger.info('successfully downloaded %s [%s bytes]' % (data['name'], data['total']))
+
+if __name__ == '__main__':
+    test = MegaNZ(sys.argv[1])
+    test.ddl_search()
+

--- a/mylar/downloaders/pixeldrain.py
+++ b/mylar/downloaders/pixeldrain.py
@@ -1,0 +1,145 @@
+#  This file is part of Mylar.
+#
+#  Mylar is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Mylar is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
+
+import requests
+import sys
+import os
+import time
+from operator import itemgetter
+from pathlib import Path
+import urllib
+
+import mylar
+from mylar import db, helpers, logger, search, search_filer
+
+class PixelDrain(object):
+
+    def __init__(self):
+        self.dl_location = mylar.CONFIG.DDL_LOCATION
+        self.headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1',
+            'Referer': 'https://pixeldrain.com',
+        }
+        self.session = requests.Session()
+
+    def ddl_download(self, link, id, issueid):
+        self.id = id
+        self.url = link
+        if self.dl_location is not None and not os.path.isdir(
+            self.dl_location
+        ):
+            checkdirectory = mylar.filechecker.validateAndCreateDirectory(
+                self.dl_location, True
+            )
+            if not checkdirectory:
+                logger.warn(
+                    '[PixelDrain][ABORTING] Error trying to validate/create DDL download'
+                    ' directory: %s.' % self.dl_location
+                )
+                return {"success": False, "filename": filename, "path": None, "link_type_failure": 'GC-Pixel'}
+
+
+        t = self.session.get(
+                self.url,
+                verify=True,
+                headers=self.headers,
+                stream=True,
+                timeout=(30,30)
+            )
+
+        file_id = os.path.basename(
+            urllib.parse.unquote(t.url)
+        )  # .decode('utf-8'))
+        logger.fdebug(t.url)
+        logger.fdebug(t)
+        logger.fdebug('[PixelDrain] file_id: %s' % file_id)
+
+        logger.fdebug('[PixelDrain] retrieving info for file_id: %s' % file_id)
+        f_info = self.session.get(f"https://pixeldrain.com/api/file/{file_id}/info", verify=True, headers=self.headers,stream=True)
+        if f_info.status_code == 200:
+            info = f_info.json()
+            logger.fdebug('[PixelDrain] pixeldrain_info_response: %s' % info)
+            file_info = {'filename': info['name'],
+                         'filesize': info['size'],
+                         'avail': info['availability'],
+                         'can_dl': info['can_download']}
+        else:
+            # should return null here - unobtainable link.
+            file_info = None
+
+        myDB = db.DBConnection()
+        # write the filename to the db for tracking purposes...
+        logger.info('[PixelDrain] Writing to db: %s [%s]' % (file_info['filename'], file_info['filesize']))
+        myDB.upsert(
+            'ddl_info',
+            {'filename': str(file_info['filename']), 'remote_filesize': str(file_info['filesize']), 'size': helpers.human_size(file_info['filesize'])},
+            {'id': self.id},
+        )
+        logger.fdebug(file_info)
+
+        logger.fdebug('[PixelDrain] now threading the send')
+        return self.pixel_ddl(file_id, file_info, issueid)
+
+    def pixel_ddl(self, file_id, fileinfo, issueid):
+        filename = fileinfo['filename']
+        file, ext = os.path.splitext(os.path.basename( filename ) )
+        filename = '%s[__%s__]%s' % (file, issueid, ext)
+
+        filesize = fileinfo['filesize']
+        filepath = os.path.join(self.dl_location, filename)
+
+        myDB = db.DBConnection()
+        myDB.upsert(
+            'ddl_info',
+            {'tmp_filename': filename},  # tmp_filename should be all that's needed to be updated at this point...
+            {'id': self.id},
+        )
+
+        try:
+            response = self.session.get(
+                    'https://pixeldrain.com/api/file/'+file_id,
+                    verify=True,
+                    headers=self.headers,
+                    stream=True,
+                    timeout=(30,30)
+                )
+
+            logger.fdebug('[PixelDrain] now writing....')
+            with open(filepath, 'wb') as f:
+                for chunk in response.iter_content(chunk_size=1024):
+                    if chunk:
+                        f.write(chunk)
+                        f.flush()
+
+        except Exception as e:
+            logger.warn('[PixelDrain][ERROR] %s' % e)
+            if 'EBLOCKED' in str(e):
+                logger.warn('[PixelDrain] Content has been removed - we should move on to the next one at this point.')
+            return {"success": False, "filename": filename, "path": None, "link_type_failure": 'GC-Pixel'}
+
+        logger.fdebug('[PixelDrain] download completed - donwloaded %s / %s' % (os.stat(filepath).st_size, filesize))
+
+        logger.info('[PixelDrain] ddl_linked - filename: %s' % filename)
+
+        if ext == '.zip':
+            ggc = mylar.getcomics.GC()
+            return ggc.zip_zip(self.id, str(filepath), filename)
+        else:
+            return {"success": True, "filename": filename, "path": str(filepath)}
+
+if __name__ == '__main__':
+    test = PixelDrain()
+    test.ddl_down()
+

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -258,6 +258,7 @@ class FileChecker(object):
 
         #parse out the extension for type
         comic_ext = ('.cbr','.cbz','.cb7','.pdf')
+        comic_ext = tuple(x for x in comic_ext if x not in mylar.CONFIG.IGNORE_SEARCH_WORDS)
         if os.path.splitext(filename)[1].endswith(comic_ext):
             filetype = os.path.splitext(filename)[1]
         else:
@@ -729,7 +730,16 @@ class FileChecker(object):
                     volumeprior_label = sf
                     sep_volume = True
                     logger.fdebug('volume label detected, but vol. number is not adjacent, adjusting scope to include number.')
-                elif 'volume' in sf.lower() or all(['part' in sf.lower(), len(sf) == 4]):
+                elif 'volume' in sf.lower():
+                    volume = re.sub("[^0-9]", "", sf)
+                    if volume.isdigit():
+                        volume_found['volume'] = volume
+                        volume_found['position'] = split_file.index(sf)
+                    else:
+                        volumeprior = True
+                        volumeprior_label = sf
+                        sep_volume = True
+                elif all(['part' in sf.lower(), len(sf) == 4]):
                     if self.watchcomic is not None and 'part' not in self.watchcomic.lower():
                         volume = re.sub("[^0-9]", "", sf)
                         if volume.isdigit():
@@ -896,6 +906,7 @@ class FileChecker(object):
                         logger.fdebug('yearposition[%s] -- dc[position][%s]' % (yearposition, x['yearposition']))
                         if yearposition < x['yearposition']:
                             if all([len(possible_issuenumbers) == 1, possible_issuenumbers[0]['number'] == x['year'], x['yearposition'] != possible_issuenumbers[0]['position']]):
+                                logger.fdebug('issue2year is true')
                                 issue2year = True
                                 highest_series_pos = x['yearposition']
                             yearposition = x['yearposition']
@@ -1113,6 +1124,7 @@ class FileChecker(object):
         splitvalue = None
         alt_series = None
         alt_issue = None
+        onefortheleader = False
         try:
             if yearposition is not None:
                 try:
@@ -1127,15 +1139,28 @@ class FileChecker(object):
         except:
             pass
         else:
-            if tmpval > 2:
-                logger.fdebug('There are %s extra words between the issue # and the year position. Deciphering if issue title or part of series title.' % tmpval)
-                tmpval1 = ' '.join(split_file[issue_number_position:yearposition])
-                if split_file[issue_number_position+1] == '-':
-                    usevalue = ' '.join(split_file[issue_number_position+2:yearposition])
-                    splitv = split_file[issue_number_position+2:yearposition]
+            if tmpval >= 2:
+                #logger.fdebug('There are %s extra words between the issue # and the year position. Deciphering if issue title or part of series title.' % tmpval)
+                #logger.fdebug('split_file[issue_number_position]: [%s] -->  %s' % (issue_number_position, split_file[issue_number_position]))
+                #logger.fdebug('split_file[yearposition]: [%s] --> %s' % (yearposition, split_file[yearposition]))
+                #2024-01-07 - new for one-shot where no issue number in filename, but year is present in title
+                if split_file[issue_number_position] == re.sub(r'[\)\(]', '', split_file[yearposition]).strip():
+                    logger.fdebug('issue number is the same as year - assuming issue number is actually part of the title and this is a one-shot-type of book')
+                    onefortheleader = True
+                    if [True for x in split_file if x.lower() == 'annual']:
+                        booktype = 'issue'
+                    else:
+                        booktype = 'TPB/GN/HC/One-Shot'
+                    issue_number = None
                 else:
-                    splitv = split_file[issue_number_position:yearposition]
-                splitvalue = ' '.join(splitv)
+                    tmpval1 = ' '.join(split_file[issue_number_position:yearposition])
+                    if split_file[issue_number_position+1] == '-':
+                        usevalue = ' '.join(split_file[issue_number_position+2:yearposition])
+                        splitv = split_file[issue_number_position+2:yearposition]
+                    else:
+                        splitv = split_file[issue_number_position:yearposition]
+                    splitvalue = ' '.join(splitv)
+                #end 2024-01-07
             else:
                 #store alternate naming of title just in case
                 if '-' not in split_file[0]:
@@ -1173,7 +1198,7 @@ class FileChecker(object):
         #logger.info('volume_found: ' + str(volume_found))
 
    #2017-10-21
-        if highest_series_pos > issue_number_position:
+        if highest_series_pos > issue_number_position and not onefortheleader:
             highest_series_pos = issue_number_position
             #if volume_found['position'] >= issue_number_position:
             #    highest_series_pos = issue_number_position
@@ -1279,7 +1304,7 @@ class FileChecker(object):
                 series_name_decoded = re.sub('special', '', series_name_decoded, flags=re.I).strip()
 
         if (any([issue_number is None, series_name is None]) and booktype == 'issue'):
-
+            bythepass = False
             if all([issue_number is None, booktype == 'issue', issue_volume is not None]):
                 if ignore_mod_position != -1:
                     logger.fdebug('Possible Annual detected - no identifying issue number present, no clarification in filename - assuming year (%s) as issue number' % issue_year)
@@ -1288,30 +1313,39 @@ class FileChecker(object):
                     logger.fdebug('Possible UNKNOWN TPB/GN/HC detected - no issue number present, no clarification in filename, but volume present with series title')
                     booktype = 'TPB/GN/HC/One-Shot'
             else:
-                logger.fdebug('Cannot parse the filename properly. I\'m going to make note of this filename so that my evil ruler can make it work.')
-
-                if series_name is not None:
-                    dreplace = self.dynamic_replace(series_name)['mod_seriesname']
+                if all([issue_number is None, issue_volume is None, 'annual' in series_name.lower(), booktype == 'issue']):
+                    if ignore_mod_position != -1:
+                        logger.fdebug('Possible Annual detected - no identifying issue number present, no clarification in filename - assuming year (%s) as issue number' % issue_year)
+                        issue_number = issue_year
+                        bythepass = True
+                    else:
+                        logger.fdebug('Cannot parse the filename properly. I\'m going to make note of this filename so that my evil ruler can make it work.')
                 else:
-                    dreplace = None
-                return {'parse_status':        'failure',
-                        'sub':                 path_list,
-                        'comicfilename':       filename,
-                        'comiclocation':       self.dir,
-                        'series_name':         series_name,
-                        'series_name_decoded': series_name_decoded,
-                        'issueid':             issueid,
-                        'alt_series':          alt_series,
-                        'alt_issue':           alt_issue,
-                        'dynamic_name':        dreplace,
-                        'issue_number':        issue_number,
-                        'justthedigits':       issue_number, #redundant but it's needed atm
-                        'series_volume':       issue_volume,
-                        'issue_year':          issue_year,
-                        'annual_comicid':      None,
-                        'scangroup':           scangroup,
-                        'booktype':            booktype,
-                        'reading_order':       None}
+                    logger.fdebug('Cannot parse the filename properly. I\'m going to make note of this filename so that my evil ruler can make it work.')
+
+                if not bythepass:
+                    if series_name is not None:
+                        dreplace = self.dynamic_replace(series_name)['mod_seriesname']
+                    else:
+                        dreplace = None
+                    return {'parse_status':        'failure',
+                            'sub':                 path_list,
+                            'comicfilename':       filename,
+                            'comiclocation':       self.dir,
+                            'series_name':         series_name,
+                            'series_name_decoded': series_name_decoded,
+                            'issueid':             issueid,
+                            'alt_series':          alt_series,
+                            'alt_issue':           alt_issue,
+                            'dynamic_name':        dreplace,
+                            'issue_number':        issue_number,
+                            'justthedigits':       issue_number, #redundant but it's needed atm
+                            'series_volume':       issue_volume,
+                            'issue_year':          issue_year,
+                            'annual_comicid':      None,
+                            'scangroup':           scangroup,
+                            'booktype':            booktype,
+                            'reading_order':       None}
 
         if self.justparse:
             return {'parse_status':           'success',
@@ -1586,6 +1620,7 @@ class FileChecker(object):
     def traverse_directories(self, dir):
         filelist = []
         comic_ext = ('.cbr','.cbz','.cb7','.pdf')
+        comic_ext = tuple(x for x in comic_ext if x not in mylar.CONFIG.IGNORE_SEARCH_WORDS)
 
         if all([mylar.CONFIG.ENABLE_TORRENTS is True, self.pp_mode is True]):
             from mylar import db

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -138,7 +138,7 @@ class GC(object):
         if mylar.CONFIG.ENABLE_PROXY:
             self.session.proxies.update({
                 'http':  mylar.CONFIG.HTTP_PROXY,
-                'https': mylar.CONFIG.HTTPS_PROXY 
+                'https': mylar.CONFIG.HTTPS_PROXY
             })
 
         self.session_path = session_path if session_path is not None else os.path.join(mylar.CONFIG.SECURE_DIR, ".gc_cookies.dat")
@@ -154,6 +154,8 @@ class GC(object):
         self.oneoff = oneoff
 
         self.search_format = ['"%s #%s (%s)"', '%s #%s (%s)', '%s #%s', '%s %s']
+
+        self.pack_receipts = ['+ TPBs', '+TPBs', '+ TPB', '+TPB', 'TPB', '+ Deluxe Books', '+ Annuals', '+Annuals', ' & ']
 
         self.provider_stat = provider_stat
 
@@ -313,7 +315,7 @@ class GC(object):
             verify=True,
             headers=self.headers,
             stream=True,
-            timeout=(30,10)
+            timeout=(30,30)
         )
 
         with open(title + '.html', 'wb') as f:
@@ -339,7 +341,7 @@ class GC(object):
                 params={'s': queryline},
                 verify=True,
                 headers=self.headers,
-                timeout=(30,10)
+                timeout=(30,30)
             ).text
 
             write_time = time.time()
@@ -347,13 +349,22 @@ class GC(object):
             self.provider_stat['lastrun'] = write_time
             page_results, next_url = self.parse_search_result(page_html)
 
+            #logger.fdebug('page_results: %s' % page_results)
+            possible_choices = []
             for result in page_results:
                 if 'Weekly' not in self.query.get('comicname', "") and 'Weekly' in result.get('title', ""):
                     continue
                 if result["link"] in seen_urls:
                     continue
                 seen_urls.add(result["link"])
+                #if not mylar.CONFIG.PACK_PRIORITY:
+                #    possible_choices.append(result)
+                #else:
                 yield result
+
+            #if not mylar.CONFIG.PACK_PRIORITY and possible_choices:
+            #    logger.info('[pack-last choices] possible choices to check before page-loading next page..: %s' % possible_choices)
+            #    yield possible_choices
 
     def parse_search_result(self, page_html):
         resultlist = []
@@ -380,72 +391,16 @@ class GC(object):
             titlefind = f.find("h1", {"class": "post-title"})
             title = titlefind.get_text(strip=True)
             title = re.sub('\u2013', '-', title).strip()
-            filename = title
-            issues = None
-            pack = False
 
-            # see if it's a pack type
-            issfind_st = title.find('#')
-            issfind_en = title.find('-', issfind_st)
-            if issfind_en != -1:
-                if all([title[issfind_en + 1] == ' ', title[issfind_en + 2].isdigit()]):
-                    iss_en = title.find(' ', issfind_en + 2)
-                    if iss_en != -1:
-                        issues = title[issfind_st + 1 : iss_en]
-                        pack = True
-                if title[issfind_en + 1].isdigit():
-                    iss_en = title.find(' ', issfind_en + 1)
-                    if iss_en != -1:
-                        issues = title[issfind_st + 1 : iss_en]
-                        pack = True
-
-            # to handle packs that are denoted without a # sign being present.
-            # if there's a dash, check to see if both sides of the dash are numeric.
-            if pack is False and title.find('-') != -1:
-                issfind_en = title.find('-')
-                if all(
-                       [
-                           title[issfind_en + 1] == ' ',
-                           title[issfind_en + 2].isdigit(),
-                       ]
-                ) and all(
-                       [
-                           title[issfind_en -1] == ' ',
-                       ]
-                ):
-                    spaces = [m.start() for m in re.finditer(' ', title)]
-                    dashfind = title.find('-')
-                    space_beforedash = title.find(' ', dashfind - 1)
-                    space_afterdash = title.find(' ', dashfind + 1)
-                    if not title[space_afterdash+1].isdigit():
-                        pass
-                    else:
-                        iss_end = title.find(' ', space_afterdash + 1)
-                        if iss_end == -1:
-                            iss_end = len(title)
-                        set_sp = None
-                        for sp in spaces:
-                            if sp < space_beforedash:
-                                prior_sp = sp
-                            else:
-                                set_sp = prior_sp
-                                break
-                        if title[set_sp:space_beforedash].strip().isdigit():
-                            issues = title[set_sp:iss_end].strip()
-                            pack = True
-
-            # if it's a pack - remove the issue-range and the possible issue years
-            # (cause it most likely will span) and pass thru as separate items
-            if pack is True:
-                f_iss = title.find('#')
-                if f_iss != -1:
-                    title = '%s%s'.strip() % (title[:f_iss-1], title[f_iss+1:])
-                title = re.sub(issues, '', title).strip()
-                # kill any brackets in the issue line here.
-                issues = re.sub(r'[\(\)\[\]]', '', issues).strip()
-                if title.endswith('#'):
-                    title = title[:-1].strip()
-                title += '#1'  # we add this dummy value back in so the parser won't choke as we have the issue range stored already
+            pack_checker = self.check_for_pack(title, issue_in_pack=self.query['issue'])
+            if pack_checker:
+                issues = pack_checker['issues']
+                gc_booktype = pack_checker['gc_booktype']
+                pack = pack_checker['pack']
+                series = pack_checker['series']
+                title = pack_checker['title']
+                filename = pack_checker['filename']
+                year = pack_checker['year']
             else:
                 if any(
                     [
@@ -456,6 +411,10 @@ class GC(object):
                     ]
                 ):
                     continue
+                else:
+                    pack = False
+                    issues = None
+                    filename = series = title = None
 
             needle_style = "text-align: center;"
             option_find = f.find("p", {"style": needle_style})
@@ -518,6 +477,8 @@ class GC(object):
                     "filename": filename,
                     "size": re.sub(' ', '', size).strip(),
                     "pack": pack,
+                    "series": series,
+                    "gc_booktype": gc_booktype,
                     "issues": issues,
                     "link": link,
                     "year": year,
@@ -525,8 +486,13 @@ class GC(object):
                     "site": 'DDL(GetComics)',
                 }
             )
-
-            logger.fdebug('%s [%s]' % (title, size))
+            if pack:
+                pck = 'yes'
+                fname = filename
+            else:
+                pck = 'no'
+                fname = title
+            logger.fdebug('%s [%s] [PACK: %s]' % (fname, size, pck))
 
         older_posts_a = soup.find("a", class_="pagination-older")
         next_page = None
@@ -535,24 +501,33 @@ class GC(object):
 
         return resultlist, next_page
 
-    def parse_downloadresults(self, id, mainlink, comicinfo=None):
+    def parse_downloadresults(self, id, mainlink, comicinfo=None, packinfo=None, link_type_failure=None):
         try:
             booktype = comicinfo[0]['booktype']
         except Exception:
             booktype = None
 
-        try:
-            pack = comicinfo[0]['pack']
-        except Exception:
-            pack = False
+        pack = pack_numbers = pack_issuelist = None
+        logger.fdebug('packinfo: %s' % (packinfo,))
+
+        if packinfo is not None:
+            pack = packinfo['pack']
+            pack_numbers = packinfo['pack_numbers']
+            pack_issuelist = packinfo['pack_issuelist']
+        else:
+            try:
+                pack = comicinfo[0]['pack']
+            except Exception as e:
+                pack = False
 
         myDB = db.DBConnection()
-
         series = None
         year = None
         size = None
-
         title = os.path.join(mylar.CONFIG.CACHE_DIR, 'getcomics-' + id)
+        if not os.path.exists(title):
+            logger.fdebug('Unable to locate local cached html file - attempting to retrieve page results again..')
+            self.loadsite(id, mainlink)
         soup = BeautifulSoup(open(title + '.html', encoding='utf-8'), 'html.parser')
 
         i = 0
@@ -564,6 +539,7 @@ class GC(object):
         looped_thru_once = True
 
         beeswax = soup.findAll("p", {"style": "text-align: center;"})
+        logger.info('[DDL-GATHERER-OF-LINKAGE] Now compiling release information & available links...')
         while True:
             #logger.fdebug('count_bees: %s' % count_bees)
             f = beeswax[count_bees]
@@ -573,9 +549,9 @@ class GC(object):
             if not linkage:
                 linkage_test = f.text.strip()
                 if 'support and donation' in linkage_test:
-                    logger.fdebug('detected end of links - breaking out here...')
                     if looped_thru_once is False:
                         valid_links[multiple_links].update({'links': gather_links})
+                    #logger.fdebug('detected end of links - breaking out here...')
                     break
 
                 if looped_thru_once and all(
@@ -585,7 +561,7 @@ class GC(object):
                      'Size' in linkage_test,
                     ]
                 ):
-                    logger.fdebug('detected headers of title - ignoring this portion...')
+                    #logger.fdebug('detected headers of title - ignoring this portion...')
                     while True:
                         prev_option = option_find
                         option_find = option_find.findNext(text=True)
@@ -648,17 +624,25 @@ class GC(object):
                     i = 0
                     series = None
                 else:
-                    logger.info('[DDL-GATHERER-OF-LINKAGE] Now compiling available links...')
-                    gather_links.append({
-                         "series": series,
-                         "site": lk['title'],
-                         "year": year,
-                         "issues": None,
-                         "size": size,
-                         "links": lk['href'],
-                         "pack": comicinfo[0]['pack']
-                    })
-                    #logger.fdebug('gather_links so far: %s' % gather_links)
+                    t_site = re.sub('link', '', lk['title'].lower()).strip()
+                    ltf = False
+                    if link_type_failure is not None:
+                        logger.fdebug('link_type_failure: %s' % link_type_failure)
+                        if [True for tst in link_type_failure if t_site.lower() in tst.lower()]:
+                            logger.fdebug('[REDO-FAILURE-DETECTION] detected previous invalid link for %s - ignoring this result'
+                                        ' and seeing if anything else can be downloaded.' % t_site)
+                            ltf = True
+                    if not ltf:
+                        gather_links.append({
+                             "series": series,
+                             "site": t_site,
+                             "year": year,
+                             "issues": None,
+                             "size": size,
+                             "links": lk['href'],
+                             "pack": comicinfo[0]['pack']
+                        })
+                        #logger.fdebug('gather_links so far: %s' % gather_links)
             count_bees +=1
 
         #logger.fdebug('final valid_links: %s' % (valid_links))
@@ -672,58 +656,210 @@ class GC(object):
            for a in y['links']:
                if k != 'normal':
                    # if it's HD-Upscaled / SD-Digital it needs to be handled differently than a straight DL link
-                   if any([a['site'].lower() == 'download now', a['site'].lower() == 'mirror download']): # 'MEGA' in a['site'], 'PIXEL' in a['site']]):
-                       tmp_links.append(a)
-                       tmp_sites.append(k)
-                       site_position[k] = cntr
-                       #logger.fdebug('%s -- %s' % (k, a['series']))
+                   if any([a['site'].lower() == 'download now', a['site'].lower() == 'mirror download']):
+                       d_site = '%s:%s' % (k, a['site'].lower())
+                       tmp_a = a
+                       tmp_a['site_type'] = d_site
+                       tmp_links.append(tmp_a)
+                       tmp_sites.append(d_site)
+                       site_position[d_site] = cntr
+                       logger.fdebug('%s -- %s' % (d_site, a['series']))
+                       cntr +=1
+                   elif any(['mega' in a['site'].lower(), 'pixel' in a['site'].lower(), 'mediafire' in a['site'].lower()]):
+                       if 'mega' in a['site'].lower():
+                           d_site = '%s:%s' % (k, 'mega')
+                       elif 'pixel' in a['site'].lower():
+                           d_site = '%s:%s' % (k, 'pixeldrain')
+                       else:
+                           d_site = '%s:%s' % (k, 'mediafire')
+                       tmp_a = a
+                       tmp_a['site_type'] = d_site
+                       tmp_links.append(tmp_a)
+                       tmp_sites.append(d_site)
+                       site_position[d_site] = cntr
+                       logger.fdebug('%s -- %s' % (d_site, a['series']))
                        cntr +=1
                else:
-                   if any([a['site'].lower() == 'download now', a['site'].lower() == 'mirror download']):
-                       tmp_links.append(a)
-                       tmp_sites.append(a['site'].lower())
-                       site_position[a['site'].lower()] = cntr
-                       #logger.fdebug('%s -- %s' % (a['site'], a['series']))
+                   if any(
+                             [
+                                 a['site'].lower() == 'download now',
+                                 a['site'].lower() == 'mirror download',
+                                 'mega' in a['site'].lower(),
+                                 'pixel' in a['site'].lower(),
+                                 'mediafire' in a['site'].lower()
+                             ]
+                       ):
+                       t_site = a['site'].lower()
+                       if 'mega' in a['site'].lower():
+                           t_site = 'mega'
+                       elif 'pixel' in a['site'].lower():
+                           t_site = 'pixeldrain'
+                       elif 'mediafire' in a['site'].lower():
+                           t_site = 'mediafire'
+                       d_site = '%s:%s' % (k, t_site)
+                       tmp_a = a
+                       tmp_a['site_type'] = d_site
+                       tmp_links.append(tmp_a)
+                       tmp_sites.append(d_site)
+                       site_position[d_site] = cntr
+                       logger.fdebug('%s -- %s' % (d_site, a['series']))
                        cntr +=1
+
 
         #logger.fdebug('tmp_links: %s' % (tmp_links))
-        #logger.fdebug('tmp_sites: %s' % (tmp_sites))
+        logger.fdebug('tmp_sites: %s' % (tmp_sites))
+        logger.fdebug('site_position: %s' % (site_position))
+        link_types = ('HD-Upscaled', 'SD-Digital', 'HD-Digital')
+        link_matched = False
         if len(tmp_links) == 1:
-            logger.info('only one available item that can be downloaded via main server - %s. Let\'s do this..' % tmp_links[0]['series'])
             link = tmp_links[0]
             series = link['series']
+            logger.info('only one available item that can be downloaded via %s - %s. Let\'s do this..' % (link['site'], series))
+            link_matched = True
         elif len(tmp_links) > 1:
             logger.info('Multiple available download options (%s) - checking configuration to see which to grab...' % (" ,".join(tmp_sites)))
-            if any([('HD-Upscaled', 'SD-Digital', 'HD-Digital') in tmp_sites]):
-                if mylar.CONFIG.DDL_PREFER_UPSCALED:
-                    kk = tmp_links[site_position['HD-Upscaled']]
-                    if not kk:
-                        kk = tmp_links[site_position['HD-Digital']]
-                        logger.info('HD-Digital preference detected...attempting %s' % kk['series'])
+            site_check = [y for x in link_types for y in tmp_sites if x in y]
+            for ddlp in mylar.CONFIG.DDL_PRIORITY_ORDER:
+                force_title = False
+                site_lp = ddlp
+                logger.fdebug('priority ddl enabled - checking %s' % site_lp)
+                if site_check: #any([('HD-Upscaled', 'SD-Digital', 'HD-Digital') in tmp_sites]):
+                    if mylar.CONFIG.DDL_PREFER_UPSCALED:
+                        if site_lp == 'mega':
+                            sub_site_chk = [y for y in tmp_sites if 'mega' in y]
+                            if sub_site_chk:
+                                if any('HD-Upscaled' in ssc for ssc in sub_site_chk):
+                                    kk = tmp_links[site_position['HD-Upscaled:mega']]
+                                    logger.info('[MEGA] HD-Upscaled preference detected...attempting %s' % kk['series'])
+                                    link_matched = True
+                                elif any('HD-Digital' in ssc for ssc in sub_site_chk):
+                                    kk = tmp_links[site_position['HD-Digital:mega']]
+                                    logger.info('[MEGA] HD-Digital preference detected...attempting %s' % kk['series'])
+                                    link_matched = True
+
+                        elif not link_matched and site_lp == 'pixeldrain':
+                            sub_site_chk = [y for y in tmp_sites if 'pixel' in y]
+                            if sub_site_chk:
+                                if any('HD-Upscaled' in ssc for ssc in sub_site_chk):
+                                    kk = tmp_links[site_position['HD-Upscaled:pixeldrain']]
+                                    logger.info('[PixelDrain] HD-Upscaled preference detected...attempting %s' % kk['series'])
+                                    link_matched = True
+                                elif any('HD-Digital' in ssc for ssc in sub_site_chk):
+                                    kk = tmp_links[site_position['HD-Digital:pixeldrain']]
+                                    logger.info('[PixelDrain] HD-Digital preference detected...attempting %s' % kk['series'])
+                                    link_matched = True
+
+                        elif not link_matched and site_lp == 'mediafire':
+                            sub_site_chk = [y for y in tmp_sites if 'mediafire' in y]
+                            if sub_site_chk:
+                                if any('HD-Upscaled' in ssc for ssc in sub_site_chk):
+                                    kk = tmp_links[site_position['HD-Upscaled:mediafire']]
+                                    logger.info('[mediafire] HD-Upscaled preference detected...attempting %s' % kk['series'])
+                                    link_matched = True
+                                elif any('HD-Digital' in ssc for ssc in sub_site_chk):
+                                    kk = tmp_links[site_position['HD-Digital:mediafire']]
+                                    logger.info('[mediafire] HD-Digital preference detected...attempting %s' % kk['series'])
+                                    link_matched = True
+
+                        elif not link_matched and site_lp == 'main':
+                            sub_site_chk = [y for y in tmp_sites if 'download now' in y]
+                            if any('HD-Upscaled' in ssc for ssc in sub_site_chk):
+                                kk = tmp_links[site_position['HD-Upscaled:download now']]
+                                logger.info('[MAIN-SERVER] HD-Upscaled preference detected...attempting %s' % kk['series'])
+                                link_matched = True
+                            elif any('HD-Digital' in ssc for ssc in sub_site_chk):
+                                kk = tmp_links[site_position['HD-Digital:download now']]
+                                logger.info('[MAIN-SERVER] HD-Digital preference detected...attempting %s' % kk['series'])
+                                link_matched = True
                     else:
-                        logger.info('HD-Upscaled preference detected...attempting %s' % kk['series'])
+                        if not link_matched and site_lp == 'mega':
+                            sub_site_chk = [y for y in tmp_sites if 'mega' in y]
+                            if sub_site_chk:
+                                kk = tmp_links[site_position['SD-Digtal:mega']]
+                                logger.info('[MEGA] SD-Digital preference detected...attempting %s' % kk['series'])
+                                link_matched = True
+
+                        elif not link_matched and site_lp == 'pixeldrain':
+                            sub_site_chk = [y for y in tmp_sites if 'pixel' in y]
+                            if sub_site_chk:
+                                kk = tmp_links[site_position['SD-Digtal:pixeldrain']]
+                                logger.info('[PixelDrain] SD-Digital preference detected...attempting %s' % kk['series'])
+                                link_matched = True
+
+                        elif not link_matched and site_lp == 'mediafire':
+                            sub_site_chk = [y for y in tmp_sites if 'mediafire' in y]
+                            if sub_site_chk:
+                                kk = tmp_links[site_position['SD-Digtal:mediafire']]
+                                logger.info('[mediafire] SD-Digital preference detected...attempting %s' % kk['series'])
+                                link_matched = True
+
+                        elif not link_matched and site_lp == 'main':
+                            try:
+                                kk = tmp_links[site_position['SD-Digital:download now']]
+                                logger.info('[MAIN-SERVER] SD-Digital preference detected...attempting %s' % kk['series'])
+                                link_matched = True
+                            except Exception as e:
+                                kk = tmp_links[site_position['SD-Digital:mirror download']]
+                                logger.info('[MIRROR-SERVER] SD-Digital preference detected...attempting %s' % kk['series'])
+                                link_matched = True
+
+                    link = kk
+                    series = link['series']
+                    #logger.fdebug('link: %s' % link)
                 else:
-                    kk = tmp_links[site_position['SD-Digital']]
-                    logger.info('SD-Digital preference detected...attempting %s' % kk['series'])
-                link = kk
-                series = link['series']
-                #logger.fdebug('link: %s' % link)
-            else:
-               if 'download now' in tmp_sites:
-                   link = tmp_links[site_position['download now']]
-               elif 'mirror download' in tmp_sites:
-                   link = tmp_links[site_position['mirror download']]
-               else:
-                   link = tmp_links[0]
-                   series = link['series']
+                   if not link_matched and site_lp == 'mega':
+                       sub_site_chk = [y for y in tmp_sites if 'mega' in y]
+                       if sub_site_chk:
+                           try:
+                               link = tmp_links[site_position['normal:mega']]
+                               link_matched = True
+                           except Exception as e:
+                               link = tmp_links[site_position['normal:mega link']]
+                               link_matched = True
+                   elif not link_matched and site_lp == 'pixeldrain':
+                       sub_site_chk = [y for y in tmp_sites if 'pixel' in y]
+                       if sub_site_chk:
+                           try:
+                               link = tmp_links[site_position['normal:pixeldrain']]
+                               link_matched = True
+                           except Exception as e:
+                               logger.info('[PIXELDRAIN] Unable to attain proper link...')
+                               link_matched = False
+                   elif not link_matched and site_lp == 'mediafire':
+                       sub_site_chk = [y for y in tmp_sites if 'mediafire' in y]
+                       if sub_site_chk:
+                           try:
+                               link = tmp_links[site_position['normal:mediafire']]
+                               link_matched = True
+                           except Exception as e:
+                               logger.info('[mediafire] Unable to attain proper link...')
+                               link_matched = False
+                   elif not link_matched and site_lp == 'main':
+                       if 'download now' in tmp_sites:
+                           link = tmp_links[site_position['normal:download now']]
+                       elif 'mirror download' in tmp_sites:
+                           link = tmp_links[site_position['normal:mirror download']]
+                       else:
+                           link = tmp_links[0]
+                           force_title = True
+                       if 'sh.st' in link:
+                           logger.fdebug('[Paywall-link detected] this is not a valid link')
+                       else:
+                           if force_title:
+                               series = link['series']
+                           link_matched = True
+
+            dl_selection = link['site']
         else:
             logger.info('No valid items available that I am able to download from. Not downloading...')
-            return {'success': False}
+            return {'success': False, 'links_exhausted': link_type_failure}
 
         logger.fdebug(
-            'Now downloading: %s [%s] / %s ... this can take a while'
-            ' (go get some take-out)...' % (series, year, size)
+            '[%s] Now downloading: %s [%s] / %s ... this can take a while'
+            ' (go get some take-out)...' % (dl_selection, series, year, size)
         )
+
+        tmp_filename = '%s (%s)' % (series, year)
 
         links = []
 
@@ -739,12 +875,17 @@ class GC(object):
                         tmp = linkline['href']
                     except Exception:
                         continue
+
+                    site = linkline.findNext(text=True)
+                    #logger.fdebug('servertype: %s' % (site))
+
                     if tmp:
                         if any(
                             [
                                 'run.php' in linkline['href'],
                                 'go.php' in linkline['href'],
                                 'comicfiles.ru' in linkline['href'],
+                                ('links.php' in linkline['href'] and site == 'Main Server'),
                             ]
                         ):
                             volume = x.findNext(text=True)
@@ -759,6 +900,13 @@ class GC(object):
                             else:
                                 series = volume[:issues_st].strip()
                                 issues = volume[issues_st + 1 : series_st].strip()
+                                ver_check = self.pack_check(issues, packinfo)
+                                if ver_check is False:
+                                    #logger.fdebug('ver_check is False - ignoring')
+                                    continue
+
+                            if issues is None and any([booktype == 'Print', booktype is None, booktype == 'Digital']):
+                                continue
                             year_end = volume.find(')', series_st + 1)
                             year = re.sub(
                                 r'[\(\)]', '', volume[series_st + 1 : year_end]
@@ -768,7 +916,7 @@ class GC(object):
                                 r'[\(\)]', '', volume[year_end + 1 : size_end]
                             ).strip()
                             linked = linkline['href']
-                            site = linkline.findNext(text=True)
+                            #site = linkline.findNext(text=True)
                             if site == 'Main Server':
                                 links.append(
                                     {
@@ -783,7 +931,7 @@ class GC(object):
                                 )
         else:
             if booktype != 'TPB' and pack is False:
-                logger.fdebug('TPB links detected, but booktype set to %s' % booktype)
+                logger.fdebug('Extra links detected, possibly different booktypes - but booktype set to %s' % booktype)
             else:
                 check_extras = soup.findAll("h3")
                 for sb in check_extras:
@@ -829,7 +977,7 @@ class GC(object):
                 'Unable to retrieve any valid immediate download links.'
                 ' They might not exist.'
             )
-            return {'success': False}
+            return {'success': False, 'links_exhausted': link_type_failure}
         if all([link is not None, len(links) == 0]):
             logger.info(
                 'Only one item discovered, changing queue length to accomodate: %s [%s]'
@@ -854,10 +1002,28 @@ class GC(object):
                 mod_id = id
             else:
                 mod_id = id + '-' + str(cnt)
-            # logger.fdebug('[%s] %s (%s) %s [%s][%s]'
-            #     % (x['site'], x['series'], x['year'], x['issues'],
-            #     x['size'],  x['link'])
-            #     )
+
+            lt_site = x['site'].lower()
+            if any([lt_site == 'main server', lt_site == 'download now']):
+                link_type = 'GC-Main'
+            elif lt_site == 'mirror download':
+                link_type = 'GC-Mirror'
+            elif lt_site == 'mega':
+                link_type = 'GC-Mega'
+            elif lt_site == 'mediafire':
+                link_type = 'GC-Media'
+            elif lt_site == 'pixeldrain':
+                link_type = 'GC-Pixel'
+            else:
+                logger.warn('[GC-Site-Unknown] Unknown site detected...%s' % lt_site)
+                link_type = 'Unknown'
+
+            if self.issueid is None:
+                self.issueid = comicinfo[0]['IssueID']
+            if self.comicid is None:
+                self.comicid = comicinfo[0]['ComicID']
+            if self.oneoff is None:
+                self.oneoff = comicinfo[0]['oneoff']
 
             ctrlval = {'id': mod_id}
             vals = {
@@ -871,10 +1037,17 @@ class GC(object):
                 'mainlink': mainlink,
                 'site': 'DDL(GetComics)',
                 'pack': x['pack'],
+                'link_type': link_type,
                 'updated_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M'),
                 'status': 'Queued',
             }
             myDB.upsert('ddl_info', vals, ctrlval)
+
+            #tmp_filename = None
+            #if any([link_type == 'Mega', link_type == 'Mega Link']):
+                # this is needed so that we assign some tmp filename
+                # (it will get renamed upon completion anyways)
+                #tmp_filename = comicinfo[0]['nzbtitle']
 
             mylar.DDL_QUEUE.put(
                 {
@@ -887,6 +1060,10 @@ class GC(object):
                     'issueid': self.issueid,
                     'oneoff': self.oneoff,
                     'id': mod_id,
+                    'link_type': link_type,
+                    'filename': tmp_filename,
+                    'comicinfo': comicinfo,
+                    'packinfo': packinfo,
                     'site': 'DDL(GetComics)',
                     'remote_filesize': 0,
                     'resume': None,
@@ -894,10 +1071,16 @@ class GC(object):
             )
             cnt += 1
 
-        return {'success': True}
+        return {'success': True, 'site': link_type}
 
-    def downloadit(self, id, link, mainlink, resume=None, issueid=None, remote_filesize=0):
-        # logger.info('[%s] %s -- mainlink: %s' % (id, link, mainlink))
+    def downloadit(self, id, link, mainlink, resume=None, issueid=None, remote_filesize=0, link_type=None):
+        #logger.fdebug('[%s] %s -- mainlink: %s' % (id, link, mainlink))
+        if 'sh.st' in link:
+            logger.fdebug('[Paywall-link detected] This is not a valid link, this should be requeued to search to gather all available links')
+            return {
+               "success": False,
+               "link_type": link_type}
+
         if mylar.DDL_LOCK is True:
             logger.fdebug(
                 '[DDL] Another item is currently downloading via DDL. Only one item can'
@@ -908,9 +1091,9 @@ class GC(object):
             mylar.DDL_LOCK = True
 
         myDB = db.DBConnection()
+        mylar.DDL_QUEUED.append(id)
         filename = None
         self.cookie_receipt()
-        #self.headers['Accept-encoding'] = 'gzip'
         try:
             with requests.Session() as s:
                 if resume is not None:
@@ -919,7 +1102,6 @@ class GC(object):
                     )
                     self.headers['Range'] = 'bytes=%d-' % resume
 
-                #logger.fdebug('session cookies: %s' % (self.session.cookies,))
                 t = self.session.get(
                     link,
                     verify=True,
@@ -930,7 +1112,7 @@ class GC(object):
 
                 filename = os.path.basename(
                     urllib.parse.unquote(t.url)
-                )  # .decode('utf-8'))
+                )
                 if 'GetComics.INFO' in filename:
                     filename = re.sub('GetComics.INFO', '', filename, re.I).strip()
 
@@ -948,18 +1130,16 @@ class GC(object):
                         if 'run.php-urls' not in link:
                             link = re.sub('run.php-url=', 'run.php-urls', link)
                             link = re.sub('go.php-url=', 'run.php-urls', link)
-                            #logger.fdebug('session cookies: %s' % (self.session.cookies,))
                             t = self.session.get(
                                 link,
                                 verify=True,
                                 headers=self.headers,
                                 stream=True,
-                                timeout=(30,10)
+                                timeout=(30,30)
                             )
-                            t.headers['Accept-encoding'] = 'gzip'
                             filename = os.path.basename(
                                 urllib.parse.unquote(t.url)
-                            )  # .decode('utf-8'))
+                            )
                             if 'GetComics.INFO' in filename:
                                 filename = re.sub(
                                     'GetComics.INFO', '', filename, re.I
@@ -983,6 +1163,7 @@ class GC(object):
                                     "success": False,
                                     "filename": filename,
                                     "path": None,
+                                    "link_type": link_type,
                                 }
 
                         else:
@@ -997,7 +1178,11 @@ class GC(object):
                             )
                             remote_filesize = 0
                             mylar.DDL_LOCK = False
-                            return {"success": False, "filename": filename, "path": None}
+                            return {
+                                "success": False,
+                                "filename": filename,
+                                "path": None,
+                                "link_type": link_type}
 
                 # write the filename to the db for tracking purposes...
                 myDB.upsert(
@@ -1017,14 +1202,15 @@ class GC(object):
                             '[ABORTING] Error trying to validate/create DDL download'
                             ' directory: %s.' % mylar.CONFIG.DDL_LOCATION
                         )
-                        return {"success": False, "filename": filename, "path": None}
+                        return {
+                           "success": False,
+                           "filename": filename,
+                           "path": None,
+                           "link_type": link_type}
 
                 dst_path = os.path.join(mylar.CONFIG.DDL_LOCATION, filename)
 
-                # if t.headers.get('content-encoding') == 'gzip':
-                #    buf = StringIO(t.content)
-                #    f = gzip.GzipFile(fileobj=buf)
-
+                t.headers['Accept-encoding'] = 'gzip'
                 if resume is not None:
                     with open(dst_path, 'ab') as f:
                         for chunk in t.iter_content(chunk_size=1024):
@@ -1055,53 +1241,358 @@ class GC(object):
         except requests.exceptions.Timeout as e:
             logger.error('[ERROR] download has timed out due to inactivity...: %s', e)
             mylar.DDL_LOCK = False
-            return {"success": False, "filename": filename, "path": None}
+            return {
+               "success": False,
+               "filename": filename,
+               "path": None,
+               "link_type": link_type}
 
         except Exception as e:
             logger.error('[ERROR] %s' % e)
             mylar.DDL_LOCK = False
-            return {"success": False, "filename": filename, "path": None}
-
+            return {
+               "success": False,
+               "filename": filename,
+               "path": None,
+               "link_type": link_type}
         else:
             mylar.DDL_LOCK = False
-            if os.path.isfile(dst_path):
-                if dst_path.endswith('.zip'):
-                    new_path = os.path.join(
-                        mylar.CONFIG.DDL_LOCATION, re.sub('.zip', '', filename).strip()
+            return self.zip_zip(id, dst_path, filename)
+
+
+    def zip_zip(self, id, dst_path, filename):
+        if os.path.isfile(dst_path):
+            if dst_path.endswith('.zip'):
+                new_path = os.path.join(
+                    mylar.CONFIG.DDL_LOCATION, re.sub('.zip', '', filename).strip()
+                )
+                logger.info(
+                    'Zip file detected.'
+                    ' Unzipping into new modified path location: %s' % new_path
+                )
+                try:
+                    zip_f = zipfile.ZipFile(dst_path, 'r')
+                    zip_f.extractall(new_path)
+                    zip_f.close()
+                except Exception as e:
+                    logger.warn(
+                        '[ERROR: %s] Unable to extract zip file: %s' % (e, new_path)
                     )
-                    logger.info(
-                        'Zip file detected.'
-                        ' Unzipping into new modified path location: %s' % new_path
-                    )
+                    return {"success": False, "filename": filename, "path": None}
+                else:
                     try:
-                        zip_f = zipfile.ZipFile(dst_path, 'r')
-                        zip_f.extractall(new_path)
-                        zip_f.close()
+                        os.remove(dst_path)
                     except Exception as e:
                         logger.warn(
-                            '[ERROR: %s] Unable to extract zip file: %s' % (e, new_path)
+                            '[ERROR: %s] Unable to remove zip file from %s after'
+                            ' extraction.' % (e, dst_path)
                         )
-                        return {"success": False, "filename": filename, "path": None}
-                    else:
-                        try:
-                            os.remove(dst_path)
-                        except Exception as e:
-                            logger.warn(
-                                '[ERROR: %s] Unable to remove zip file from %s after'
-                                ' extraction.' % (e, dst_path)
-                            )
-                        filename = None
-                else:
-                    new_path = dst_path
-                return {"success": True, "filename": filename, "path": new_path}
+                    filename = None
+            else:
+                new_path = dst_path
+            return {"success": True, "filename": filename, "path": new_path}
 
         mylar.DDL_LOCK = False
         return {"success": False, "filename": filename, "path": None}
 
+    def check_for_pack(self, title, issue_in_pack=None):
+
+        og_title = title
+
+        volume_label = None
+        annuals = False
+        issues = None
+        pack = False
+
+        filename = series = title
+
+        #logger.fdebug('pack: %s' % pack)
+        tpb = False
+        gc_booktype = None
+        # see if it's a pack type
+
+        volume_issues = None
+        title_length = len(title)
+
+        # find the year
+        year_check = re.search(r'(\d{4}-\d{4})', title, flags=re.I)
+        if not year_check:
+            year_check = re.findall(r'(\d{4})', title, flags=re.I)
+            if year_check:
+                for yc in year_check:
+                    if title[title.find(yc)-1] != '#':
+                        if yc.startswith('19') or yc.startswith('20'):
+                            year = yc
+                            logger.fdebug('year: %s' % year)
+                            break
+            else:
+                #logger.fdebug('no year found within name...')
+                year = None
+        else:
+            year = year_check.group()
+            #logger.fdebug('year range: %s' % year)
+
+        if year is not None:
+            title = re.sub(year, '', title).strip()
+            title = re.sub('\(\)', '', title).strip()
+
+        issfind_st = title.find('#')
+        #logger.fdebug('issfind_st: %s' % issfind_st)
+        if issfind_st != -1:
+            issfind_en = title.find('-', issfind_st)
+        else:
+           # if it's -1, odds are it's a range, so need to work back
+            issfind_en = title.find('-')
+            #logger.fdebug('issfind_en: %s' % issfind_en)
+            #logger.fdebug('issfind_en-2: %s' % issfind_en -2)
+            if title[issfind_en -2].isdigit():
+                issfind_st = issfind_en -2
+                #logger.fdebug('issfind_st: %s' % issfind_st)
+            #logger.fdebug('rfind: %s' % title.lower().rfind('vol'))
+            if title.lower().rfind('vol') != -1:
+                #logger.fdebug('yes')
+                vol_find = title.lower().rfind('vol')
+                logger.fdebug('vol_find: %s' % vol_find)
+                if vol_find+2 == issfind_st:  #vol 1 - 5
+                    issfind_st = vol_find+3
+                if vol_find+3 == issfind_st:  #vol. 1 - 5
+                    issfind_st = vol_find+4
+
+        #logger.fdebug('issfind_en: %s' % issfind_en)
+        if issfind_en != -1:
+            if all([title[issfind_en + 1] == ' ', title[issfind_en + 2].isdigit()]):
+                iss_en = title.find(' ', issfind_en + 2)
+                #logger.info('iss_en: %s [%s]' % (iss_en, title[iss_en +2]))
+                if iss_en == -1:
+                    iss_en = len(title)
+                if iss_en != -1:
+                    #logger.info('issfind_st: %s' % issfind_st)
+                    issues = title[issfind_st : iss_en]
+                    if title.lower().rfind('vol') == issfind_st -5 or title.lower().rfind('vol') == issfind_st -4:
+                        series = '%s %s' % (title[:title.lower().rfind('vol')].strip(), title[iss_en:].strip())
+                        logger.info('new series: %s' % series)
+                        volume_issues = issues
+                        if len(title) - 6 > title.lower().rfind('tpb') > 1:
+                            gc_booktype = 'TPB'
+                        elif len(title) - 6 > title.lower().rfind('gn') > 1:
+                            gc_booktype = 'GN'
+                        elif len(title) - 6 > title.lower().rfind('hc') > 1:
+                            gc_booktype = 'HC'
+                        elif len(title) - 6 > title.lower().rfind('one-shot') > 1:
+                            gc_booktype = 'One-Shot'
+                        else:
+                            gc_booktype = 'TPB/GN/HC/One-Shot'
+                        tpb = True
+                    #else:
+                    t1 = title.lower().rfind('volume')
+                    vcheck = 'volume'
+                    if t1 == -1:
+                        t1 = title.lower().rfind('vol.')
+                        vcheck = 'vol.'
+                        if t1 == -1:
+                            t1 = title.lower().rfind('vol')
+                            vcheck = 'vol'
+                    if t1 != -1:
+                        #logger.fdebug('vcheck: %s' % (len(vcheck)))
+                        #logger.fdebug('title.find: %s' % title.lower().find(' ', t1))
+                        vv = title.lower().find(' ', title.lower().find(' ', t1)+1)
+                        #logger.fdebug('vv: %s' % vv)
+                        if tpb:
+                            volume_label = title[t1:t1+len(vcheck)].strip()
+                        else:
+                            volume_label = title[t1:vv].strip()
+                        logger.fdebug('volume discovered: %s' % volume_label)
+
+                    pack = True
+                    logger.fdebug('issues: %s' % issues)
+            elif title[issfind_en + 1].isdigit():
+                iss_en = title.find(' ', issfind_en + 1)
+                if iss_en != -1:
+                    issues = title[issfind_st + 1 : iss_en]
+                    pack = True
+
+
+        # to handle packs that are denoted without a # sign being present.
+        # if there's a dash, check to see if both sides of the dash are numeric.
+        logger.fdebug('pack: [%s] %s' % (type(pack),pack))
+        if not pack and title.find('-') != -1:
+            #logger.fdebug('title: %s' % title)
+            #logger.fdebug('title[issfind_en+1]: %s' % title[issfind_en +1])
+            #logger.fdebug('title[issfind_en+2]: %s' % title[issfind_en +2])
+            #logger.fdebug('title[issfind_en-1]: %s' % title[issfind_en -1])
+            if all(
+                   [
+                       title[issfind_en + 1] == ' ',
+                       title[issfind_en + 2].isdigit(),
+                   ]
+            ) and all(
+                   [
+                       title[issfind_en -1] == ' ',
+                   ]
+            ):
+                spaces = [m.start() for m in re.finditer(' ', title)]
+                dashfind = title.find('–')
+                space_beforedash = title.find(' ', dashfind - 1)
+                space_afterdash = title.find(' ', dashfind + 1)
+                if not title[space_afterdash+1].isdigit():
+                    pass
+                else:
+                    iss_end = title.find(' ', space_afterdash + 1)
+                    if iss_end == -1:
+                        iss_end = len(title)
+                    set_sp = None
+                    for sp in spaces:
+                        if sp < space_beforedash:
+                            prior_sp = sp
+                        else:
+                            set_sp = prior_sp
+                            break
+                    if title[set_sp:space_beforedash].strip().isdigit():
+                        issues = title[set_sp:iss_end].strip()
+                        pack = True
+        # if it's a pack - remove the issue-range and the possible issue years
+        # (cause it most likely will span) and pass thru as separate items
+        if series is None:
+            series = title
+        if pack is True or pack is False:
+            #f_iss = series.find('#')
+            #if f_iss != -1:
+            #    series = '%s%s'.strip() % (title[:f_iss-1], title[f_iss+1:])
+            #series = re.sub(issues, '', series).strip()
+            # kill any brackets in the issue line here.
+            #issgggggggues = re.sub(r'[\(\)\[\]]', '', issues).strip()
+            #if series.endswith('#'):
+            #    series = series[:-1].strip()
+            #title += ' #1'  # we add this dummy value back in so the parser won't choke as we have the issue range stored already
+
+            #if year is not None:
+            #    title += ' (%s)' % year
+            logger.fdebug('pack_check: %s/ title: %s' % (pack, title))
+            og_series = series
+            if pack is False:
+                f_iss = title.find('#')
+                #logger.fdebug('f_iss: %s' % f_iss)
+                if f_iss != -1:
+                    series = '%s'.strip() % (title[:f_iss-1])
+                    #logger.fdebug('changed_title: %s' % series)
+            #logger.fdebug('title: %s' % title)
+            issues = r'%s' % issues
+            title = re.sub(issues, '', title).strip()
+            # kill any brackets in the issue line here.
+            #logger.fdebug('issues-before: %s' % issues)
+            issues = re.sub(r'[\(\)\[\]]', '', issues).strip()
+            #logger.fdebug('issues-after: %s' % issues)
+            if series.endswith('#'):
+                series = series[:-1].strip()
+
+            og_series = series
+
+            crap = re.findall(r"\(.*?\)", title)
+            for c in crap:
+                title = re.sub(c, '', title).strip()
+            if crap:
+                title= re.sub(r'[\(\)\[\]]', '', title).strip()
+
+            pr = [x for x in self.pack_receipts if x in title]
+            nott = title
+            for x in pr:
+                #logger.fdebug('removing %s from %s' % (x, title))
+                try:
+                    if x == 'TPB':
+                        if gc_booktype is None:
+                            gc_booktype = 'TPB'
+                        tpb = True
+                    # may have to put HC/GN/One_shot in here as well...
+                    if 'Annual' in x:
+                        annuals = True
+                    if ' &' in x and title.rfind(x) <= len(title) + 3:
+                        x = title[title.rfind(x):]
+                    nt = nott.replace(x, '').strip()
+                    #logger.fdebug('[%s] new nott: %s' % (x, nott))
+                except Exception as e:
+                    #logger.warn('error: %s' % e)
+                    pass
+                else:
+                    nott = nt
+
+            #logger.fdebug('title: %s' % title)
+            #logger.fdebug('final nott: %s' % nott)
+            if nott != title:
+                series = re.sub('\s+', ' ', nott).strip()
+                series = re.sub(r'[\(\)\[\]]', '', series).strip()
+                title = re.sub('\s+', ' ', nott).strip()
+                title = re.sub(r'[\(\)\[\]]', '', title).strip()
+            else:
+                series = re.sub('\s+', ' ', nott).strip()
+
+            if pack is True:
+                if year is not None:
+                    title += ' (%s)' % year
+                else:
+                    title = '%s #%s (%s)' % (title, self.query['issue'], self.query['year'])
+            else:
+                title = series = filename
+                #if all([year is not None, year not in title]):
+                #    title += ' (%s)' % year
+            #logger.fdebug('final title: %s' % (title))
+
+            if volume_label:
+                series = re.sub(volume_label, '', series, flags=re.I).strip()
+                volume_label = re.sub('[^0-9]', '', volume_label).strip()
+
+            if tpb and gc_booktype is None:
+                gc_booktype = 'TPB'
+            else:
+                if gc_booktype is None:
+                    gc_booktype = 'issue'
+
+            logger.fdebug('title: %s' % title)
+            logger.fdebug('series: %s' % series)
+            logger.fdebug('filename: %s' % filename)
+            logger.fdebug('year: %s' % year)
+            logger.fdebug('pack: %s' % pack)
+            logger.fdebug('tpb/gn/hc: %s' % tpb)
+            if all([pack, tpb]):
+                logger.fdebug('volumes: %s' % volume_issues)
+            else:
+                if volume_label:
+                    logger.fdebug('volume: %s' % volume_label)
+                if annuals:
+                    logger.fdebug('annuals: %s' % annuals)
+                logger.fdebug('issues: %s' % issues)
+
+            return {'title': title,
+                    'filename': filename,
+                    'series': series,
+                    'year': year,
+                    'pack': pack,
+                    'volume': volume_label,
+                    'annuals': annuals,
+                    'gc_booktype': gc_booktype,
+                    'issues': issues}
+        else:
+            return None
+
+    def pack_check(self, issues, packinfo):
+        try:
+            pack_numbers = packinfo['pack_numbers']
+            issue_range = packinfo['pack_issuelist']['issue_range']
+            ist = re.sub('#', '', issues).strip()
+            iss = ist.find('-')
+            first_iss = issues[:iss].strip()
+            last_iss = issues[iss+1:].strip()
+            if all([int(first_iss) in issue_range, int(last_iss) in issue_range]):
+                logger.fdebug('first issue(%s) and last issue (%s) of ddl link fall within pack range of %s' % (first_iss, last_iss, pack_numbers))
+                return True
+        except Exception as e:
+            pass
+
+        return False
+
     def issue_list(self, pack):
         # packlist = [x.strip() for x in pack.split(',)]
         packlist = pack.replace('+', ' ').replace(',', ' ').split()
-        print(packlist)
+        #logger.fdebug(packlist)
         plist = []
         pack_issues = []
         for pl in packlist:
@@ -1125,7 +1616,7 @@ class GC(object):
                 pack_issues.append(pi)
 
         pack_issues.sort()
-        print("pack_issues: %s" % pack_issues)
+        logger.fdebug("pack_issues: %s" % pack_issues)
 
 
 # if __name__ == '__main__':

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -1096,7 +1096,7 @@ def issue_collection(issuedata, nostatus, serieslast_updated=None):
                 #logger.fdebug("Not changing the status at this time - reverting to previous module after to re-append existing status")
                 pass #newValueDict['Status'] = "Skipped"
 
-            logger.info('issue_collection results: [%s] %s' % (controlValueDict, newValueDict))
+            #logger.fdebug('issue_collection results: [%s] %s' % (controlValueDict, newValueDict))
             try:
                 myDB.upsert(dbwrite, newValueDict, controlValueDict)
             except sqlite3.InterfaceError as e:

--- a/mylar/req_test.py
+++ b/mylar/req_test.py
@@ -21,7 +21,7 @@ import subprocess
 import codecs
 import configparser
 import platform
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 import mylar
 from mylar import logger

--- a/mylar/rsscheck.py
+++ b/mylar/rsscheck.py
@@ -26,7 +26,7 @@ import time
 import random
 from bs4 import BeautifulSoup
 from io import StringIO
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 import mylar
 from mylar import db, logger, ftpsshup, helpers, auth32p, utorrent, helpers, filechecker

--- a/mylar/sabnzbd.py
+++ b/mylar/sabnzbd.py
@@ -22,7 +22,7 @@ import os
 import sys
 import re
 import time
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 import mylar
 from mylar import logger, cdh_mapping
 
@@ -166,10 +166,6 @@ class SABnzbd(object):
             try:
                 min_sab = '3.2.0'
                 sab_vers = mylar.CONFIG.SAB_VERSION
-                if 'beta' in sab_vers:
-                    sab_vers = re.sub('[^0-9]', '', sab_vers)
-                    if len(sab_vers) > 3:
-                        sab_vers = sab_vers[:-1] # remove beta value entirely...
                 if parse_version(sab_vers) >= parse_version(min_sab):
                     logger.fdebug('SABnzbd version is higher than 3.2.0. Querying history based on nzo_id directly.')
                     hist_params['nzo_ids'] = sendresponse

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -1205,6 +1205,8 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                 if all([booktype == 'TPB', iscnt > 1]) or all([booktype == 'GN', iscnt > 1]) or all([booktype =='HC', iscnt > 1]) or all([booktype == 'One-Shot', iscnt == 1, cla['JusttheDigits'] is None]):
                     if cla['SeriesVolume'] is not None:
                         just_the_digits = re.sub('[^0-9]', '', cla['SeriesVolume']).strip()
+                    elif cla['JusttheDigits'] is None:
+                        just_the_digits = None
                     else:
                         just_the_digits = re.sub('[^0-9]', '', cla['JusttheDigits']).strip()
                 else:
@@ -1264,7 +1266,7 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
             logger.fdebug('[ANNUAL-CHK] No annuals with identical issue numbering across annual volumes were detected for this series')
             mc_annualnumber = None
         else:
-            logger.fdebug('[ANNUAL-CHK] Multiple issues with identical numbering were detected across multiple annual volumes. Attempting to accomodate.')
+            logger.fdebug('[ANNUAL-CHK] Multiple annuals with identical numbering were detected across multiple annual volumes. Attempting to accomodate.')
             for mc in mult_ann_check:
                 mc_annualnumber.append({"Int_IssueNumber": mc['Int_IssueNumber']})
 
@@ -1468,8 +1470,8 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                             isslocation = tmpfc['ComicFilename'] #helpers.conversion(tmpfc['ComicFilename'])
                             issSize = str(tmpfc['ComicSize'])
                             logger.fdebug(module + ' .......filename: ' + isslocation)
-                            logger.fdebug(module + ' .......filesize: ' + str(tmpfc['ComicSize'])) 
-                            # to avoid duplicate issues which screws up the count...let's store the filename issues then 
+                            logger.fdebug(module + ' .......filesize: ' + str(tmpfc['ComicSize']))
+                            # to avoid duplicate issues which screws up the count...let's store the filename issues then
                             # compare earlier...
                             issuedupechk.append({'fcdigit':   fcdigit,
                                                  'filename':  tmpfc['ComicFilename'],
@@ -1513,17 +1515,16 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                     break
                 int_iss = helpers.issuedigits(reann['Issue_Number'])
                 #logger.fdebug(module + ' int_iss:' + str(int_iss))
-
                 issyear = reann['IssueDate'][:4]
                 old_status = reann['Status']
 
-                year_check = re.findall(r'(/d{4})(?=[\s]|annual\b|$)', temploc, flags=re.I)
+                year_check = re.findall(r'(\d{4})(?=[\s]|annual\b|$)', temploc, flags=re.I)
                 if year_check:
                     ann_line = '%s annual' % year_check[0]
                     logger.fdebug('ann_line: %s' % ann_line)
-                    fcdigit = helpers.issuedigits(re.sub(ann_line, '', temploc.lower()).strip())
-                #fcdigit = helpers.issuedigits(re.sub('2021 annual', '', temploc.lower()).strip())
-                fcdigit = helpers.issuedigits(re.sub('annual', '', temploc.lower()).strip())
+                    fcdigit = helpers.issuedigits('1')
+                else:
+                    fcdigit = helpers.issuedigits(re.sub('annual', '', temploc.lower()).strip())
                 if fcdigit == 999999999999999:
                     fcdigit = helpers.issuedigits(re.sub('special', '', temploc.lower()).strip())
 
@@ -1802,11 +1803,13 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
 
     logger.fdebug('[nothaves] issue_status_generation_time_taken: %s' % (datetime.datetime.now() - u_start))
 
-    if len(update_iss) > 0:
+    if any([len(update_iss) > 0, len(update_ann) > 0]):
         r_start = datetime.datetime.now()
         try:
-            myDB.action("UPDATE issues SET Status=? WHERE IssueID=?", update_iss, executemany=True)
-            myDB.action("UPDATE annuals SET Status=? WHERE IssueID=?", update_ann, executemany=True)
+            if len(update_iss) > 0:
+                myDB.action("UPDATE issues SET Status=? WHERE IssueID=?", update_iss, executemany=True)
+            if len(update_ann) > 0:
+                myDB.action("UPDATE annuals SET Status=? WHERE IssueID=?", update_ann, executemany=True)
         except Exception as e:
             logger.warn('Error updating: %s' % e)
         logger.fdebug('[nothaves] issue_status_writing took %s' % (datetime.datetime.now() - r_start))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,13 @@
 #### ESSENTIAL LIBRARIES FOR MAIN FUNCTIONALITY ####
 APScheduler>=3.6.3
 beautifulsoup4>=4.8.2
-cfscrape>=2.0.8
 cheroot>=8.2.1
 CherryPy>=18.5.0
 configparser>=4.0.2
 feedparser>=5.2.1
 Mako>=1.1.0
 natsort>=3.5.2
+packaging>=22.0
 Pillow>=10.1
 portend>=2.6
 pystun>=0.1.0


### PR DESCRIPTION
**Improvements**
IMP: (DDL) Allow additonal downloading from mega, mediafire and pixeldrain links when using DDL GC.
IMP: (DDL -- config.ini) ``ddl_priority_order`` can be customized to set the priority order in which the DDL links will be attempted
IMP: (DDL) Will cycle thru ddl_priority_order in sequence attempting each link as it gets to it, until link is able to be downloaded or link exhaustion occurs
IMP: Don't post-process or scan extensions if provided in ``ignore_search_words``
IMP: ``listAnnualSeries`` api endpoint added
IMP: ``format_booktype`` now set to True by default (allows use of $Type in folder format)
IMP: (DDL) Additional add-on server entry for DDL 
IMP: (DDL) Improved Pack parsing / detection
IMP: Dupechecker will now prioritize ``(F#)``/``(f#)`` in filenames as 'Fixed' over normally  named files or lower numbered (f#)
IMP: Pack issue # tracking will track issues that belong to a particular pack so individually queueing issues within pack before it's completed, will not redownload issues belonging to the pack.
IMP: Added Link column to DDL Manage page (display which type of link was/is being used)
IMP: (DDL --> Manage) Adjusted column widths & spacing to correct some double-lines occurring
IMP: (DDL --> Manage) Show pack issue range for packs as opposed to showing the individual item that was being searched for
IMP: Notification of packs being downloaded will now show which DDL link was used to download as well as complete name of pack

**Fixes**
FIX: Annuals were written to incorrect table sometimes resulting in status/filename being locked in db and unable to remove
FIX: Annuals that had the year present in the annual name and no issue number would not be recognized during series scans
FIX: (carepackage) when creating carepackage, if requirements were set to ``==`` would cause error if it was higher/lower versioning
FIX: Volume of series on cv > 10 would not be recognized as such when adding/refreshing series
FIX: Parsing of files that had part /volume would fail when ``part`` was part of the series title
FIX: One-shots with no issue number (but year is present) in filename will now be properly accounted for in series rechecks if booktype is set correctly
FIX: Removed some incorrect ``logger.warn`` references so that will log regardless of language
FIX: Error when removing directory that doesn't physically exist where it was recorded as being (delete series option)
FIX: (searchresults --> Edit) would not update comic location path when booktype was changed via dropdown
FIX: (searchresults --> Edit) GN was incorrectly labelled as GC within the booktype dropdown
FIX: Incorrect status colours for annuals when integration is enabled (Archived, Ignored)
FIX: Improper parsing of sabnzbd version in with newer versions would cause errors when checking / sending to sabnzbd
FIX: Remove depreciated imghdr module in lieu of using pillow (api.py)
FIX: Replace depreciated SafeConfigParser call from configparser when generating carepackage
FIX: Depreciation of pkg_resources - use packaging now (addition to requirements)