### PR TITLE
FIX: booktype will default to Print instead of None, FIX: error when searching for items being returned no issue numbers

### DIFF
--- a/mylar/cv.py
+++ b/mylar/cv.py
@@ -1276,7 +1276,7 @@ def get_imprint_volume_and_booktype(series, comicyear, publisher, firstissueid, 
     comic['ComicVersion'] = 'None' #noversion'
 
     #figure out if it's a print / digital edition.
-    comic['Type'] = 'None'
+    comic['Type'] = 'Print'
     if comic_deck != 'None':
         if any(['print' in comic_deck.lower(), 'digital' in comic_deck.lower(), 'paperback' in comic_deck.lower(), 'one shot' in re.sub('-', '', comic_deck.lower()).strip(), 'hardcover' in comic_deck.lower()]):
             if all(['print' in comic_deck.lower(), 'reprint' not in comic_deck.lower()]):

--- a/mylar/search_filer.py
+++ b/mylar/search_filer.py
@@ -728,7 +728,12 @@ class search_check(object):
 
             # here's the catch, sometimes annuals get posted as the Pub Year
             # instead of the Series they belong to (V2012 vs V2013)
-            if annualize is True and any(
+            if all(
+                    [
+                        annualize is True,
+                        parsed_comic['issue_number'] is not None,
+                    ]
+            ) and any(
                     [
                         int(ComicYear) == int(F_ComicVersion),
                         int(ComicYear) == int(parsed_comic['issue_number']),
@@ -933,13 +938,13 @@ class search_check(object):
                         intIss = 1000
                     else:
                         if annualize is True:
-                            if len(re.sub('[^0-9]', '', parsed_comic['issue_number']).strip()) == 4:
+                            if parsed_comic['issue_number'] is None:
+                                # if issue_number is None, assume it's #1 of the annual
+                                intIss = 1000
+                            elif len(re.sub('[^0-9]', '', parsed_comic['issue_number']).strip()) == 4:
                                 intIss = 1000
                             elif parsed_comic['issue_number'] is not None:
                                 intIss = helpers.issuedigits(parsed_comic['issue_number'])
-                            else:
-                                # if issue_number is None, assume it's #1 of the annual
-                                intIss = 1000
                         else:
                             intIss = 9999999999
                 if filecomic['justthedigits'] is not None:

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -1129,7 +1129,7 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
     if rescan['Status'] == 'Paused':
         pause_status = True
 
-    if (all([rescan['Type'] != 'Print', rescan['Type'] != 'Digital', rescan['Type'] != 'None', rescan['Type'] is not None]) and rescan['Corrected_Type'] != 'Print') or any([rescan['Corrected_Type'] == 'TPB', rescan['Corrected_Type'] == 'HC', rescan['Corrected_Type'] == 'GN']):
+    if (all([rescan['Type'] != 'Print', rescan['Type'] != 'Digital', rescan['Type'] != 'None', rescan['Type'] is not None]) and rescan['Corrected_Type'] != 'Print') or any([rescan['Corrected_Type'] == 'TPB', rescan['Corrected_Type'] == 'HC', rescan['Corrected_Type'] == 'GN', rescan['Corrected_Type'] == 'One-Shot']):
         if rescan['Type'] == 'One-Shot' and rescan['Corrected_Type'] is None:
             booktype = 'One-Shot'
         else:
@@ -1140,7 +1140,7 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
             else:
                 booktype = 'TPB'
     else:
-        booktype = None
+        booktype = 'Print'
 
     annscan = myDB.select('SELECT * FROM annuals WHERE ComicID=? AND NOT Deleted', [ComicID])
     if annscan is None:


### PR DESCRIPTION
- FIX: Booktype will default to Print instead of None when adding a series
- FIX: Error when searching for items being returned with no issue numbers and doing comparison checks
- FIX: One-Shots booktype not able to scan in issues with no issue number (independent annuals)