### PR TITLE
IMP: nzbget subpath option added to GUI, IMP: None option added to Usent radio selection

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -407,7 +407,7 @@
                 <td>
                        <fieldset>
                          <legend>Usenet</legend>
-                            <input type="radio" name="nzb_downloader" id="nzb_downloader_sabnzbd" value="0" ${config['nzb_downloader_sabnzbd']}> Sabnzbd&nbsp;&nbsp;<input type="radio" name="nzb_downloader" id="nzb_downloader_nzbget" value="1" ${config['nzb_downloader_nzbget']}> NZBget&nbsp;&nbsp;<input type="radio" name="nzb_downloader" id="nzb_downloader_blackhole" value="2" ${config['nzb_downloader_blackhole']}> Black Hole
+                            <input type="radio" name="nzb_downloader" id="nzb_downloader_sabnzbd" value="0" ${config['nzb_downloader_sabnzbd']}> Sabnzbd&nbsp;&nbsp;<input type="radio" name="nzb_downloader" id="nzb_downloader_nzbget" value="1" ${config['nzb_downloader_nzbget']}> NZBget&nbsp;&nbsp;<input type="radio" name="nzb_downloader" id="nzb_downloader_blackhole" value="2" ${config['nzb_downloader_blackhole']}> Black Hole&nbsp;&nbsp;<input type="radio" name="nzb_downloader" id="nzb_downloader_none" value="3" ${config['nzb_downloader_none']}> None
                        </fieldset>
                        <fieldset id="sabnzbd_options">
 	                	<div class="row">
@@ -500,6 +500,11 @@
                                     <small>usually http://localhost</small>
                                 </div>
                                 <div class="row">
+                                    <label>NZBGet Sub-Path:</label>
+                                    <input type="text" id="nzbget_sub" name="nzbget_sub" value="${config['nzbget_sub']}" size="30">
+                                    <small>the sub-path with no trailing slash (ie. /myname/nzbget)</small>
+                                </div>
+                                <div class="row">
                                     <label>NZBGet Port:</label>
                                     <input type="text" id="nzbget_port" name="nzbget_port" value="${config['nzbget_port']}" size="36">
                                 </div>
@@ -552,7 +557,9 @@
                                             <input type="text" name="blackhole_dir" value="${config['blackhole_dir']}" size="30">
                                         <small>Folder your Download program watches for NZBs</small>
                                     </div>
-                          </fieldset>
+                         </fieldset>
+                         <fieldset id="none_options">
+                         </fieldset>
                           <fieldset id="general_nzb_options">           
                             <div class="checkbox row">
                                 <label>Usenet Retention (in days)</label>
@@ -2509,20 +2516,24 @@
 
                 if ($("#nzb_downloader_sabnzbd").is(":checked"))
                         {
-                                $("#nzbget_options,#blackhole_options").hide();
-                                $("#sabnzbd_options").show();
+                                $("#nzbget_options,#blackhole_options,#none_options").hide();
+                                $("#sabnzbd_options,#general_nzb_options").show();
                         }
                 if ($("#nzb_downloader_nzbget").is(":checked"))
                         {
-                                $("#sabnzbd_options,#blackhole_options").hide();
-                                $("#nzbget_options").show();
+                                $("#sabnzbd_options,#blackhole_options,#none_options").hide();
+                                $("#nzbget_options,#general_nzb_options").show();
                         }
                 if ($("#nzb_downloader_blackhole").is(":checked"))
                         {
-                                $("#sabnzbd_options,#nzbget_options").hide();
-                                $("#blackhole_options").show();
+                                $("#sabnzbd_options,#nzbget_options,#none_options").hide();
+                                $("#blackhole_options,#general_nzb_options").show();
                         }
