### PR TITLE
FIXES...FIXES...FIXES..(and a few improvements)

### DIFF
--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -123,23 +123,31 @@
                                 <br>
 				<%
                                     mylar.PROVIDER_STATUS = {}
-                                    for ko, vo in sorted(mylar.CONFIG.PROVIDER_ORDER.items()):
-                                        mylar.PROVIDER_STATUS.update({vo : 'success'})
-                                        for kb in mylar.PROVIDER_BLOCKLIST:
-                                            if vo == kb['site']:
-                                                mylar.PROVIDER_STATUS.update({vo : 'fail'})
-                                                break
+                                    prov_fail = False
+                                    try:
+                                        for ko, vo in sorted(mylar.CONFIG.PROVIDER_ORDER.items()):
+                                            mylar.PROVIDER_STATUS.update({vo : 'success'})
+                                            for kb in mylar.PROVIDER_BLOCKLIST:
+                                                if vo == kb['site']:
+                                                    mylar.PROVIDER_STATUS.update({vo : 'fail'})
+                                                    break
+                                    except Exception:
+                                        prov_fail = True
                                 %>
                                 Providers:
-                                %for prov, stats in sorted(mylar.PROVIDER_STATUS.items()):
-                                    <%
-                                        if stats == 'success':
-                                            st_image = '<img src="images/success.png" height="8" width="8">'
-                                        else:
-                                            st_image = '<img src="images/x_red.png" height="8" width="8">'
-                                    %>
-                                    ${prov}:${st_image} &nbsp
-                                %endfor
+                                %if prov_fail:
+                                    <span title="This should correct itself eventually"><img src="images/x_red.png" height="8" width="8" />Unable to determine Provider Status' at this time...</span>
+                                %else:
+                                    %for prov, stats in sorted(mylar.PROVIDER_STATUS.items()):
+                                        <%
+                                            if stats == 'success':
+                                                st_image = '<img src="images/success.png" height="8" width="8">'
+                                            else:
+                                                st_image = '<img src="images/x_red.png" height="8" width="8">'
+                                        %>
+                                        ${prov}:${st_image} &nbsp
+                                    %endfor
+                                %endif
                         </div>
                         <div id="config_messages_dialog" title="configuration checks / warnings" style="display:none">
                            <span id="mbody"></span>

