### PR TITLE
Fixing shortcomings of the mattermost notifications

### DIFF
--- a/mylar/notifiers.py
+++ b/mylar/notifiers.py
@@ -478,6 +478,8 @@ class SLACK:
 
 class MATTERMOST:
     def __init__(self, test_webhook_url=None):
+        self.test_hook = not (test_webhook_url == None)
+        logger.debug(self.test_hook)
         self.webhook_url = mylar.CONFIG.MATTERMOST_WEBHOOK_URL if test_webhook_url is None else test_webhook_url
 
     def notify(self, text, attachment_text, snatched_nzb=None, prov=None, sent_to=None, module=None, metadata=None, imageFile=None):
@@ -495,14 +497,8 @@ class MATTERMOST:
         else:
             pass
 
-        payload = {
-            "text": attachment_text,
-            "username": "Mylar",
-            "icon_url": "https://github.com/mylar3/mylar3/raw/master/data/images/mylarlogo.png",
-            "image_url": f"data:image/jpeg;base64,{imageFile}",
-            "footer": "Powered by [Mylar](https://github.com/mylar3/mylar3)",
-            "footer_icon": "https://github.com/mylar3/mylar3/raw/master/data/images/mylarlogo.png",
-            "attachments":[
+        if not self.test_hook:
+            attachments = [
                 {
                     "title":f"{metadata['series']} ({metadata['year']}) - Issue {metadata['issue']}",
                     "fields": [
@@ -520,17 +516,21 @@ class MATTERMOST:
                             "short": True,
                             "title": "Year",
                             "value": metadata['year']
-                        },
-                        {
-                            "short": False,
-                            "title": "Cover",
-                            "value": f"![Cover](data:image/jpeg;base64,{imageFile})"
                         }
                     ]
                 }
             ]
-        }
+        else:
+            attachments = []
 
+        payload = {
+            "text": attachment_text,
+            "username": "Mylar",
+            "icon_url": "https://github.com/mylar3/mylar3/raw/master/data/images/mylarlogo.png",
+            "footer": "Powered by [Mylar](https://github.com/mylar3/mylar3)",
+            "footer_icon": "https://github.com/mylar3/mylar3/raw/master/data/images/mylarlogo.png",
+            "attachments": attachments
+        }
         try:
             response = requests.post(self.webhook_url, json=payload, verify=True)
         except Exception as e:


### PR DESCRIPTION
When I first poked around to write this, the notifier did not account for two things:

- imageFile being None (which would cause the notifier to barf)
- the base64-encoded string hitting a server-side max_body_size, resulting in a 400 - Bad Request and a log entry of "Premature EoF" on the side of the Mattermost instance

I decided to remove the image from the payload for these two reasons.

Alos this fixes the Test function (which didn't barf, but plain refused to work).

Now with 100% more correct branch base... Keep forgetting branching off python3-dev