### PR TITLE
[FIX] fix error if comicinfo is None in DDL queue

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -440,11 +440,11 @@ class PostProcessor(object):
                         return self.queue.put(self.valreturn)
                     logger.info('I have located %s files that I should be able to post-process. Continuing...' % filelist['comiccount'])
                 else:
-                    if all([self.comicid is None, '_' not in self.issueid]):
+                    if all([self.comicid is None, self.issueid is not None and '_' not in self.issueid]):
                          cid = myDB.selectone('SELECT ComicID FROM issues where IssueID=?', [str(self.issueid)]).fetchone()
                          self.comicid = cid[0]
                     else:
-                         if '_' in self.issueid:
+                         if self.issueid is not None and '_' in self.issueid:
                              logger.fdebug('Story Arc post-processing request detected.')
                              self.issuearcid = self.issueid
                              self.issueid = None

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -1061,11 +1061,11 @@ class GC(object):
                 logger.warn('[GC-Site-Unknown] Unknown site detected...%s' % lt_site)
                 link_type = 'Unknown'
 
-            if self.issueid is None:
+            if self.issueid is None and comicinfo is not None:
                 self.issueid = comicinfo[0]['IssueID']
-            if self.comicid is None:
+            if self.comicid is None and comicinfo is not None:
                 self.comicid = comicinfo[0]['ComicID']
-            if self.oneoff is None:
+            if self.oneoff is None and comicinfo is not None:
                 self.oneoff = comicinfo[0]['oneoff']
 
             ctrlval = {'id': mod_id}


### PR DESCRIPTION
This MR solves this error:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\de_va\mylar3\mylar\logger.py", line 337, in new_run
    old_run(*args, **kwargs)
  File "C:\python310\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\de_va\mylar3\mylar\helpers.py", line 3428, in ddl_downloader
    ggc.parse_downloadresults(item['id'], item['mainlink'], item['comicinfo'], item['packinfo'], link_type_failure[item['id']])
  File "C:\Users\de_va\mylar3\mylar\getcomics.py", line 1065, in parse_downloadresults
    self.issueid = comicinfo[0]['IssueID']
TypeError: 'NoneType' object is not subscriptable
```