--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -2061,7 +2061,8 @@
             // Handle click on "Select all" control
             $('#issues-select-all').on('click', function(){
                 // Get all rows with search applied
-                var rows = tables.rows({ 'search': 'applied' }).nodes();
+                var rows = $('#issue_table').DataTable().rows({ 'search': 'applied' }).nodes();
+                //var rows = tables.rows({ 'search': 'applied' }).nodes();
                // Check/uncheck checkboxes for all rows in the table
                $('input[type="checkbox"]', rows).prop('checked', this.checked);
                count_checks('issues');
@@ -2087,7 +2088,8 @@
             // Handle click on "Select all" control
             $('#annuals-select-all').on('click', function(){
                 // Get all rows with search applied
-                var rows = tables.rows({ 'search': 'applied' }).nodes();
+                var rows = $('#annual_table').DataTable().rows({ 'search': 'applied' }).nodes();
+                //var rows = tables.rows({ 'search': 'applied' }).nodes();
                // Check/uncheck checkboxes for all rows in the table
                $('input[type="checkbox"]', rows).prop('checked', this.checked);
                count_checks('annuals');

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -279,7 +279,7 @@
                                 <legend>API</legend>
                                 <div class="row">
                                    <label>ComicVine API Key</label>
-                                   <input type="text" name="comicvine_api" id="comicvine_api" value="${config['comicvine_api']}" title="get one for free @ http://api.comicvine.com" size="40">
+                                   <input type="text" placeholder="None" onfocus="if(this.value==this.defaultValue) this.value='$config["comicvine_api"]}';" name="comicvine_api" id="comicvine_api" value="${config['comicvine_api']}" title="get one for free @ https://comicvine.gamespot.com/api" size="40">
                                    <small>specify your own CV API key here </small>
                                 </div>
 
@@ -817,49 +817,6 @@
                             </br><small>last run: ${config['rss_last']}</small>
                           </div>
                         </fieldset>
-                	<fieldset>
-                		<div class="row checkbox left clearfix">
-                                    <input id="usenzbsu" type="checkbox" onclick="initConfigCheckbox($(this));" name="nzbsu" value="1" ${config['nzbsu']} /><legend>NZB.SU</legend>
-                		</div>
-                		<div class="config">
-                                        <div class="row checkbox">
-                                            <input type="checkbox" name="nzbsu_verify" id="nzbsu_verify" value="1" ${config['nzbsu_verify']} /><label>Verify SSL</label>
-                                        </div>
-                                        <div class="row">
-                                            <label>NZB.SU UID</label>
-                                            <input type="text" name="nzbsu_uid" value="${config['nzbsu_uid']}" size="15" >
-                                            <small>( only needed for RSS feed )</small>
-                                        </div>
-	                		<div class="row">
-	                		 	<label>NZB.SU API</label>
-                                                <input type="text" name="nzbsu_apikey" id="nzbsu_apikey" value="${config['nzbsu_api']}" size="36">
-                  		        </div>
-                                        <div>
-                                                <img name="nzbsu_statusicon" id="nzbsu_statusicon" src="images/success.png" style="float:right;visibility:hidden;" height="20" width="20" />
-                                                <input type="button" class="newznabtest" value="Test Connection" id="test_nzbsu" name="test_nzbsu" style="float:right;margin-right:10px;" />
-                                        </div>
-                		</div>
-                	</fieldset>
-
-                        <fieldset>
-                                <div class="row checkbox left clearfix">
-                                     <input id="usedognzb" type="checkbox" onclick="initConfigCheckbox($(this));" name="dognzb" value="1" ${config['dognzb']} /><legend>DOGNZB</legend>
-                                </div>
-                                <div class="config">
-                                        <div class="row checkbox">
-                                             <input id="dognzb_verify" type="checkbox" name="dognzb_verify" id="dognzb_verify" value="1" ${config['dognzb_verify']} /><label>Verify SSL</label>
-                                        </div>
-                                        <div class="row">
-                                                <label>DOGNZB API</label>
-                                                <input type="text" name="dognzb_apikey" id="dognzb_apikey" value="${config['dognzb_api']}" size="36">
-                                        </div>
-                                        <div>
-                                                 <img name="dognzb_statusicon" id="dognzb_statusicon" src="images/success.png" style="float:right;visibility:hidden;" height="20" width="20" />
-                                                 <input type="button" class="newznabtest" value="Test Connection" id="test_dognzb" name="test_dognzb" style="float:right;margin-right:10px;" />
-                                        </div>
-                                </div>
-                        </fieldset>
-
                         <fieldset>
                                 <div class="row checkbox left clearfix">
                                    <input id="useexperimental" type="checkbox" onclick="initConfigCheckbox($(this));" name="experimental" value="1" ${config['experimental']} /><legend>Use Experimental Search</legend>
@@ -3380,8 +3337,8 @@
                 initConfigCheckbox("#sab_to_mylar");
                 initConfigCheckbox("#usenewznab");
                 initConfigCheckbox("#enable_torznab");
-		initConfigCheckbox("#usenzbsu");
-                initConfigCheckbox("#usedognzb");
+		//initConfigCheckbox("#usenzbsu");
+                //initConfigCheckbox("#usedognzb");
                 initConfigCheckbox("#enable_torrents");
                 initConfigCheckbox("#enable_torrent_search");
                 initConfigCheckbox("#enable_32p");

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -126,10 +126,14 @@
                        "targets": [ 4 ],
                        "visible": true,
                        "render":function (data,type,full) {
-                           if (full[4].includes('Unknown')){
-                               return 'N/A';
+                           if (full[4]){
+                               if (full[4].includes('Unknown')){
+                                   return 'N/A';
+                               } else {
+                                   return full[4];
+                               }
                            } else {
-                               return full[4];
+                               return 'N/A';
                            }
                        }
                     },

--- a/data/interfaces/default/searchresults.html
+++ b/data/interfaces/default/searchresults.html
@@ -42,9 +42,21 @@
                 <tr>
                 <td style="float:left;margin-right:10px;"><span class="gradeZ" style="border:1px solid#ccc;float:left;width:30px;height:12px;margin:4px;"></span> Digital/TPB/GN/HC</td></tr>
             </table>
+
+<!--
+                   </br>
+                   <div class="row">
+                       <div class="row checkbox left clearfix">
+                           <input type="checkbox" name="markupcoming" id="markupcoming" style="vertical-align: middle; margin: 3px; margin-top: -1px;" value=1 ${checked(mylar.CONFIG.AUTOWANT_UPCOMING)} /><label>Mark Upcoming issues as Wanted</label></br>
+                       </div>
+                       <div class="row checkbox left clearfix">
+                           <input type="checkbox" name="markall" id="markall" style="vertical-align: middle; margin: 3px; margin-top: -1px;" value=1 ${checked(mylar.CONFIG.AUTOWANT_ALL)} /><label>Mark All issues as Wanted</label>
+                       </div>
+                   </div>
+-->
         </div>
 
-        </br>
+        </br></br>
 
         <div class="table_wrapper" id="search_wrapper">
 
@@ -143,6 +155,9 @@
         }
 
         function addseries(comicid, query_id, com_location, booktype){
+            //var markupcoming = document.getElementById("markupcoming").checked;
+            //var markall = document.getElementById("markall").checked;
+
             if(typeof(com_location) === "undefined" || com_location === null){
                 com_location = null;
             }
@@ -153,7 +168,7 @@
             $.when($.ajax({
                  type: "GET",
                  url: "addbyid",
-                 data: { comicid: comicid, query_id: query_id, com_location: com_location, booktype: booktype},
+                 data: { comicid: comicid, query_id: query_id, com_location: com_location, booktype: booktype}, //, markupcoming: markupcoming, markall: markall},
                  success: function(response) {
                     //obj = JSON.parse(response);
                  },

--- a/lib/comictaggerlib/comicvinetalker.py
+++ b/lib/comictaggerlib/comicvinetalker.py
@@ -21,7 +21,6 @@ import re
 import time
 import datetime
 import sys
-from user_agent2 import generate_user_agent
 
 from bs4 import BeautifulSoup
 
@@ -102,8 +101,7 @@ class ComicVineTalker(QObject):
 
         self.log_func = None
 
-        #self.cv_headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246'}
-        self.cv_headers = {'User-Agent': generate_user_agent(os='win', device_type='desktop')}
+        self.cv_headers = {'User-Agent': ComicVineTalker.cv_user_agent}
 
     def setLogFunc(self, log_func):
         self.log_func = log_func

--- a/lib/comictaggerlib/main.py
+++ b/lib/comictaggerlib/main.py
@@ -54,6 +54,7 @@ def ctmain():
             SETTINGS.save()
 
     ComicVineTalker.api_key = SETTINGS.cv_api_key
+    ComicVineTalker.cv_user_agent = SETTINGS.cv_user_agent
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 

--- a/lib/comictaggerlib/settings.py
+++ b/lib/comictaggerlib/settings.py
@@ -98,6 +98,7 @@ class ComicTaggerSettings:
         self.remove_html_tables = False
         self.cv_api_key = ""
         self.notes_format = 'Issue ID'
+        self.cv_user_agent = None
 
         # CBL Tranform settings
 
@@ -270,6 +271,8 @@ class ComicTaggerSettings:
             self.cv_api_key = self.config.get('comicvine', 'cv_api_key')
         if self.config.has_option('comicvine', 'notes_format'):
             self.notes_format = self.config.get('comicvine', 'notes_format')
+        if self.config.has_option('comicvine', 'cv_user_agent'):
+            self.cv_user_agent = self.config.get('comicvine', 'cv_user_agent')
 
         if self.config.has_option(
                 'cbl_transform', 'assume_lone_credit_is_primary'):
@@ -424,6 +427,7 @@ class ComicTaggerSettings:
             'comicvine', 'remove_html_tables', self.remove_html_tables)
         self.config.set('comicvine', 'cv_api_key', self.cv_api_key)
         self.config.set('comicvine', 'notes_format', self.notes_format)
+        self.config.set('comicvine', 'cv_user_agent', self.cv_user_agent)
 
         if not self.config.has_section('cbl_transform'):
             self.config.add_section('cbl_transform')

--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -767,7 +767,18 @@ class PostProcessor(object):
                         if wv['ComicPublished'] is None:
                             logger.fdebug('Publication Run cannot be generated - probably due to an incomplete Refresh. Manually refresh the following series and try again: %s (%s)' % (wv['ComicName'], wv['ComicYear']))
                             continue
-                        if any([wv['Status'] == 'Paused', bool(wv['ForceContinuing']) is True]) or (wv['Have'] == wv['Total'] and not any(['Present' in wv['ComicPublished'], helpers.now()[:4] in wv['ComicPublished']])):
+                        if (wv['Status'] == 'Paused' and any(
+                                [
+                                  wv['cv_removed'] == 2,
+                                  bool(wv['ForceContinuing']) is True
+                                ]
+                            )) or (wv['Have'] == wv['Total'] and not any(
+                                [
+                                  'Present' in wv['ComicPublished'],
+                                  helpers.now()[:4] in wv['ComicPublished']
+                                ]
+                            )
+                        ):
                             dbcheck = myDB.selectone('SELECT Status FROM issues WHERE ComicID=? and Int_IssueNumber=?', [wv['ComicID'], tmp_iss]).fetchone()
                             if not dbcheck and mylar.CONFIG.ANNUALS_ON:
                                 dbcheck = myDB.selectone('SELECT Status FROM annuals WHERE ComicID=? and Int_IssueNumber=?', [wv['ComicID'], tmp_iss]).fetchone()

--- a/mylar/downloaders/mediafire.py
+++ b/mylar/downloaders/mediafire.py
@@ -127,7 +127,12 @@ class MediaFire(object):
                 logger.fdebug('[MediaFire] Content has been removed - we should move on to the next one at this point.')
             return {"success": False, "filename": None, "path": None, "link_type_failure": 'GC-Media'}
 
-        logger.fdebug('[MediaFire] download completed - donwloaded %s / %s' % (os.stat(filepath).st_size, fileinfo['filesize']))
+        try:
+            filesize = os.stat(filepath).st_size
+        except FileNotFoundError:
+            return {"success": false, "filenme": None, "path": None}
+        else:
+            logger.fdebug('[MediaFire] download completed - downloaded %s / %s' % (filesize, fileinfo['filesize']))
 
         logger.fdebug('[MediaFire] ddl_linked - filename: %s' % fileinfo['filename'])
 

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -544,9 +544,15 @@ class GC(object):
         logger.info('[DDL-GATHERER-OF-LINKAGE] Now compiling release information & available links...')
         while True:
             #logger.fdebug('count_bees: %s' % count_bees)
-            f = beeswax[count_bees]
-            option_find = beeswax[count_bees]
-            linkage = f.find("div", {"class": "aio-pulse"})
+            try:
+                f = beeswax[count_bees]
+                option_find = beeswax[count_bees]
+                linkage = f.find("div", {"class": "aio-pulse"})
+            except Exception as e:
+                if looped_thru_once is False:
+                    valid_links[multiple_links].update({'links': gather_links})
+                break
+
             #logger.fdebug('linkage: %s' % linkage)
             if not linkage:
                 linkage_test = f.text.strip()
@@ -649,7 +655,7 @@ class GC(object):
                                  "issues": None,
                                  "size": size,
                                  "links": lk['href'],
-                                 "pack": comicinfo[0]['pack']
+                                 "pack": pack
                             })
                             #logger.fdebug('gather_links so far: %s' % gather_links)
             count_bees +=1
@@ -784,23 +790,38 @@ class GC(object):
                     if not link_matched and site_lp == 'mega':
                         sub_site_chk = [y for y in tmp_sites if 'mega' in y]
                         if sub_site_chk:
-                            kk = tmp_links[site_position['SD-Digital:mega']]
-                            logger.info('[MEGA] SD-Digital preference detected...attempting %s' % kk['series'])
-                            link_matched = True
+                            try:
+                               kk = tmp_links[site_position['SD-Digital:mega']]
+                               logger.info('[MEGA] SD-Digital preference detected...attempting %s' % kk['series'])
+                               link_matched = True
+                            except KeyError:
+                                kk = tmp_links[site_position['normal:mega']]
+                                logger.info('[MEGA] mega preference detected...attempting %s' % kk['series'])
+                                link_matched = True
 
                     elif not link_matched and site_lp == 'pixeldrain':
                         sub_site_chk = [y for y in tmp_sites if 'pixel' in y]
                         if sub_site_chk:
-                            kk = tmp_links[site_position['SD-Digital:pixeldrain']]
-                            logger.info('[PixelDrain] SD-Digital preference detected...attempting %s' % kk['series'])
-                            link_matched = True
+                            try:
+                                kk = tmp_links[site_position['SD-Digital:pixeldrain']]
+                                logger.info('[PixelDrain] SD-Digital preference detected...attempting %s' % kk['series'])
+                                link_matched = True
+                            except KeyError:
+                                kk = tmp_links[site_position['normal:pixeldrain']]
+                                logger.info('[PixelDrain] PixelDrain preference detected...attempting %s' % kk['series'])
+                                link_matched = True
 
                     elif not link_matched and site_lp == 'mediafire':
                         sub_site_chk = [y for y in tmp_sites if 'mediafire' in y]
                         if sub_site_chk:
-                            kk = tmp_links[site_position['SD-Digital:mediafire']]
-                            logger.info('[mediafire] SD-Digital preference detected...attempting %s' % kk['series'])
-                            link_matched = True
+                            try:
+                                kk = tmp_links[site_position['SD-Digital:mediafire']]
+                                logger.info('[mediafire] SD-Digital preference detected...attempting %s' % kk['series'])
+                                link_matched = True
+                            except KeyError:
+                                kk = tmp_links[site_position['normal:mediafire']]
+                                logger.info('[mediafire] mediafire preference detected...attempting %s' % kk['series'])
+                                link_matched = True
 
                     elif not link_matched and site_lp == 'main':
                         try:
@@ -808,9 +829,19 @@ class GC(object):
                             logger.info('[MAIN-SERVER] SD-Digital preference detected...attempting %s' % kk['series'])
                             link_matched = True
                         except Exception as e:
-                            kk = tmp_links[site_position['SD-Digital:mirror download']]
-                            logger.info('[MIRROR-SERVER] SD-Digital preference detected...attempting %s' % kk['series'])
-                            link_matched = True
+                            try:
+                                kk = tmp_links[site_position['SD-Digital:mirror download']]
+                                logger.info('[MIRROR-SERVER] SD-Digital preference detected...attempting %s' % kk['series'])
+                                link_matched = True
+                            except KeyError:
+                                try:
+                                    kk = tmp_links[site_position['normal:download now']]
+                                    logger.info('[MAIN-SERVER] main preference detected...attempting %s' % kk['series'])
+                                    link_matched = True
+                                except KeyError:
+                                    kk = tmp_links[site_position['normal:mirror download']]
+                                    logger.info('[MIRROR-SERVER] main-mirror preference detected...attempting %s' % kk['series'])
+                                    link_matched = True
 
                     if link_matched:
                         link = kk
@@ -938,7 +969,7 @@ class GC(object):
                                         "issues": issues,
                                         "size": size,
                                         "links": linked,
-                                        "pack": comicinfo[0]['pack']
+                                        "pack": pack
                                     }
                                 )
         else:
@@ -980,7 +1011,7 @@ class GC(object):
                                         "issues": issues,
                                         "size": size,
                                         "links": linked,
-                                        "pack": comicinfo[0]['pack']
+                                        "pack": pack
                                     }
                                 )
 

