### PR TITLE
Update config.py for better default search interval

### DIFF
--- a/mylar/config.py
+++ b/mylar/config.py
@@ -114,7 +114,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'SEARCH_TIER_CUTOFF': (int, 'General', 14), # days
 
     'RSS_CHECKINTERVAL': (int, 'Scheduler', 20),
-    'SEARCH_INTERVAL': (int, 'Scheduler', 360),
+    'SEARCH_INTERVAL': (int, 'Scheduler', 1440),
     'DOWNLOAD_SCAN_INTERVAL': (int, 'Scheduler', 5),
     'CHECK_GITHUB_INTERVAL' : (int, 'Scheduler', 360),
     'BLOCKLIST_TIMER': (int, 'Scheduler', 3600),


### PR DESCRIPTION
Changed the default search time from 360 minutes to 1440 minutes. 

I think this better aligns with how comics are being released these days and also feels like a better default option for new users who are adding a lot of issues to their watchlist. We have had a influx of people coming to support channels who are just starting out using mylar and adding 500+ issues off the bat. 