### PR TITLE
Tagging Selected Issues

### DIFF
--- a/data/interfaces/default/comicdetails_update.html
+++ b/data/interfaces/default/comicdetails_update.html
@@ -34,7 +34,7 @@
                             <a id="menu_link_refresh" title="Rescan local files" onclick="force_rescan(${comic['ComicID']})">Recheck Files</a>
                         <a id="menu_link_searchmissing" title="Search for all Missing files" onclick="search4missing(${comic['ComicID']})" href="#">Search-4-Missing</a>
                         %if any([mylar.CONFIG.ENABLE_META, mylar.CONFIG.CBR2CBZ_ONLY]):
-                            <a id="menu_link_refresh" href="#" title="perform metatagging on each Downloaded issue" onclick="group_metatag(${comic['ComicID']})">Manual MetaTagging</a>
+                            <a id="menu_link_refresh" href="#" title="perform metatagging on each Downloaded issue (Be wary of CV API limits)" onclick="group_metatag(${comic['ComicID']})">Manual MetaTagging</a>
                         %endif
 
                         %if comic['Status'] == 'Paused':
@@ -488,7 +488,18 @@
                         %endif
                 </select>
                 <input type="hidden" value="Go">
+                %if any([mylar.CONFIG.ENABLE_META, mylar.CONFIG.CBR2CBZ_ONLY]):
+                    <div style="padding-left: 10px; float:right">
+                        <a id="metatag_issues" href="#" title="Perform metatagging on selected issues (Be wary of CV API limits)" onclick="metatag_the_issues(${comic['ComicID']}, 'issues')" 
+                            class="ui-button ui-widget ui-state-default ui-corner-all ui-button-text-icon-primary" role="button" aria-disabled="false" 
+                            style="background-image: -webkit-linear-gradient(#616161, #4e4e4e) !important;">
+                            <span class="ui-button-icon-primary ui-icon ui-icon-refresh"></span>
+                            <span class="ui-button-text" style="font-weight: normal;">MetaTag Issues</span>
+                        </a>
+                    </div>     
+                %endif          
         </div>
+        
 
           <table class="display select" id="issue_table">
                 <thead>
@@ -531,6 +542,16 @@
                 </select>
                 selected annuals
                 <input type="hidden" value="Go">
+                %if any([mylar.CONFIG.ENABLE_META, mylar.CONFIG.CBR2CBZ_ONLY]):
+                    <div style="padding-left: 10px; float:right">
+                        <a id="metatag_issues" href="#" title="Perform metatagging on selected issues (Be wary of CV API limits)" onclick="metatag_the_issues(${comic['ComicID']}, 'annuals')" 
+                            class="ui-button ui-widget ui-state-default ui-corner-all ui-button-text-icon-primary" role="button" aria-disabled="false" 
+                            style="background-image: -webkit-linear-gradient(#616161, #4e4e4e) !important;">
+                            <span class="ui-button-icon-primary ui-icon ui-icon-refresh"></span>
+                            <span class="ui-button-text" style="font-weight: normal;">MetaTag Issues</span>
+                        </a>
+                    </div>   
+                %endif
         </div>
             <table class="display select" id="annual_table">
                 <thead>
@@ -1094,6 +1115,41 @@
                   //reload_tabs();
                   //reload_tables();
               });
+        }
+
+        function metatag_the_issues(comicid, tabletype){
+            $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Now metatagging selected items...</div>");
+            $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+            if (tabletype == 'issues'){
+                var checks = document.getElementsByName("issueid[]");
+            } else {
+                var checks = document.getElementsByName("aissueid[]");
+            }
+
+            var checkboxesChecked = [];
+            for (var i=0; i<checks.length; i++) {
+                if (checks[i].checked) {
+                    // console.log(checks[i].value);
+                    checkboxesChecked.push(checks[i].value);
+                }
+            } 
+
+            $.when($.ajax({
+                type: "GET",
+                url: "bulk_metatag",
+                data: { ComicID: comicid, IssueIDs: checkboxesChecked },
+                traditional : true,
+                success: function(response) {
+                   obj = JSON.parse(response);
+                },
+                error: function(data)
+                    {
+                      alert('ERROR'+data.responseText);
+                    },
+             })).done(function(data) {
+                 //reload_tabs();
+                 //reload_tables();
+             });
         }
 
         function run_single_metatag(issueid, comicid, issuenumber){

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -345,6 +345,9 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'CMTAG_VOLUME': (bool, 'Metatagging', True),
     'CMTAG_START_YEAR_AS_VOLUME': (bool, 'Metatagging', True),
     'SETDEFAULTVOLUME': (bool, 'Metatagging', False),
+    'CV_BATCH_LIMIT_PROTECTION': (bool, 'Metatagging', True),
+    'CV_BATCH_LIMIT_THRESHOLD': (int, 'Metatagging', 200),
+
 
     'ENABLE_TORRENTS': (bool, 'Torrents', False),
     'ENABLE_TORRENT_SEARCH': (bool, 'Torrents', False),

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -8106,7 +8106,7 @@ class WebInterface(object):
         if mylar.CONFIG.ANNUALS_ON:
             groupinfo += myDB.select('SELECT IssueID, Location FROM annuals WHERE ComicID=? and and Location is not NULL', [ComicID])
 
-        if groupinfo is None:
+        if len(groupinfo) == 0:
             logger.warn('No issues physically exist within the series directory for me to (re)-tag.')
             return
 


### PR DESCRIPTION
Added a button to enable meta-tagging of a set of selected issues on a series page.

I've also added a new config variable to enable a check on trying to submit a single request for tagging for any number of issues over a threshold.  This is to try to defend against CV API limits a bit.  I've defaulted it to on, and a 200 limit.  This will prevent the new feature, and the series retag, from submitting a request for >200 tagging.  It will report an error on screen in this case.

It won't manage cumulative tracking if you do it in batches.  It also won't predict failure for the collected impact of multiple series being tagged at once from the Manage->Manage Comics tagging, but would stop any individual series within those selected which have >threshold downloaded issues as they go through the same route as the manual metatagging button.

I haven't exposed the setting in the UI as I don't think it's necessary to futz with much unless there are significant changes with CV, but happy to debate whether it should be enabled by default or not.

Feel free to squash the commits as well - I accidentally introduced a bug in the first one that I fixed in the third ...

Would close: https://github.com/mylar3/mylar3/issues/1525