### PR TITLE
Ascii fraction issue whole number fix

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -2782,11 +2782,20 @@ class PostProcessor(object):
                 issuenum = re.sub("[^0-9]", "", issuenum)
                 issue_except = '.HU'
             elif '\xbd' in issuenum:
-                issuenum = '0.5'
+                wholenum = issuenum.replace('\xbd', '')
+                if wholenum == '':
+                    wholenum = "0"
+                issuenum = f'{wholenum}.5'
             elif '\xbc' in issuenum:
-                issuenum = '0.25'
+                wholenum = issuenum.replace('\xbc', '')
+                if wholenum == '':
+                    wholenum = "0"
+                issuenum = f'{wholenum}.25'
             elif '\xbe' in issuenum:
-                issuenum = '0.75'
+                wholenum = issuenum.replace('\xbe', '')
+                if wholenum == '':
+                    wholenum = "0"
+                issuenum = f'{wholenum}.75'
             elif '\u221e' in issuenum:
                 #issnum = utf-8 will encode the infinity symbol without any help
                 issuenum = 'infinity'

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -410,12 +410,31 @@ def rename_param(comicid, comicname, issue, ofilename, comicyear=None, issueid=N
             unicodeissue = issuenum
 
             if type(issuenum) == str:
-               vals = {'\xbd':'.5','\xbc':'.25','\xbe':'.75','\u221e':'9999999999','\xe2':'9999999999'}
+               vals = {'\u221e':'9999999999','\xe2':'9999999999'}
             else:
-               vals = {'\xbd':'.5','\xbc':'.25','\xbe':'.75','\\u221e':'9999999999','\xe2':'9999999999'}
+               vals = {'\\u221e':'9999999999','\xe2':'9999999999'}
             x = [vals[key] for key in vals if key in issuenum]
             if x:
                 issuenum = x[0]
+                logger.fdebug('issue number formatted: %s' % issuenum)
+
+            if '\xbd' in issuenum:
+                wholenum = issuenum.replace('\xbd', '')
+                if wholenum == '':
+                    wholenum = "0"
+                issuenum = f'{wholenum}.5'
+                logger.fdebug('issue number formatted: %s' % issuenum)
+            elif '\xbc' in issuenum:
+                wholenum = issuenum.replace('\xbc', '')
+                if wholenum == '':
+                    wholenum = "0"
+                issuenum = f'{wholenum}.25'
+                logger.fdebug('issue number formatted: %s' % issuenum)
+            elif '\xbe' in issuenum:
+                wholenum = issuenum.replace('\xbe', '')
+                if wholenum == '':
+                    wholenum = "0"
+                issuenum = f'{wholenum}.75'
                 logger.fdebug('issue number formatted: %s' % issuenum)
 
             #comicid = issuenzb['ComicID']


### PR DESCRIPTION
Fix for https://github.com/mylar3/mylar3/issues/1581

Happy to go back to the drawing board on this one, or take a second pass as a future PR.  I've re-used the same approach to renaming for the 1/2, 1/4, 3/4 in the renaming helper as in the post processor, but left the slightly different approaches to infinity (and accented a?) alone for now.  Could probably do with a single source of truth for converting issue numbers to formatted strings, large padded decimals, etc. as a common helper function for all of these at some point.  Maybe worth doing after this alongside a look at any other open issues for weird corner case numbering.