### PR TITLE
Fix: check NZBGet subpath is not None before adding it to the URL.

### DIFF
--- a/mylar/nzbget.py
+++ b/mylar/nzbget.py
@@ -41,7 +41,7 @@ class NZBGet(object):
             return {'status': False}
         url = '%s://%s:%s'
         val = (protocol,nzbget_host,mylar.CONFIG.NZBGET_PORT)
-        if mylar.CONFIG.NZBGET_SUB:
+        if mylar.CONFIG.NZBGET_SUB is not None:
             if not mylar.CONFIG.NZBGET_SUB.startswith('/'):
                 mylar.CONFIG.NZBGET_SUB = '/' + mylar.CONFIG.NZBGET_SUB
             if mylar.CONFIG.NZBGET_SUB.endswith('/'):
@@ -63,7 +63,7 @@ class NZBGet(object):
             url = url + '/' + logon_info
         url = url + '/xmlrpc'
 
-        if mylar.CONFIG.NZBGET_SUB:
+        if mylar.CONFIG.NZBGET_SUB is not None:
             self.display_url = '%s://%s:%s%s/xmlrpc' % (protocol, nzbget_host, mylar.CONFIG.NZBGET_PORT, mylar.CONFIG.NZBGET_SUB)
         else:
             self.display_url = '%s://%s:%s/xmlrpc' % (protocol, nzbget_host, mylar.CONFIG.NZBGET_PORT)


### PR DESCRIPTION
This PR fixes an issue where Mylar3 would incorrectly attempt to add the NZBGet subpath even when it was None, causing connection errors when the NZBGet Sub-Path was None.
In my docker installation it tried to access ip:6789 None instead of just ip:6789