### PR TITLE
Use configured http_proxy/https_proxy with pixeldrain

### DIFF
--- a/mylar/downloaders/pixeldrain.py
+++ b/mylar/downloaders/pixeldrain.py
@@ -34,6 +34,12 @@ class PixelDrain(object):
         }
         self.session = requests.Session()
 
+        if mylar.CONFIG.ENABLE_PROXY:
+            self.session.proxies.update({
+                'http':  mylar.CONFIG.HTTP_PROXY,
+                'https': mylar.CONFIG.HTTPS_PROXY
+            })
+
     def ddl_download(self, link, id, issueid):
         self.id = id
         self.url = link


### PR DESCRIPTION
The http_proxy and https_proxy config options were only used in getcomics.py for direct GC downloads.  Now, the pixeldrain downloader supports downloading through those http proxies if configured.