### PR TITLE
FIX: endless DDL looping when paywall site encountered, and some other fixes

### DIFF
--- a/mylar/config.py
+++ b/mylar/config.py
@@ -170,7 +170,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'CHECK_GITHUB' : (bool, 'Git', False),
     'CHECK_GITHUB_ON_STARTUP' : (bool, 'Git', False),
 
-    'ENFORCE_PERMS': (bool, 'Perms', True),
+    'ENFORCE_PERMS': (bool, 'Perms', False),
     'CHMOD_DIR': (str, 'Perms', '0777'),
     'CHMOD_FILE': (str, 'Perms', '0660'),
     'CHOWNER': (str, 'Perms', None),
@@ -267,7 +267,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'FOLDER_CACHE_LOCATION': (str, 'PostProcess', None),
 
     'PROVIDER_ORDER': (str, 'Providers', None),
-    'USENET_RETENTION': (int, 'Providers', 1500),
+    'USENET_RETENTION': (int, 'Providers', 3500),
 
     'NZB_DOWNLOADER': (int, 'Client', 0),  #0': sabnzbd, #1': nzbget, #2': blackhole
     'TORRENT_DOWNLOADER': (int, 'Client', 0),  #0': watchfolder, #1': uTorrent, #2': rTorrent, #3': transmission, #4': deluge, #5': qbittorrent
@@ -347,7 +347,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'CT_NOTES_FORMAT': (str, 'Metatagging', 'Issue ID'),
     'CT_SETTINGSPATH': (str, 'Metatagging', None),
     'CMTAG_VOLUME': (bool, 'Metatagging', True),
-    'CMTAG_START_YEAR_AS_VOLUME': (bool, 'Metatagging', False),
+    'CMTAG_START_YEAR_AS_VOLUME': (bool, 'Metatagging', True),
     'SETDEFAULTVOLUME': (bool, 'Metatagging', False),
 
     'ENABLE_TORRENTS': (bool, 'Torrents', False),
@@ -1104,7 +1104,7 @@ class Config(object):
 
         if self.CLEANUP_CACHE is True:
             logger.fdebug('[Cache Cleanup] Cache Cleanup initiated. Will delete items from cache that are no longer needed.')
-            cache_types = ['*.nzb', '*.torrent', '*.zip', '*.html', 'mylar_*']
+            cache_types = ['*.nzb', '*.torrent', '*.zip', '*.html', 'mylar_*', 'html_cache']
             cntr = 0
             for x in cache_types:
                 for f in glob.glob(os.path.join(self.CACHE_DIR,x)):
@@ -1343,13 +1343,17 @@ class Config(object):
         if self.ENABLE_DDL:
             #make sure directory for mega downloads is created...
             mega_ddl_path = os.path.join(self.DDL_LOCATION, 'mega')
+            html_cache_path = os.path.join(self.CACHE_DIR, 'html_cache')
             if not os.path.isdir(mega_ddl_path):
                 try:
                     os.makedirs(mega_ddl_path)
-                #dcreate = filechecker.validateAndCreateDirectory(mega_ddl_path, create=True)
-                #if dcreate is False:
                 except Exception as e:
                     logger.error('Unable to create temp download directory [%s] for DDL-External. You will not be able to view the progress of the download.' % mega_ddl_path)
+            if not os.path.isdir(html_cache_path):
+                try:
+                    os.makedirs(html_cache_path)
+                except Exception as e:
+                    logger.error('Unable to create html_cache folder within the cache folder location [%s]. DDL will not work until this is corrected.' % html_cache_path)
 
         if len(self.DDL_PRIORITY_ORDER) > 0 and self.DDL_PRIORITY_ORDER != '[]':
             if type(self.DDL_PRIORITY_ORDER) != list:

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3381,6 +3381,9 @@ def ddl_downloader(queue):
                 except Exception:
                     pass
 
+                # remove html file from cache if it's successful
+                ddl_cleanup(item['id'])
+
                 #logger.fdebug('after-pack_issueids: %s' % mylar.PACK_ISSUEIDS_DONT_QUEUE)
                 logger.fdebug('Successfully removed %s issueids from pack queue list as download is completed.' % pck_cnt)
 
@@ -3389,6 +3392,7 @@ def ddl_downloader(queue):
                 if ddzstat['filename'] is not None:
                     path = os.path.join(path, ddzstat['filename'])
                 logger.info('File successfully downloaded. Post Processing is not enabled - item retained here: %s' % (path,))
+                ddl_cleanup(item['id'])
             else:
                 try:
                     ltf = ddzstat['links_exhausted']
@@ -3409,8 +3413,20 @@ def ddl_downloader(queue):
                     #undo all snatched items, to previous status via item['id'] - this will be set to Skipped currently regardless of previous status
                     reverse_the_pack_snatch(item['id'], item['comicid'])
                     link_type_failure.pop(item['id'])
+                    ddl_cleanup(item['id'])
         else:
             time.sleep(5)
+
+def ddl_cleanup(id):
+   # remove html file from cache if it's successful
+   tlnk = 'getcomics-%s.html' % id
+   try:
+       os.remove(os.path.join(mylar.CONFIG.CACHE_DIR, 'html_cache', tlnk))
+   except Exception as e:
+       logger.fdebug('[HTML-cleanup] Unable to remove html used for item from html_cache folder.'
+                     ' Manual removal required or set `cleanup_cache=True` in the config.ini to'
+                     ' clean cache items on every startup. If this was a Retry - ignore this.')
+
 
 def postprocess_main(queue):
     while True:


### PR DESCRIPTION
- FIX: endless DDL looping would occur when all links were behind a paywall site and link exhaustion could not occur
- FIX: html_cache in cache_dir for GC html files so won't redownload html file until item is successfully downloaded.
- FIX: html_cache location added to cleanup_cache section
- IMP: default ``usenet_retention`` set to **3500** days.
- IMP: default ``enforce_permissions`` set to **False**
- IMP: default metatagging option ``cmtag_start_year_as_volume`` set to **True**