### PR TITLE
CRC checks on downloads and manual post-processing

### DIFF
--- a/mylar/PostProcessor.py
+++ b/mylar/PostProcessor.py
@@ -485,6 +485,24 @@ class PostProcessor(object):
                         if any(['coveronly' in cvchk, 'coversonly' in cvchk]):
                             logger.fdebug('Cover only detected. Ignoring result.')
                             continue
+
+                    if os.path.isfile(fl['comiclocation']):
+                        full_filename = fl['comiclocation']
+                    else:
+                        if fl['sub'] is not None:
+                            full_filename = os.path.join(fl['comiclocation'], fl['sub'], fl['comicfilename'])
+                        else:
+                            full_filename = os.path.join(fl['comiclocation'], fl['comicfilename'])
+
+                    # If after all that I still don't have a filename that is a file, something is probably confused.  Skip the integrity check.
+                    if os.path.isfile(full_filename):
+                        condition_check = helpers.check_file_condition(full_filename)
+                        if condition_check['status'] is False:
+                            logger.warn(f"CRC Check: File {full_filename} failed condition check ({condition_check['quality']}).  Ignoring file.")
+                            continue
+                    else:
+                        logger.warn(f"Could not find file {full_filename}.  Skipping condition check.")
+
                     self.matched = False
                     as_d = filechecker.FileChecker()
                     as_dinfo = as_d.dynamic_replace(fl['series_name']) #helpers.conversion(fl['series_name']))


### PR DESCRIPTION
Implemented file type checks and CRC checks for downloads from DDL, Usenet, Folder_Cache, and Manual Post-Processing.  Where possible the check is done straight after the download to enable "failed" marking, but for packs and manual that's not really possible so it happens in post processing.  That can cause a second pass of it, but it's harmless so wasn't worth branching for.

Currently, it will reject anything that isn't a PDF, zip, rar, or 7zip.  Can easily change that default behaviour if preferred.  It may help flag up failures with cloudflare as it'll read them as text files (no magic numbers) and reject them on quality grounds.

CRC checking is done for zip and rar using existing libraries.  7z and PDF are just passed if detected with valid header bytes.

Managed to find both bad rars and zips on usenet and GetComics to test against (Detective Comics (2016) is really really broken on usenet ...).

Resolves: https://github.com/mylar3/mylar3/issues/1541
Could be leveraged to resolve: https://github.com/mylar3/mylar3/issues/1564 but want to see how the newer CT handles those first.