### PR TITLE
Removal of () in folder structure, link to CV for items within collected editions

### DIFF
--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -181,7 +181,7 @@
                                                         if cid[re.sub('4050-', '', x['comicid']).strip()]['comicid']:
                                                             watch = "<a href='comicDetails?ComicID=%s' title='In Watchlist'>%s</a>" % (cid[re.sub('4050-', '', x['comicid']).strip()]['comicid'], x['series'])
                                                     except:
-                                                            watch = "%s" % (x['series'])
+                                                            watch = "<a href='https://comicvine.gamespot.com/volume/%s' title='link to CV' target='_blank'>%s</a>" % (x['comicid'],x['series'])
                                                 else:
                                                     watch = x['series']
                                                 if cnt == 0:

--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -160,7 +160,7 @@ class FileHandlers(object):
             chunk_f = re.compile(r'\s+')
             chunk_folder_format = chunk_f.sub(' ', chunk_f_f)
 
-        chunk_folder_format = re.sub("[()|[]]", '', chunk_folder_format).strip()
+        chunk_folder_format = re.sub(r'\(\)|\[\]', '', chunk_folder_format).strip()
         ccf = chunk_folder_format.find('/ ')
         if ccf != -1:
             chunk_folder_format = chunk_folder_format[:ccf+1] + chunk_folder_format[ccf+2:]


### PR DESCRIPTION
2 small patches:
- removal of ``()`` (empty paranthesis) leftover during folder creation when removing fields that do not exist
- collected editions will display what items they collect under Edition, if the items are not in the watchlist the link will redirect to the specific series on CV (as opposed to being in the watchlist, where it already will redirect to the watchlist item).