### PR TITLE
various fixes (see notes)

### DIFF
--- a/mylar/cv.py
+++ b/mylar/cv.py
@@ -49,7 +49,10 @@ def pulldetails(comicid, rtype, issueid=None, offset=1, arclist=None, comicidlis
         PULLURL = mylar.CVURL + str(cv_rtype) + '/?api_key=' + str(comicapi) + '&format=xml&' + str(searchset) + '&offset=' + str(offset)
     elif any([rtype == 'image', rtype == 'firstissue', rtype == 'imprints_first']):
         #this is used ONLY for CV_ONLY
-        PULLURL = mylar.CVURL + 'issues/?api_key=' + str(comicapi) + '&format=xml&filter=id:' + str(issueid) + '&field_list=cover_date,store_date,image'
+        if issueid:
+            PULLURL = mylar.CVURL + 'issues/?api_key=' + str(comicapi) + '&format=xml&filter=id:' + str(issueid) + '&field_list=cover_date,store_date,image'
+        else:
+            PULLURL = mylar.CVURL + 'volume/' + str(comicid) + '/?api_key=' + str(comicapi) + '&format=xml' + '&field_list=image'
     elif rtype == 'storyarc':
         PULLURL = mylar.CVURL + 'story_arcs/?api_key=' + str(comicapi) + '&format=xml&filter=name:' + str(issueid) + '&field_list=cover_date'
     elif rtype == 'comicyears':

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -3187,7 +3187,15 @@ def searcher(
             ggc = getcomics.GC(issueid=tmp_issueid, comicid=ComicID)
             ggc.loadsite(nzbid, link)
             ddl_it = ggc.parse_downloadresults(nzbid, link, comicinfo, pack_info)
-            tnzbprov = ddl_it['site']
+            tnzbprov = nzbprov
+            if ddl_it['success'] is True:
+                logger.info(
+                    '[%s] Successfully snatched %s from DDL site. It is currently being queued'
+                    ' to download in position %s' % (tnzbprov, nzbname, mylar.DDL_QUEUE.qsize())
+                )
+            else:
+                logger.info('[%s] Failed to retrieve %s from the DDL site.' % (tnzbprov, nzbname))
+                return "ddl-fail"
         else:
             cinfo = {'id': nzbid,
                      'series': comicinfo[0]['ComicName'],
@@ -3203,16 +3211,16 @@ def searcher(
 
             meganz = exs.MegaNZ(provider_stat=provider_stat)
             ddl_it = meganz.queue_the_download(cinfo, comicinfo, pack_info)
-            tnzbprov = 'Mega'
+            tnzbprov = 'DDL(External)'
 
-        if ddl_it['success'] is True:
-            logger.info(
-                '[%s] Successfully snatched %s from DDL site. It is currently being queued'
-                ' to download in position %s' % (tnzbprov, nzbname, mylar.DDL_QUEUE.qsize())
-            )
-        else:
-            logger.info('[%s] Failed to retrieve %s from the DDL site.' % (tnzbprov, nzbname))
-            return "ddl-fail"
+            if ddl_it['success'] is True:
+                logger.info(
+                    '[%s] Successfully snatched %s from DDL site. It is currently being queued'
+                    ' to download in position %s' % (tnzbprov, nzbname, mylar.DDL_QUEUE.qsize())
+                )
+            else:
+                logger.info('[%s] Failed to retrieve %s from the DDL site.' % (tnzbprov, nzbname))
+                return "ddl-fail"
 
         sent_to = "is downloading it directly via %s" % tnzbprov
 

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -2224,7 +2224,10 @@ def watchlist_updater(calledfrom=None, sched=False):
             '[BACKFILL-UPDATE] [%s] series need to be updated due to previous'
             ' failures: %s' % (len(prev_failed_updates), prev_failed_updates)
         )
-        to_check = dict(to_check, **prev_failed_updates)
+        try:
+            to_check = dict(to_check, **prev_failed_updates)
+        except Exception as e:
+            to_check = prev_failed_updates
         #to_check.extend(prev_failed_updates)
     else:
         logger.info(


### PR DESCRIPTION
- If cover image on series detail page is corrupted/corrupt - would error. It will now attempt to download a clean copy of the main image, and if that fails try an alternate image size (it may take a few seconds to display in page, will add a popup indicating)
-  dbupdater would error when attempting to merge previous_failed_id info into a non-existent dictionary
- Wanted page may not display if IssueNumber field is blank or some other field is empty. Will attempt to default to ComicName.
- On successful DDL downloads, if the link used worked :
    - If it was the first link used, would cause a traceback when clearing the queue of the id
    - If it was a retry/requeue, would error on attempting to preload a variable that's not really needed (one-shot) / site name
- DDL ReQueue / Restart would throw a red popup warning due to invalid reference (One-Shot) on Manage DDL page
    - When initiating a ReQueue/Restart, the resume option will only be attempted if it a main server GC link