### PR TITLE
FIX: DDL attempting items in a forever loop, FIX: scheduled searches would re-attempt previous downloads

### DIFF
--- a/data/interfaces/default/queue_management.html
+++ b/data/interfaces/default/queue_management.html
@@ -267,13 +267,16 @@
                                     var restartline = "('ddl_requeue?mode=restart&id="+String(full[5])+"',$(this));"
                                     var resumeline = "('ddl_requeue?mode=resume&id="+String(full[5])+"',$(this));"
                                     var removeline = "('ddl_requeue?mode=remove&id="+String(full[5])+"',$(this));"
+                                    tbl_options = '';
                                     if (val == 'Completed' || val == 'Failed' || val == 'Downloading'){
-                                        return '<span title="Restart"></span><a href="#" onclick="doAjaxCall'+restartline+'">Restart</a><span title="Remove"></span><a href="#" onclick="doAjaxCall'+removeline+'"><span class="ui-icon ui-icon-plus"></span>Remove</a>';
+                                        tbl_options += '<span title="Restart"></span><a href="#" onclick="doAjaxCall'+restartline+'">Restart</a>';
                                     } else if (val == 'Incomplete') {
-                                        return '<span title="Restart"></span><a href="#" onclick="doAjaxCall'+restartline+'">Restart</a><span title="Resume"></span><a href="#" onclick="doAjaxCall'+resumeline+'"><span class="ui-icon ui-icon-plus"></span>Resume</a>';
+                                        tbl_options += '<span title="Restart"></span><a href="#" onclick="doAjaxCall'+restartline+'">Restart</a><span title="Resume"></span><a href="#" onclick="doAjaxCall'+resumeline+'"><span class="ui-icon ui-icon-plus"></span>Resume</a>';
                                     } else if (val == 'Queued') {
-                                        return '<span title="Start"></span><a href="#" onclick="doAjaxCall'+restartline+'">Start</a>';
+                                        tbl_options += '<span title="Start"></span><a href="#" onclick="doAjaxCall'+restartline+'">Start</a>';
                                     }
+                                    tbl_options += '<span title="Remove"></span><a href="#" onclick="doAjaxCall'+removeline+'"><span class="ui-icon ui-icon-plus"></span>Remove</a>';
+                                    return tbl_options;
                            }         
                         },
                     ],

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -627,8 +627,7 @@ class GC(object):
                     t_site = re.sub('link', '', lk['title'].lower()).strip()
                     ltf = False
                     if link_type_failure is not None:
-                        logger.fdebug('link_type_failure: %s' % link_type_failure)
-                        if [True for tst in link_type_failure if t_site.lower() in tst.lower()]:
+                        if [True for tst in link_type_failure if t_site[:4].lower() in tst.lower()]:
                             logger.fdebug('[REDO-FAILURE-DETECTION] detected previous invalid link for %s - ignoring this result'
                                         ' and seeing if anything else can be downloaded.' % t_site)
                             ltf = True

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -2337,6 +2337,26 @@ def searchforissue(issueid=None, new=False, rsschecker=None, manual=False):
                                 mylar.SEARCHLOCK = False
                                 return
 
+                #if it's not manually initiated, make sure it's not already downloaded/snatched.
+                if not manual:
+                    checkit = searchforissue_checker(
+                                result['IssueID'],
+                                result['ReleaseDate'],
+                                result['IssueDate'],
+                                result['DigitalDate'],
+                                {'ComicName': result['ComicName'],
+                                 'Issue_Number': result['Issue_Number'],
+                                 'ComicID': result['ComicID']
+                                }
+                              )
+                    if checkit['status'] is False:
+                        logger.fdebug(
+                              'Issue is already in a Downloaded / Snatched status. If this is'
+                              ' still wanted, perform a Manual search or mark issue as Skipped'
+                              ' or Wanted.'
+                        )
+                        return
+
                 allow_packs = False
                 ComicID = result['ComicID']
                 if smode == 'story_arc':

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -2580,12 +2580,13 @@ class WebInterface(object):
                     logger.info('Marking %s : %s as wanted...' % (ComicName, ComicIssue))
                     myDB.upsert("annuals", newStatus, controlValueDict)
             moduletype = '[WANTED-SEARCH]'
-            passinfo = {'issueid':     IssueID,
-                        'comicname':   ComicName,
-                        'seriesyear':  SeriesYear,
-                        'comicid':     ComicID,
+            passinfo = {'issueid': IssueID,
+                        'comicname': ComicName,
+                        'seriesyear': SeriesYear,
+                        'comicid': ComicID,
                         'issuenumber': ComicIssue,
-                        'booktype':    BookType}
+                        'booktype': BookType,
+                        'manual': manualsearch}
 
 
             if mode == 'want':


### PR DESCRIPTION
- DDL would loop thru available links in an endless loop if first link was not available
- scheduled searches will have status checked prior to actually searching (cannot be in a Downloaded or Snatched status) unless it was initiated manually (ie. magnifying glass search)
- Added Remove option to DDL table options so items that are stuck in a Start/Incomplete status can be removed