--- a/mylar/notifiers.py
+++ b/mylar/notifiers.py
@@ -475,7 +475,7 @@ class SLACK:
 
     def test_notify(self):
         return self.notify('Test Message', 'Release the Ninjas!')
-    
+
 class MATTERMOST:
     def __init__(self, test_webhook_url=None):
         self.webhook_url = mylar.CONFIG.MATTERMOST_WEBHOOK_URL if test_webhook_url is None else test_webhook_url
@@ -731,7 +731,7 @@ class DISCORD:
 
         # Error logging
         sent_successfuly = True
-        if not response.status_code == 204 or response.status_code == 200:
+        if not all([response.status_code == 204, response.status_code == 200]):
             logger.info(module + 'Could not send notification to Discord (webhook_url=%s). Response: [%s]' % (self.webhook_url, response.text))
             sent_successfuly = False
 
@@ -779,7 +779,7 @@ class GOTIFY:
                     }
                 }
             }
-        
+
         try:
             response = requests.post(self.webhook_url, json=payload, verify=True)
         except Exception as e:

--- a/mylar/search_filer.py
+++ b/mylar/search_filer.py
@@ -869,8 +869,6 @@ class search_check(object):
             if nowrite is False:
                 if any(
                     [
-                        nzbprov == 'dognzb',
-                        nzbprov == 'nzb.su',
                         nzbprov == 'experimental',
                         'newznab' in nzbprov,
                     ]
@@ -1072,8 +1070,6 @@ class search_check(object):
                     if nowrite is False:
                         if any(
                             [
-                                nzbprov == 'dognzb',
-                                nzbprov == 'nzb.su',
                                 nzbprov == 'experimental',
                                 'newznab' in nzbprov,
                                 provider_stat['type'] == 'newznab',

--- a/mylar/weeklypull.py
+++ b/mylar/weeklypull.py
@@ -1383,10 +1383,19 @@ def mass_publishers(publishers, weeknumber, year):
     if type(publishers) == list and len(publishers) == 0:
         publishers = None
 
-    if type(publishers) == str:
-        publishers = json.loads(publishers)
-        if len(publishers) == 0:
-            publishers = None
+    if type(publishers) != list:
+        try:
+            publishers = json.loads(publishers)
+        except Exception as e:
+            try:
+                tmp_publishers = json.dumps(publishers)
+                publishers = json.loads(tmp_publishers)
+            except Exception as e:
+                logger.warn('[MASS PUBLISHERS] Unable to convert mass publishers value in current state. Error: %s' % e)
+                publishers = None
+
+    if len(publishers) == 0:
+        publishers = None
 
     if publishers is None:
         watchlist = myDB.select('SELECT * FROM weekly WHERE weeknumber=? and year=?', [weeknumber, year])


### PR DESCRIPTION
Hate doing this much in one PR, but if it doesn't go like this, it'll end up sitting for god knows how long (or I'll forget entirely):

IMP: Update current default user_agent string to a more current string
IMP: CT will now use user_agent string defined by Mylar as opposed to a random generic one on each request (if not updated, will force-update it accordingly)
IMP: Removed individual provider entries for nzbsu and dognzb from GUI, now treated as newznabs. If enabled, will be converted to newznab entry provided doesn't already exist as a newznab.
IMP: If CV indicates series year does not exist (ie. 2099) instead of using 2099, will use year of first issue or if not invalid, current year 
IMP: When refreshing/adding a series that has a directory created with the incorrect year (2099), rename existing directory using correct year
IMP: Allow for future removal of outdated config.ini options with BAD_DEFINITIONS code
IMP: CV Api Key entry field on configuration page proper placeholder of `None` so will auto-remove value prior to typing in field
FIX: Ensure index page will load if provider_order is in error for some reason
FIX: Index page would display Unknown variations for published date when invalid instead of N/A
FIX: Ensure post-processing would be allowed for CV series that have been removed from CV but retained as is within Mylar
FIX: Mass publishers variable would sometimes be in an incorrect type (str) as opposed to type (list) which would cause the mass publishers job to not run
FIX: Selecting All checkbox on seriesdetail page will now select only relevant table (issues / annuals) as opposed to both
FIX: Discord notifications would always throw a could not send notification log message, but notif would be sent ok
FIX: When parsing results of DDL, if pack was detected and an invalid issue number was parsed, would traceback
FIX: DDL --> mediafire would try to get filesize of file that could possibly not exist due to failure resulting in traceback error
FIX: DDL --> traceback when count of links discovered would be more than indicated, not using any links discovered prior to the invalid count check
FIX: DDL --> traceback due to invalid variable reference (comicinfo[[0]['pack'])
FIX: DDL --> prefer upscaled option would incorrectly assume SD-Digital instead of just a normal/undefined labelling of said issue