### PR TITLE
fix casing when invoking updater.dbUpdate

### DIFF
--- a/mylar/series_metadata.py
+++ b/mylar/series_metadata.py
@@ -40,7 +40,7 @@ class metadata_Series(object):
         for cid in self.comiclist:
 
             if self.refreshSeries is True:
-                updater.dbupdate(cid, calledfrom='json_api')
+                updater.dbUpdate(cid, calledfrom='json_api')
 
             myDB = db.DBConnection()
             comic = myDB.selectone('SELECT * FROM comics WHERE ComicID=?', [cid]).fetchone()


### PR DESCRIPTION
Simple fix here, have tested it locally fixes this error message:

```29-Feb-2024 14:51:09 - ERROR   :: mylar.excepthook.315 : mass-refresh : Uncaught exception: Traceback (most recent call last):
  File "/app/mylar/mylar/logger.py", line 337, in new_run
    old_run(*args, **kwargs)
  File "/usr/local/lib/python3.9/threading.py", line 917, in run
    self._target(*self._args, **self._kwargs)
  File "/app/mylar/mylar/updater.py", line 53, in addvialist
    dbUpdate([item['comicid']], calledfrom='refresh')
  File "/app/mylar/mylar/updater.py", line 233, in dbUpdate
    chkstatus = mylar.importer.addComictoDB(ComicID, mismatch, calledfrom='dbupdate', annload=annload, csyear=csyear, fixed_type=fixed_type)
  File "/app/mylar/mylar/importer.py", line 469, in addComictoDB
    updateddata = updateissuedata(comicid, comic['ComicName'], issued, comicIssues, calledfrom, SeriesYear=SeriesYear, latestissueinfo=latestissueinfo, serieslast_updated=serieslast_updated, series_status=series_status)
  File "/app/mylar/mylar/importer.py", line 1677, in updateissuedata
    sm.update_metadata()
  File "/app/mylar/mylar/series_metadata.py", line 43, in update_metadata
    updater.dbupdate(cid, calledfrom='json_api')
AttributeError: module 'mylar.updater' has no attribute 'dbupdate'```