### PR TITLE
post process for manually grabbed one-off storyarc issues

### DIFF
--- a/data/interfaces/default/storyarc.html
+++ b/data/interfaces/default/storyarc.html
@@ -83,6 +83,9 @@
                                               <option value=${x} ${outputselect}>${x}</option>
                                          %endfor
                                         </select><label> watchlisted issues to <span id="arcopts"></span> Directory</label>
+                           <div>
+                               <input type="checkbox" style="vertical-align: middle; margin: 3px; margin-top: -1px;" name="oneoff2arcdir" id="oneoff2arcdir" value="1" ${checked(mylar.CONFIG.ONEOFF2ARCDIR)} /><label>Process one-off issues</label>
+                           </div>
                              <div id="arc_fileops_options">
                                  <input type="checkbox" style="vertical-align: middle; margin: 3px; margin-top: -1px;" name="arc_fileops_softlink_relative" id="arc_fileops_softlink_relative" value="1" ${checked(mylar.CONFIG.ARC_FILEOPS_SOFTLINK_RELATIVE)} /><label>Create relative softlink <span style="font-size:10px;color:#999;">(default: absolute)</span></label>
                                  </div>

--- a/data/interfaces/default/storyarc_detail.html
+++ b/data/interfaces/default/storyarc_detail.html
@@ -77,6 +77,9 @@
                                    carcdir = 'GrabBag'
                          %>
                          <input type="checkbox" style="vertical-align: middle; margin: 3px; margin-top: -1px;" name="copy2arcdir" id="copy2arcdir" value="1" ${checked(mylar.CONFIG.COPY2ARCDIR)} disabled /><label>Copy watchlisted issues to ${carcdir} Directory</label>
+                         <div>
+                             <input type="checkbox" style="vertical-align: middle; margin: 3px; margin-top: -1px;" name="oneoff2arcdir" id="oneoff2arcdir" value="1" ${checked(mylar.CONFIG.ONEOFF2ARCDIR)} disabled /><label>Process one-off issues</label>
+                         </div>
 
                        <input type="hidden" name="StoryArcID" value="${storyarcid}">
                        <input type="hidden" name="StoryArcName" value="${storyarcname| u}">

--- a/data/interfaces/default/storyarc_detail.poster.html
+++ b/data/interfaces/default/storyarc_detail.poster.html
@@ -86,6 +86,9 @@
                      </div>
                      <div class="row checkbox left clearfix">
                          <input type="checkbox" style="vertical-align: middle; margin: 3px; margin-top: -1px;" name="copy2arcdir" id="copy2arcdir" value="1" ${checked(mylar.CONFIG.COPY2ARCDIR)} disabled/><label>Copy watchlisted issues to ${carcdir} Directory</label>
+                         <div>
+                             <input type="checkbox" style="vertical-align: middle; margin: 3px; margin-top: -1px;" name="oneoff2arcdir" id="oneoff2arcdir" value="1" ${checked(mylar.CONFIG.ONEOFF2ARCDIR)} disabled/><label>Process one-off issues</label>
+                         </div>
                      </div>
                        <input type="hidden" name="StoryArcID" value="${storyarcid}">
                        <input type="hidden" name="StoryArcName" value="${storyarcname| u}">

--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -1807,7 +1807,7 @@ class PostProcessor(object):
                         ofilename = orig_filename = ml['ComicLocation']
                         logger.info('[STORY-ARC POST-PROCESSING] Enabled for %s' % ml['StoryArc'])
 
-                        if all([mylar.CONFIG.STORYARCDIR is True, mylar.CONFIG.COPY2ARCDIR is True]):
+                        if all([mylar.CONFIG.STORYARCDIR is True, mylar.CONFIG.ONEOFF2ARCDIR is True]):
                             grdst = helpers.arcformat(ml['StoryArc'], helpers.spantheyears(ml['StoryArcID']), ml['Publisher'])
                             logger.info('grdst: %s' % grdst)
 
@@ -1946,7 +1946,7 @@ class PostProcessor(object):
                         logger.fdebug('writing: %s -- %s' % (newVal, ctrlVal))
                         myDB.upsert("storyarcs", newVal, ctrlVal)
                         updater.foundsearch(ComicID=ml['ComicID'], mode='story_arc', IssueID=ml['IssueID'], IssueArcID=ml['IssueArcID'], down='PP', module=module)
