### PR TITLE
IMP: Detect and handle CV reusing existing ComicIDs

### DIFF
--- a/data/interfaces/carbon/css/style.css
+++ b/data/interfaces/carbon/css/style.css
@@ -1376,7 +1376,6 @@ div#artistheader h2 a {
   vertical-align: middle;
 }
 #series_table {
-  background-color: #FFF;
   padding: 20px;
   width: 960px !important;
 }
@@ -1430,19 +1429,16 @@ div#artistheader h2 a {
   text-align: center;
   vertical-align: middle;
   font-size: 12px;
-  background-color: #353a41;
 }
 #series_table td#name {
   min-width: 290px;
   text-align: center;
   vertical-align: middle;
-  background-color: #353a41;
 }
 #series_table td#year {
   max-width: 25px;
   text-align: center;
   vertical-align: middle;
-  background-color: #353a41;
 }
 #series_table td#havepercent,
 #series_table td#totalcount {
@@ -1461,31 +1457,26 @@ div#artistheader h2 a {
   max-width: 35px;
   text-align: center;
   vertical-align: middle;
-  background-color: #353a41;
 }
 #series_table td#issue {
   max-width: 30px;
   text-align: center;
   vertical-align: middle;
-  background-color: #353a41;
 }
 #series_table td#status {
   max-width: 50px;
   text-align: center;
   vertical-align: middle;
-  background-color: #353a41;
 }
 #series_table td#published {
   max-width: 55px;
   text-align: center;
   vertical-align: middle;
-  background-color: #353a41;
 }
 #series_table td#have {
   max-width: 80px;
   text-align: center;
   vertical-align: middle;
-  background-color: #353a41;
 }
 #manageheader {
   margin-top: 45px;
@@ -2600,4 +2591,12 @@ img.mylarload.lastbad {
 }
 .py_vers {
   color: #EE3232;
+}
+.cv_row {
+  display: flex;
+  text-align: center;
+}
+.cv_column {
+  flex: 50%;
+  text-align: center;
 }

--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -6,6 +6,9 @@
 %>
 
 <%def name="headerIncludes()">
+        <div id="cv_removed_dialog" title="ComicVine ComicID change detected" style="display:none">
+            <span id="crd"></span>
+        </div>
 	<div id="subhead_container">
 		<div id="subhead_menu">
                         <a id="menu_link_refresh" title="retrieve any new information for the series" onclick="refresh_series(${comic['ComicID']})" href="#">Refresh Comic</a>
@@ -51,6 +54,7 @@
 </%def>
 <%def name="body()">
         <input type="hidden" id="page_name" value="series_detail" />
+        <input type="hidden" id="cv_removed" value="${comic['cv_removed']}" />
 	<div id="paddingheader">
 		<h1>
                    </br>
@@ -1397,8 +1401,41 @@
             }
             reload_tables();
         }
+        function fix_cv_removed(option, delete_cv_dir) {
+            var comicid = retrieve_comicid();
+            if (option == 'delete_cv_removed'){
+                opts = 'delete';
+            } else {
+                opts = 'keep';
+            }
+            $.when($.ajax({
+                 type: "GET",
+                 url: "fix_cv_removed",
+                 data: { comicid: comicid, opts: opts, delete_dir: delete_cv_dir },
+                 success: function(response) {
+                    obj = JSON.parse(response);
+                 },
+                 error: function(data)
+                     {
+                       alert('ERROR'+data.responseText);
+                     },
+            })).done(function(data) {
+                 if (opts == 'delete'){
+                     document.location.href="/";
+                 } else {
+                     $("#cv_removed_dialog").dialog('close');
+                     reload_tables();
+                 }
+                 $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>"+obj['message']+"</div>");
+                 if (obj['status'] == 'success'){
+                     $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                 } else {
+                     $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                 }
+            });
+        }
 
