### PR TITLE
De-emphasising CBL tagging

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -1267,7 +1267,7 @@
                                                     <input type="checkbox" name="ct_tag_cr" value="1" ${config['ct_tag_cr']} /><label>Write ComicRack (cr) tags (ComicInfo.xml)</label>
                                             </div>
                                             <div class="row checkbox left clearfix">
-                                                    <input type="checkbox" name="ct_tag_cbl" value="1" ${config['ct_tag_cbl']} /><label>Write ComicBookLover (Cbl) tags (zip comment)</label>
+                                                    <input id="ct_tag_cbl" type="checkbox" name="ct_tag_cbl" disabled value="1" ${config['ct_tag_cbl']} /><label>Write ComicBookLover (Cbl) tags (zip comment)</label>
                                             </div>
                                             <div class="row checkbox left clearfix">
                                                     <input type="checkbox" name="ct_cbz_overwrite" value="1" ${config['ct_cbz_overwrite']} /><label>Overwrite existing cbz tags (if they exist)</label>
@@ -1305,7 +1305,8 @@
                                             </div>
                                             <div>
                                                <p style="padding-top:10%;text-align:center;color:#999;display:block;font-size:11px;line-height:12px;">If ComicVine API Key specified, will use with ComicTagger</br>
-                                               Writing each type of metadata will increase API count respectively</p>
+                                               Writing each type of metadata will increase API count respectively</br>
+                                               Using ComicBookLover tags is discouraged</p>
                                             </div>
                                         </div>
                                 </div>
@@ -2163,6 +2164,22 @@
 
                         }
                 });
+                if ($("#ct_tag_cbl").is(":checked"))
+                        {
+                            document.getElementById("ct_tag_cbl").removeAttribute("disabled");
+                        }
+                else
+                        {
+                            document.getElementById("ct_tag_cbl").setAttribute("disabled", "disabled");
+                        }
+
+                $("#ct_tag_cbl").click(function(){
+                    if (!$("#ct_tag_cbl").checked)
+                    {
+                        document.getElementById("ct_tag_cbl").setAttribute("disabled", "disabled");
+                    }
+                });
+
                 if ($("#cmtag_volume").is(":checked"))
                         {
                                 $("#volumetag_options").slideDown();

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -337,7 +337,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'CMTAGGER_PATH': (str, 'Metatagging', None),
     'CBR2CBZ_ONLY': (bool, 'Metatagging', False),
     'CT_TAG_CR': (bool, 'Metatagging', True),
-    'CT_TAG_CBL': (bool, 'Metatagging', True),
+    'CT_TAG_CBL': (bool, 'Metatagging', False),
     'CT_CBZ_OVERWRITE': (bool, 'Metatagging', False),
     'UNRAR_CMD': (str, 'Metatagging', None),
     'CT_NOTES_FORMAT': (str, 'Metatagging', 'Issue ID'),


### PR DESCRIPTION
PR to address #1551.  

Removing the option entirely would leave the UI looking a bit odd with both an "Enable MetaTagging" checkbox, then a single checkbox for the remaining type (ComicRack).  I did consider removing the former, consolidating to a single toggle, and making tagging implicit on either CR or CBL tagging being set.  Unfortunately, this would cause problems for upgrades for anyone who doesn't currently have the ENABLE_META flag set, as the default value for the other two flags (CT_TAG_CR, CT_TAG_CBL) is True, so they would suddenly start tagging.  

In the end I settled on this simpler approach:
- Make the default value of CT_TAG_CBL False.  This should hopefully avoid new users enabling it just because it's there.
- Disable the ComicBookLover checkbox when it is unchecked.  Again, this will stop people enabling it explicitly without going into the config.ini to do it themselves, while also allowing that easy-exit using the UI to uncheck it for those with it currently active.
- Add a note to the footer of the MetaTagging section to discourage the use of ComicBookLover tagging.