-
+                if ($("#nzb_downloader_none").is(":checked"))
+                        {
+                                $("#sabnzbd_options,#nzbget_options,#blackhole_options,#general_nzb_options").hide();
+                                $("#none_options").show();
+                        }
                 if ($("#torrent_downloader_watchlist").is(":checked"))
                         {
                                 $("#utorrent_options,#rtorrent_options,#transmission_options,#deluge_options,#qbittorrent_options").hide();
@@ -2555,42 +2566,49 @@
                         }
 
                 $('input[type=radio]').change(function(){
+
                         if ($("#nzb_downloader_sabnzbd").is(":checked"))
                         {
-                                $("#nzbget_options,#blackhole_options").fadeOut("fast", function() { $("#sabnzbd_options").fadeIn() });
+                                $("#nzbget_options,#blackhole_options,#none_options").fadeOut("fast", function() { $("#sabnzbd_options,#general_nzb_options").fadeIn() });
                         }
                         if ($("#nzb_downloader_nzbget").is(":checked"))
                         {
-                                $("#sabnzbd_options,#blackhole_options").fadeOut("fast", function() { $("#nzbget_options").fadeIn() });
+                                $("#sabnzbd_options,#blackhole_options,#none_options").fadeOut("fast", function() { $("#nzbget_options,#general_nzb_options").fadeIn() });
                         }
                         if ($("#nzb_downloader_blackhole").is(":checked"))
                         {
-                                $("#sabnzbd_options,#nzbget_options").fadeOut("fast", function() { $("#blackhole_options").fadeIn() });
+                                $("#sabnzbd_options,#nzbget_options,#none_options").fadeOut("fast", function() { $("#blackhole_options,#general_nzb_options").fadeIn() });
                         }
-		   if ($("#torrent_downloader_watchlist").is(":checked"))
-		   {
-			$("#utorrent_options,#rtorrent_options,#transmission_options,#deluge_options,#qbittorrent_options").fadeOut("fast", function() { $("#watchlist_options").fadeIn() });
-		   }
-		   if ($("#torrent_downloader_utorrent").is(":checked"))
-		   {
-			$("#watchlist_options,#rtorrent_options,#transmission_options,#deluge_options,#qbittorrent_options").fadeOut("fast", function() { $("#utorrent_options").fadeIn() });
-		   }
-		   if ($("#torrent_downloader_rtorrent").is(":checked"))
-		   {
-			$("#utorrent_options,#watchlist_options,#transmission_options,#deluge_options,#qbittorrent_options").fadeOut("fast", function() { $("#rtorrent_options").fadeIn() });
-		   }
-		   if ($("#torrent_downloader_transmission").is(":checked"))
-		   {
-			$("#utorrent_options,#rtorrent_options,#watchlist_options,#deluge_options,#qbittorrent_options").fadeOut("fast", function() { $("#transmission_options").fadeIn() });
-		   }
-		   if ($("#torrent_downloader_deluge").is(":checked"))
-		   {
-			$("#utorrent_options,#rtorrent_options,#watchlist_options,#transmission_options,#qbittorrent_options").fadeOut("fast", function() { $("#deluge_options").fadeIn() });
-		   }
-                   if ($("#torrent_downloader_qbittorrent").is(":checked"))
-                   {
-                        $("#utorrent_options,#rtorrent_options,#watchlist_options,#transmission_options,#deluge_options").fadeOut("fast", function() { $("#qbittorrent_options").fadeIn() });
-                   }
+                        if ($("#nzb_downloader_none").is(":checked"))
+                        {
+                                $("#sabnzbd_options,#nzbget_options,#blackhole_options,#general_nzb_options").fadeOut("fast", function() { $("#none_options").fadeIn() });
+                        }
+                });
+                $('input[type=radio]').change(function(){
+		       if ($("#torrent_downloader_watchlist").is(":checked"))
+		       {
+                                $("#utorrent_options,#rtorrent_options,#transmission_options,#deluge_options,#qbittorrent_options").fadeOut("fast", function() { $("#watchlist_options").fadeIn() });
+		       }
+		       if ($("#torrent_downloader_utorrent").is(":checked"))
+		       {
+                                $("#watchlist_options,#rtorrent_options,#transmission_options,#deluge_options,#qbittorrent_options").fadeOut("fast", function() { $("#utorrent_options").fadeIn() });
+                       }
+		       if ($("#torrent_downloader_rtorrent").is(":checked"))
+		       {
+                                $("#utorrent_options,#watchlist_options,#transmission_options,#deluge_options,#qbittorrent_options").fadeOut("fast", function() { $("#rtorrent_options").fadeIn() });
+                       }
+                       if ($("#torrent_downloader_transmission").is(":checked"))
+                       {
+                               $("#utorrent_options,#rtorrent_options,#watchlist_options,#deluge_options,#qbittorrent_options").fadeOut("fast", function() { $("#transmission_options").fadeIn() });
+                       }
+                       if ($("#torrent_downloader_deluge").is(":checked"))
+                       {
+	                       $("#utorrent_options,#rtorrent_options,#watchlist_options,#transmission_options,#qbittorrent_options").fadeOut("fast", function() { $("#deluge_options").fadeIn() });
+                       }
+                       if ($("#torrent_downloader_qbittorrent").is(":checked"))
+                       {
+                               $("#utorrent_options,#rtorrent_options,#watchlist_options,#transmission_options,#deluge_options").fadeOut("fast", function() { $("#qbittorrent_options").fadeIn() });
+                       }
                 });
 
                 var deletedNewznabs = 0;