-                        if all([mylar.CONFIG.STORYARCDIR is True, mylar.CONFIG.COPY2ARCDIR is True]):
+                        if all([mylar.CONFIG.STORYARCDIR is True, mylar.CONFIG.ONEOFF2ARCDIR is True]):
                             logger.fdebug('%s [%s] Post-Processing completed for: %s' % (module, ml['StoryArc'], grab_dst))
                         else:
                             logger.fdebug('%s [%s] Post-Processing completed for: %s' % (module, ml['StoryArc'], ml['ComicLocation']))

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -327,6 +327,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'STORYARCDIR': (bool, 'StoryArc', False),
     'STORYARC_LOCATION': (str, 'StoryArc', None),
     'COPY2ARCDIR': (bool, 'StoryArc', False),
+    'ONEOFF2ARCDIR': (bool, 'StoryArc', False),
     'ARC_FOLDERFORMAT': (str, 'StoryArc', '$arc ($spanyears)'),
     'ARC_FILEOPS': (str, 'StoryArc', 'copy'),
     'ARC_FILEOPS_SOFTLINK_RELATIVE': (bool, 'StoryArc', False),

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -2837,7 +2837,7 @@ def arcformat(arc, spanyears, publisher):
             dstloc = os.path.join(mylar.CONFIG.DESTINATION_DIR, 'StoryArcs', arcpath)
         else:
             dstloc = os.path.join(mylar.CONFIG.STORYARC_LOCATION, arcpath)
-    elif mylar.CONFIG.COPY2ARCDIR is True:
+    elif any([mylar.CONFIG.COPY2ARCDIR is True, mylar.CONFIG.ONEOFF2ARCDIR is True]):
         logger.warn('Story arc directory is not configured. Defaulting to grabbag directory: ' + mylar.CONFIG.GRABBAG_DIR)
         dstloc = os.path.join(mylar.CONFIG.GRABBAG_DIR, arcpath)
     else:

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -7027,7 +7027,7 @@ class WebInterface(object):
 
     readlistOptions.exposed = True
 
-    def arcOptions(self, StoryArcID=None, StoryArcName=None, read2filename=0, storyarcdir=0, arc_folderformat=None, copy2arcdir=0, arc_fileops='copy', arc_fileops_softlink_relative=0):
+    def arcOptions(self, StoryArcID=None, StoryArcName=None, read2filename=0, storyarcdir=0, arc_folderformat=None, copy2arcdir=0, oneoff2arcdir=0, arc_fileops='copy', arc_fileops_softlink_relative=0):
         mylar.CONFIG.READ2FILENAME = bool(int(read2filename))
         mylar.CONFIG.STORYARCDIR = bool(int(storyarcdir))
         if arc_folderformat is None:
@@ -7035,12 +7035,14 @@ class WebInterface(object):
         else:
             mylar.CONFIG.ARC_FOLDERFORMAT = arc_folderformat
         mylar.CONFIG.COPY2ARCDIR = bool(int(copy2arcdir))
+        mylar.CONFIG.ONEOFF2ARCDIR = bool(int(oneoff2arcdir))
         mylar.CONFIG.ARC_FILEOPS = arc_fileops
         mylar.CONFIG.ARC_FILEOPS_SOFTLINK_RELATIVE = bool(int(arc_fileops_softlink_relative))
         options = {'read2filename':                 mylar.CONFIG.READ2FILENAME,
                    'storyarcdir':                   mylar.CONFIG.STORYARCDIR,
                    'arc_folderformat':              mylar.CONFIG.ARC_FOLDERFORMAT,
                    'copy2arcdir':                   mylar.CONFIG.COPY2ARCDIR,
+                   'oneoff2arcdir':                 mylar.CONFIG.ONEOFF2ARCDIR,
                    'arc_fileops':                   mylar.CONFIG.ARC_FILEOPS,
                    'arc_fileops_softlink_relative': mylar.CONFIG.ARC_FILEOPS_SOFTLINK_RELATIVE}
         mylar.CONFIG.writeconfig(values=options)


### PR DESCRIPTION

Adds new option (oneoff2arcdir) to allow manually grabbed one-off storyarc issues to be copied to the configured storyarc directory without copying watchlisted issues. Uses existing code to do the copying/moving/linking, only changes the option used to trigger the file action.

Option added to storyarc pages. Not really sure about the wording. Thought about:

[x] [copy] one-off issues to StoryArc directory
 -- [x] include watchedlisted issues

I didn't want to change the meaning of the existing copy2arcdir option.