-       function count_checks(tabletype){
+        function count_checks(tabletype){
             if (tabletype == 'issues'){
                 var checks = document.getElementsByName("issueid[]");
                 cc = document.getElementById("markissue");
@@ -1532,6 +1569,20 @@
         }
 
         function initThisPage(){
+                if (document.getElementById("cv_removed").value === '1'){
+                   $("#crd").append('<center>ComicVine has decided to remove this volume and has replaced it with an entirely different volume. You have 2 options:</center></br> \
+                                     <p style="display: block;"><div class="cv_row"><div class="cv_column">Remove this volume from your watchlist</br> (all issues/annuals)</br> \
+                                     </br><input id="delete_cv_removed" type="button" value="DELETE" onclick="fix_cv_removed(this.id, delete_cv_dir.value);" /> \
+                                     </br></br><input type="checkbox" style="vertical-align: middle; margin: 3px; margin-top: -1px;" name="delete_cv_dir" id="delete_cv_dir" value="1" /> \
+                                     <label>Remove directory when deleting Series?</label></div> \
+                                     <div class="cv_column">Retain existing information but no new</br> information will be available (ie. Paused)</br> \
+                                     </br><input id="keep_cv_removed" type="button" value="KEEP" onclick="fix_cv_removed(this.id, delete_cv_dir.value);" /> \
+                                     </p></div></div>');
+                   $("#cv_removed_dialog").dialog({
+                      modal: true,
+                      width: "50%",
+                   });
+                }
                 $( "#tabs" ).tabs({
                     cache: false,
                 });

--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -1337,7 +1337,6 @@ div#artistheader h2 a {
   vertical-align: middle;
 }
 #series_table {
-  background-color: #FFF;
   padding: 20px;
   width: 960px !important;
 }
@@ -2480,4 +2479,12 @@ img.mylarload.lastbad {
 }
 .py_vers {
   color: #EE3232;
+}
+.cv_row {
+  display: flex;
+  text-align: center;
+}
+.cv_column {
+  flex: 50%;
+  text-align: center;
 }

--- a/data/interfaces/default/index-alphaindex.html
+++ b/data/interfaces/default/index-alphaindex.html
@@ -47,14 +47,16 @@
 
                                 comic_percent = comic['percent']
 
-				if comic['Status'] == 'Paused':
+                                if comic['cv_removed'] == 1:
+                                        grade = 'U'
+				elif comic['Status'] == 'Paused':
 					grade = 'T'
 				elif comic['Status'] == 'Loading':
 			        	grade = 'L'
                                 elif comic['Status'] == 'Error':
                                         grade = 'X'
                                 else:
-                                        grade = 'A'
+                                        grade = 'Z'
 
                                 comicpub = comic['ComicPublisher']
                                 try:
@@ -64,12 +66,14 @@
                                     pass
 
                                 comicname = comic['ComicSortName']
-                                try:
-                                    if len(comic['ComicSortName']) > 55:
-                                        comicname = comic['ComicSortName'][:55] + '...'
-                                except:
-                                    pass
-
+                                if comicname is not None:
+                                    try:
+                                        if len(comic['ComicSortName']) > 55:
+                                            comicname = comic['ComicSortName'][:55] + '...'
+                                    except:
+                                        pass
+                                else:
+                                    comicname = comic['ComicName']
                                 comicline = comicname
 
                                 comictype = comic['Type']
@@ -116,6 +120,17 @@
 		</tbody>
 	</table>
       </div>
+      <div>
+            <table style="float: right; border-spacing:3px;border-collapse:separate;">
+              <tr>
+                <td id="legend_removed" style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:${legend_colors['removed']};" title="Series has been removed from CV"></span> CV removed</td>
+                <td id="legend_paused" style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:${legend_colors['paused']};" title="Series is Paused"></span> Paused series</td>
+                <td id="legend_failed" style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:${legend_colors['failed']};" title="Series was unable to complete adding/refreshing"></span> Failed/Error</td>
+                <td id="legend_loading" style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:${legend_colors['loading']};" title="Loading information state"></span> Loading</td>
+              </tr>
+            </table>
+     </div>
+
 </%def>
 
 <%def name="headIncludes()">

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -7,7 +7,7 @@
 
 <%def name="body()">
         <input type="hidden" id="page_name" value="index" />
-        <div class="table_wrapper">
+        <div class="table_wrapper" id="series_table_wrapper">
 	<table class="display" id="series_table">
 	    <thead>
 	        <tr>
@@ -25,6 +25,16 @@
             </tbody>
 	</table>
       </div>
+      <div>
+            <table style="float: right; border-spacing:3px;border-collapse:separate;">
+              <tr>
+                <td id="legend_removed" style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:${legend_colors['removed']};" title="Series has been removed from CV"></span> CV removed</td>
+                <td id="legend_paused" style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:${legend_colors['paused']};" title="Series is Paused"></span> Paused series</td>
+                <td id="legend_failed" style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:${legend_colors['failed']};" title="Series was unable to complete adding/refreshing"></span> Failed/Error</td>
+                <td id="legend_loading" style="float:left;margin-left:2px;vertical-align:middle;"><span style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;background:${legend_colors['loading']};" title="Loading information state"></span> Loading</td>
+              </tr>
+            </table>
+     </div>
 </%def>
 
 <%def name="headIncludes()">
@@ -37,7 +47,6 @@
 	<script>
         $.fn.DataTable.ext.pager.numbers_length = 3;
         function initThisPage() {
-            initActions();
             $('#series_table').dataTable( {
                 "preDrawCallback": function (settings){
                     pageScrollPos = $('#series_table div.datatables_scrollBody').scrollTop();
@@ -182,14 +191,18 @@
                      "infoFiltered":"(filtered from _MAX_ total items)"
                 },
                 "rowCallback": function (nRow, aData, iDisplayIndex, iDisplayIndexFull) {
-                     if (aData[6] === "Paused") {
-                        $('td', nRow).closest('tr').addClass("gradeT");
-                     } else if (aData[6] === "Loading") {
-                        $('td', nRow).closest('tr').addClass("gradeL");
-                     } else if (aData[6] === "Error" || aData[6] == "Failed") {
-                        $('td', nRow).closest('tr').addClass("gradeX");
+                     if (aData[13] === 1){
+                        $('td', nRow).closest('tr').addClass("gradeU");
                      } else {
-                        $('td', nRow).closest('tr').addClass("gradeA");
+                        if (aData[6] === "Paused") {
+                           $('td', nRow).closest('tr').addClass("gradeT");
+                        } else if (aData[6] === "Loading") {
+                           $('td', nRow).closest('tr').addClass("gradeL");
+                        } else if (aData[6] === "Error" || aData[6] == "Failed") {
+                           $('td', nRow).closest('tr').addClass("gradeX");
+                       } else {
+                           $('td', nRow).closest('tr').addClass("gradeZ");
+                        }
                      }
                      nRow.children[0].id = 'publisher';
                      nRow.children[1].id = 'name';
@@ -201,7 +214,7 @@
                      nRow.children[7].id = 'active';
                      return nRow;
                  },
-                 "drawCallback": function (o) {
+                 "drawCallback": function (settings) {
                      // Jump to top of page
                      $('#series_table div.dataTables_scrollBody').scrollTop(pageScrollPos);
                  },
@@ -215,9 +228,11 @@
                  {
                  },
             });
+
         };
         $(document).ready(function(){
             initThisPage();
+            initActions();
         });
 	</script>
 	

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -795,7 +795,7 @@ def dbcheck():
         except sqlite3.OperationalError:
             logger.warn('Unable to update readinglist table to new storyarc table format.')
 
-    c.execute('CREATE TABLE IF NOT EXISTS comics (ComicID TEXT UNIQUE, ComicName TEXT, ComicSortName TEXT, ComicYear TEXT, DateAdded TEXT, Status TEXT, IncludeExtras INTEGER, Have INTEGER, Total INTEGER, ComicImage TEXT, FirstImageSize INTEGER, ComicPublisher TEXT, PublisherImprint TEXT, ComicLocation TEXT, ComicPublished TEXT, NewPublish TEXT, LatestIssue TEXT, intLatestIssue INT, LatestDate TEXT, Description TEXT, DescriptionEdit TEXT, QUALalt_vers TEXT, QUALtype TEXT, QUALscanner TEXT, QUALquality TEXT, LastUpdated TEXT, AlternateSearch TEXT, UseFuzzy TEXT, ComicVersion TEXT, SortOrder INTEGER, DetailURL TEXT, ForceContinuing INTEGER, ComicName_Filesafe TEXT, AlternateFileName TEXT, ComicImageURL TEXT, ComicImageALTURL TEXT, DynamicComicName TEXT, AllowPacks TEXT, Type TEXT, Corrected_SeriesYear TEXT, Corrected_Type TEXT, TorrentID_32P TEXT, LatestIssueID TEXT, Collects CLOB, IgnoreType INTEGER, AgeRating TEXT, FilesUpdated TEXT, seriesjsonPresent INT, dirlocked INTEGER)')
+    c.execute('CREATE TABLE IF NOT EXISTS comics (ComicID TEXT UNIQUE, ComicName TEXT, ComicSortName TEXT, ComicYear TEXT, DateAdded TEXT, Status TEXT, IncludeExtras INTEGER, Have INTEGER, Total INTEGER, ComicImage TEXT, FirstImageSize INTEGER, ComicPublisher TEXT, PublisherImprint TEXT, ComicLocation TEXT, ComicPublished TEXT, NewPublish TEXT, LatestIssue TEXT, intLatestIssue INT, LatestDate TEXT, Description TEXT, DescriptionEdit TEXT, QUALalt_vers TEXT, QUALtype TEXT, QUALscanner TEXT, QUALquality TEXT, LastUpdated TEXT, AlternateSearch TEXT, UseFuzzy TEXT, ComicVersion TEXT, SortOrder INTEGER, DetailURL TEXT, ForceContinuing INTEGER, ComicName_Filesafe TEXT, AlternateFileName TEXT, ComicImageURL TEXT, ComicImageALTURL TEXT, DynamicComicName TEXT, AllowPacks TEXT, Type TEXT, Corrected_SeriesYear TEXT, Corrected_Type TEXT, TorrentID_32P TEXT, LatestIssueID TEXT, Collects CLOB, IgnoreType INTEGER, AgeRating TEXT, FilesUpdated TEXT, seriesjsonPresent INT, dirlocked INTEGER, cv_removed INTEGER)')
     c.execute('CREATE TABLE IF NOT EXISTS issues (IssueID TEXT, ComicName TEXT, IssueName TEXT, Issue_Number TEXT, DateAdded TEXT, Status TEXT, Type TEXT, ComicID TEXT, ArtworkURL Text, ReleaseDate TEXT, Location TEXT, IssueDate TEXT, DigitalDate TEXT, Int_IssueNumber INT, ComicSize TEXT, AltIssueNumber TEXT, IssueDate_Edit TEXT, ImageURL TEXT, ImageURL_ALT TEXT, forced_file INT)')
     c.execute('CREATE TABLE IF NOT EXISTS snatched (IssueID TEXT, ComicName TEXT, Issue_Number TEXT, Size INTEGER, DateAdded TEXT, Status TEXT, FolderName TEXT, ComicID TEXT, Provider TEXT, Hash TEXT, crc TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS upcoming (ComicName TEXT, IssueNumber TEXT, ComicID TEXT, IssueID TEXT, IssueDate TEXT, Status TEXT, DisplayComicName TEXT)')
@@ -1005,6 +1005,11 @@ def dbcheck():
         c.execute('SELECT seriesjsonPresent from comics')
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE comics ADD COLUMN seriesjsonPresent INT')
+
+    try:
+        c.execute('SELECT cv_removed from comics')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE comics ADD COLUMN cv_removed INT')
 
     try:
         c.execute('SELECT DynamicComicName from comics')

--- a/mylar/cv.py
+++ b/mylar/cv.py
@@ -15,7 +15,7 @@
 import re
 import time
 import pytz
-from mylar import logger, helpers
+from mylar import db, logger, helpers
 import mylar
 from bs4 import BeautifulSoup as Soup
 from xml.parsers.expat import ExpatError
@@ -1479,3 +1479,28 @@ def basenum_mapping(ordinal=False):
                     'xi': '9'}
 
     return basenums
+
+def check_that_biatch(comicid, oldinfo, newinfo):
+    failures = 0
+    if newinfo['ComicName'] is not None:
+        if newinfo['ComicName'].lower() != oldinfo['comicname'].lower():
+            failures +=1
+    if newinfo['ComicYear'] is not None:
+        if newinfo['ComicYear'] != oldinfo['comicyear']:
+            failures +=1
+    if newinfo['ComicPublisher'] is not None:
+        if newinfo['ComicPublisher'] != oldinfo['publisher']:
+            failures +=1
+    if newinfo['ComicURL'] is not None:
+        if newinfo['ComicURL'] != oldinfo['detailurl']:
+            failures +=1
+
+    if failures > 2:
+        # if > 50% failure (> 2/4 mismatches) assume removed...
+        logger.warn('[%s] Detected CV removing existing data for series [%s (%s)] and replacing it with [%s (%s)].'
+                    'This is a failure for this series and will be paused until fixed manually' %
+                    (failures, oldinfo['comicname'], oldinfo['comicyear'], newinfo['ComicName'], newinfo['ComicYear'])
+        )
+        return True
+
+    return False

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -1528,7 +1528,8 @@ def havetotals(refreshit=None):
                 try:
                     cpub = re.sub('(N)', '', comic['ComicPublished']).strip()
                 except Exception as e:
-                    logger.warn('[Error: %s] No Publisher found for %s - you probably want to Refresh the series when you get a chance.' % (e, comic['ComicName']))
+                    if comic['cv_removed'] == 0:
+                        logger.warn('[Error: %s] No Publisher found for %s - you probably want to Refresh the series when you get a chance.' % (e, comic['ComicName']))
                     cpub = None
 
             comictype = comic['Type']
@@ -1553,6 +1554,9 @@ def havetotals(refreshit=None):
             else:
                 comicImage = comic['ComicImage']
 
+            #cv_removed: 0 = series is present on CV
+            #            1 = series has been removed from CV
+            #            2 = series has been removed from CV but retaining what mylar has in it's db
 
             comics.append({"ComicID":         comic['ComicID'],
                            "ComicName":       comic['ComicName'],
@@ -1574,7 +1578,8 @@ def havetotals(refreshit=None):
                            "DateAdded":       comic['LastUpdated'],
                            "Type":            comic['Type'],
                            "Corrected_Type":  comic['Corrected_Type'],
-                           "displaytype":     comictype})
+                           "displaytype":     comictype,
+                           "cv_removed":      comic['cv_removed']})
         return comics
 
 def filesafe(comic):


### PR DESCRIPTION
Will check existing information in db with what CV is telling it is supposed to be. It will now do 4 comparison checks - if > 50% of the checks fail, it will assume it's been changed and indicate as such. It will then:
- automatically pause the series
- flag it as ``cv_removed`` color coded on the main watchlist page
- when loading the series detail page for the given series, it will prompt with an explanation and 2 choices:
   - delete: delete the series from the watchlist (also an option to delete the series from the disk)
   - keep: will retain the series as is with no further information being retrieved from CV

*Note: this also adds a color-coded legend to the bottom of the main watchlist/index page, along with color-coded rows now for  status of : ``cv_removed``, ``loading``, ``paused``, and ``failed/error``.