@@ -2714,11 +2732,12 @@
                 $('#test_nzbget').click(function () {
                     var imagechk = document.getElementById("nzbget_statusicon");
                     var nzbhost = document.getElementById("nzbget_host").value;
+                    var nzbsub = document.getElementById("nzbget_sub").value;
                     var nzbport = document.getElementById("nzbget_port").value;
                     var nzbuser = document.getElementById("nzbget_username").value;
                     var nzbpass = document.getElementById("nzbget_password").value;
                     $.get("NZBGet_test",
-                        { nzbhost: nzbhost, nzbport: nzbport, nzbusername: nzbuser, nzbpassword: nzbpass },
+                        { nzbhost: nzbhost, nzbport: nzbport, nzbusername: nzbuser, nzbpassword: nzbpass, nzbsub:nzbsub },
                         function(data){
                             if (data.error != undefined) {
                                 alert(data.error);

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -271,7 +271,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'PROVIDER_ORDER': (str, 'Providers', None),
     'USENET_RETENTION': (int, 'Providers', 3500),
 
-    'NZB_DOWNLOADER': (int, 'Client', 0),  #0': sabnzbd, #1': nzbget, #2': blackhole
+    'NZB_DOWNLOADER': (int, 'Client', 3),  #0': sabnzbd, #1': nzbget, #2': blackhole, #3': none(default)
     'TORRENT_DOWNLOADER': (int, 'Client', 0),  #0': watchfolder, #1': uTorrent, #2': rTorrent, #3': transmission, #4': deluge, #5': qbittorrent
 
     'SAB_HOST': (str, 'SABnzbd', None),
@@ -290,6 +290,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
 
 
     'NZBGET_HOST': (str, 'NZBGet', None),
+    'NZBGET_SUB': (str, 'NZBGet', None),
     'NZBGET_PORT': (str, 'NZBGet', None),
     'NZBGET_USERNAME': (str, 'NZBGet', None),
     'NZBGET_PASSWORD': (str, 'NZBGet', None),
@@ -1524,7 +1525,7 @@ class Config(object):
         if startup is False:
             if self.POST_PROCESSING is True and ( all([self.NZB_DOWNLOADER == 0, self.SAB_CLIENT_POST_PROCESSING is True]) or all([self.NZB_DOWNLOADER == 1, self.NZBGET_CLIENT_POST_PROCESSING is True]) ):
                 mylar.queue_schedule('nzb_queue', 'start')
-            elif self.POST_PROCESSING is True and ( all([self.NZB_DOWNLOADER == 0, self.SAB_CLIENT_POST_PROCESSING is False]) or all([self.NZB_DOWNLOADER == 1, self.NZBGET_CLIENT_POST_PROCESSING is False]) ):
+            elif self.POST_PROCESSING is True and ( all([self.NZB_DOWNLOADER == 0, self.SAB_CLIENT_POST_PROCESSING is False]) or all([self.NZB_DOWNLOADER == 1, self.NZBGET_CLIENT_POST_PROCESSING is False]) or self.NZB_DOWNLOADER == 3):
                 mylar.queue_schedule('nzb_queue', 'stop')
 
             if self.ENABLE_DDL is True:
@@ -1587,16 +1588,16 @@ class Config(object):
         mylar.USE_NZBGET = False
         mylar.USE_BLACKHOLE = False
 
+        if all([self.NZB_DOWNLOADER ==0, self.SAB_HOST is None]) or all([self.NZB_DOWNLOADER ==1, self.NZBGET_HOST is None]) or all([self.NZB_DOWNLOADER==2, self.BLACKHOLE_DIR is None]):
+            logger.info('NZB Downloader detected as invalid entry - defaulting to None')
+            self.NZB_DOWNLOADER = 3
+
         if self.NZB_DOWNLOADER == 0:
             mylar.USE_SABNZBD = True
         elif self.NZB_DOWNLOADER == 1:
             mylar.USE_NZBGET = True
         elif self.NZB_DOWNLOADER == 2:
             mylar.USE_BLACKHOLE = True
-        else:
-            #default to SABnzbd
-            self.NZB_DOWNLOADER = 0
-            mylar.USE_SABNZBD = True
 
         if self.SAB_PRIORITY.isdigit():
             if self.SAB_PRIORITY == "0": self.SAB_PRIORITY = "Default"

--- a/mylar/nzbget.py
+++ b/mylar/nzbget.py
@@ -41,6 +41,10 @@ class NZBGet(object):
             return {'status': False}
         url = '%s://%s:%s'
         val = (protocol,nzbget_host,mylar.CONFIG.NZBGET_PORT)
+        if mylar.CONFIG.NZBGET_SUB:
+            url = '%s://%s:%s%s'
+            val+=(mylar.CONFIG.NZBGET_SUB,)
+
         logon_info = ''
         if mylar.CONFIG.NZBGET_USERNAME is not None:
             logon_info = '%s:'
@@ -54,9 +58,13 @@ class NZBGet(object):
         if logon_info != '':
             url = url + '/' + logon_info
         url = url + '/xmlrpc'
-        #val = val + (nzbget_host,mylar.CONFIG.NZBGET_PORT,)
-        self.display_url = '%s://%s:%s/xmlrpc' % (protocol, nzbget_host, mylar.CONFIG.NZBGET_PORT)
+
+        if mylar.CONFIG.NZBGET_SUB:
+            self.display_url = '%s://%s:%s%s/xmlrpc' % (protocol, nzbget_host, mylar.CONFIG.NZBGET_PORT, mylar.CONFIG.NZBGET_SUB)
+        else:
+            self.display_url = '%s://%s:%s/xmlrpc' % (protocol, nzbget_host, mylar.CONFIG.NZBGET_PORT)
         self.nzb_url = (url % val)
+
         self.server = xmlrpc.client.ServerProxy(self.nzb_url) #,allow_none=True)
 
     def sender(self, filename, test=False):

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6743,6 +6743,7 @@ class WebInterface(object):
                     "nzb_downloader_sabnzbd": helpers.radio(mylar.CONFIG.NZB_DOWNLOADER, 0),
                     "nzb_downloader_nzbget": helpers.radio(mylar.CONFIG.NZB_DOWNLOADER, 1),
                     "nzb_downloader_blackhole": helpers.radio(mylar.CONFIG.NZB_DOWNLOADER, 2),
+                    "nzb_downloader_none": helpers.radio(mylar.CONFIG.NZB_DOWNLOADER, 3),
                     "sab_host": mylar.CONFIG.SAB_HOST,
                     "sab_user": mylar.CONFIG.SAB_USERNAME,
                     "sab_api": mylar.CONFIG.SAB_APIKEY,
@@ -6756,6 +6757,7 @@ class WebInterface(object):
                     "sab_remove_completed": helpers.checked(mylar.CONFIG.SAB_REMOVE_COMPLETED),
                     "sab_remove_failed": helpers.checked(mylar.CONFIG.SAB_REMOVE_FAILED),
                     "nzbget_host": mylar.CONFIG.NZBGET_HOST,
+                    "nzbget_sub": mylar.CONFIG.NZBGET_SUB,
                     "nzbget_port": mylar.CONFIG.NZBGET_PORT,
                     "nzbget_user": mylar.CONFIG.NZBGET_USERNAME,
                     "nzbget_pass": mylar.CONFIG.NZBGET_PASSWORD,
@@ -7478,7 +7480,7 @@ class WebInterface(object):
 
     SABtest.exposed = True
 
-    def NZBGet_test(self, nzbhost=None, nzbport=None, nzbusername=None, nzbpassword=None):
+    def NZBGet_test(self, nzbhost=None, nzbport=None, nzbusername=None, nzbpassword=None, nzbsub=None):
         if nzbhost is None:
             nzbhost = mylar.CONFIG.NZBGET_HOST
         if nzbport is None:
@@ -7487,6 +7489,8 @@ class WebInterface(object):
             nzbusername = mylar.CONFIG.NZBGET_USERNAME
         if nzbpassword is None:
             nzbpassword = mylar.CONFIG.NZBGET_PASSWORD
+        if nzbsub is None:
+            nzbsub = mylar.CONFIG.NZBGET_SUB
 
         logger.fdebug('Now attempting to test NZBGet connection')
 
@@ -7499,7 +7503,11 @@ class WebInterface(object):
             nzbgethost = nzbhost[7:]
 
         url = '%s://%s:%s'
-        nzbparams = (protocol,nzbgethost,nzbport,)
+        nzbparams = (protocol,nzbgethost,nzbport)
+        if nzbsub:
+            url = '%s://%s:%s%s'
+            nzbparams += (nzbsub,)
+
         logon_info = ''
         if all([nzbusername is not None, nzbpassword is not None]):
             logon_info = '%s:%s'
@@ -7511,7 +7519,6 @@ class WebInterface(object):
             url = url + '/' + logon_info
         url = url + '/xmlrpc'
         nzb_url = (url % nzbparams)
-        logger.info('nzb_url: %s' % (nzb_url,))
 
         import xmlrpc.client, http.client, socket
         nzbserver = xmlrpc.client.ServerProxy(nzb_url)


### PR DESCRIPTION
- nzbget URL subpath option added to GUI
- None option added to Usenet radio selection - will default to None for new installations
- if sab/nzbget are enabled and their host values are empty (or blackhole is enabled and directory value is empty) will save it as if the None option was selected (on save only)