### PR TITLE
Added the ability to force search a subset of issues in the wanted list

### DIFF
--- a/data/interfaces/default/upcoming.html
+++ b/data/interfaces/default/upcoming.html
@@ -6,7 +6,7 @@
 <%def name="headerIncludes()">
 	<div id="subhead_container">
 		<div id="subhead_menu">
-			<a href="#" id="menu_link_scan" onclick="doAjaxCall('forceSearch',$(this))" data-success="Checking for wanted issues successful" data-error="Error checking wanted issues">Force Check</a>
+			<a href="#" id="menu_link_scan" onclick="doAjaxCall('forceSearch',$(this))" data-success="Checking for wanted issues successful" data-error="Error checking wanted issues">Force Check All</a>
 		</div>
 	</div>
 </%def>
@@ -216,9 +216,37 @@
             });
         }
 
+        function search_the_issues() {
+            var checks = document.getElementsByName("issueid[]");
+            var checkboxesChecked = [];
+            for (var i=0; i<checks.length; i++) {
+                if (checks[i].checked) {
+                    // console.log(checks[i].value);
+                    checkboxesChecked.push(checks[i].value);
+                }
+            }
+
+            $.when($.ajax({
+                type: "GET",
+                url: "forceSearch",
+                data: { issueIds: checkboxesChecked },
+                traditional : true,
+                success: function(response) {
+                    obj = JSON.parse(response);
+                 },
+                 error: function(data)
+                     {
+                       alert('ERROR'+data.responseText);
+                     },
+            })).done(function(data) {
+                 reload_table();
+            });
+        }
+
        function count_checks(){
             var checks = document.getElementsByName("issueid[]");
             cc = document.getElementById("markissue");
+            fc = document.getElementById("menu_link_scan");
             var checkfound = false;
             for (var i=0; i<checks.length; i++) {
                 if (checks[i].checked) {
@@ -228,8 +256,12 @@
             }
             if (checkfound == true){
                 cc.style.display = "block";
+                fc.onclick = function(){ search_the_issues() };
+                fc.getElementsByClassName('ui-button-text')[0].innerText = "Force Check Selected";
             } else {
                 cc.style.display = "none";
+                fc.onclick = function(){ doAjaxCall('forceSearch',this) };
+                fc.getElementsByClassName('ui-button-text')[0].innerText = "Force Check All";
             }
         }
 

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -4500,11 +4500,28 @@ class WebInterface(object):
         raise cherrypy.HTTPRedirect("home")
     forceUpdate.exposed = True
 
-    def forceSearch(self):
+    def forceSearch(self, issueIds = None):
         #from mylar import search
         #threading.Thread(target=search.searchforissue).start()
         #raise cherrypy.HTTPRedirect("home")
-        self.schedulerForceCheck(jobid='search')
+        if issueIds is None:
+            self.schedulerForceCheck(jobid='search')
+        else:
+            myDB = db.DBConnection()
+
+            for issueId in issueIds:
+                issue_data = myDB.selectone("SELECT C.Type, C.ComicYear, I.ComicName, I.Issue_Number, I.ComicID, I.IssueID FROM comics as C INNER JOIN issues as I on C.ComicID = I.ComicID WHERE I.IssueID=?", [issueId]).fetchone()
+                passInfo = {'issueid': issueId,
+                            'comicname': issue_data['ComicName'],
+                            'seriesyear': issue_data['ComicYear'],
+                            'comicid': issue_data['ComicID'],
+                            'issuenumber': issue_data['Issue_Number'],
+                            'booktype': issue_data['Type'],
+                            'manual': True}
+                logger.fdebug(f"Adding issue {issue_data['ComicName']} #{issue_data['Issue_Number']} [{issueId}] to search queue")
+                s = mylar.SEARCH_QUEUE.put(passInfo)
+
+        return json.dumps({'status': 'success'})
     forceSearch.exposed = True
 
     def forceRescan(self, ComicID, bulk=False, action='recheck', api=False):


### PR DESCRIPTION
Sometimes I don't always want to trigger a force search of my entire watchlist, but a subset that may cross over multiple volumes.  I could drill into each volume individually and initiate the searches, but that's too many clicks for my lazy fingers.  Instead I have repurposed the Force Check button to change behaviour when you have selections on the Wanted page, so it will just throw those items onto the search queue.

Behaviour:
- With no items selected, button behaves as before but is renamed to "Force Check All"
- With items selected, button is renamed to "Force Check Selected" and will only add the selected items to the queue

Useful for:
- Times I have added a load of backfill volumes for something new I want to read, and I want to initiate search across them all without also wasting search time on the items at the top of the watchlist that I know are just waiting for the standard release cycle.
- Initiating a search for a subset of Tier 2 items if I think they may have come available somewhere.