### PR TITLE
Fix: Negative numbered volume fixes

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -927,7 +927,7 @@ class PostProcessor(object):
                                     if watchmatch['series_volume'] is not None:
                                         just_the_digits = re.sub('[^0-9]', '', watchmatch['series_volume']).strip()
                                     else:
-                                        just_the_digits = re.sub('[^0-9.]', '', watchmatch['justthedigits']).strip()
+                                        just_the_digits = re.sub('[^0-9.-]', '', watchmatch['justthedigits']).strip()
                                 else:
                                     just_the_digits = watchmatch['justthedigits']
                             except Exception as e:

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -1333,8 +1333,8 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
     issname = []
     issdate = []
     issuedata = []
-    #let's start issue #'s at 0 -- thanks to DC for the new 52 reboot! :)
-    latestiss = "0"
+    # Start looking for the latest issue ID very low to accomodate series with only negative issues
+    latestiss = "-999999999"
     latestdate = "0000-00-00"
     latest_stdate = "0000-00-00"
     latestissueid = None


### PR DESCRIPTION
See issue https://github.com/mylar3/mylar3/issues/1623

- A general fix for correctly identifying the highest issue number when the issue numbers are not >= 0
- A specific fix for post processing on one-shot types to consider a possibility of a negatively issue numbered one-shot