### PR TITLE
Fix: Misc typos

### DIFF
--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -507,7 +507,7 @@ class FileChecker(object):
             if re.sub('g11', "\'", sf.lower()) == "director's":
                 try:
                     tmp_test = split_file.index(sf)+1
-                except Exeption as e:
+                except Exception as e:
                     logger.warn('failure to match to Director\'s Cut - ignoring as an issue match')
                 else:
                     try:

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -4097,7 +4097,7 @@ class WebInterface(object):
                     if os.path.exists(os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comicdir))):
                         secondary_folders = os.path.join(mylar.CONFIG.MULTIPLE_DEST_DIRS, os.path.basename(comicdir))
                     else:
-                        ff = mylar.filers.FileHandlers(ComicID=ComicID)
+                        ff = mylar.filers.FileHandlers(ComicID=cid)
                         secondary_folders = ff.secondary_folders(comicdir)
             except:
                 pass


### PR DESCRIPTION
Noticed in passing while doing other changes, isolating them to a standalone PR.  One typo in "Exception", one reference to a variable that isn't declared (and should be "cid" within the loop).