### PR TITLE
AirDC++ for Search & Download

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -834,6 +834,58 @@
                         </fieldset>
                         <fieldset>
                                 <div class="row checkbox left clearfix">
+                                     <input id="enable_airdcpp" type="checkbox" onclick="initConfigCheckbox($(this));" name="enable_airdcpp" value="1" ${config['enable_airdcpp']} /><legend>AirDC++</legend>
+                                </div>
+                                <div class="config">
+                                   <div id="airdcpp_options">
+                                       <div class="row">
+                                          <label>Address:Port</label>
+                                          <input type="text" name="airdcpp_host" id="airdcpp_host" value="${config['airdcpp_host']}" size="30">
+                                          <small>http://localhost:5600</small>
+                                       </div>
+                                       <div class="row">
+                                           <label>Username</label>
+                                           <input type="text" name="airdcpp_username" id="airdcpp_username" value="${config['airdcpp_username']}" size="20">
+                                       </div>
+                                       <div class="row">
+                                           <label>Password</label>
+                                           <input type="password" name="airdcpp_password" id="airdcpp_password" value="${config['airdcpp_password']| h}" size="20">
+                                       </div>
+                                       <div class="row">
+                                           <label>Downloads Directory</label>
+                                           <input type="text" name="airdcpp_download_dir" id="airdcpp_download_dir" value="${config['airdcpp_download_dir']}" size="50">
+                                       </div>
+                                       <div class="row">
+                                             <label>Search Hubs</label>
+                                             <input type="text" name="airdcpp_hubs" id="airdcpp_hubs" value="${config['airdcpp_hubs']}" size="50">
+                                             <small>comma separated, leave blank for all</small>
+                                        </div>
+                                       <div class="row">
+                                           <label>Announce Hub</label>
+                                           <input type="text" name="airdcpp_announce_hub" id="airdcpp_announce_hub" value="${config['airdcpp_announce_hub']}" size="50">
+                                           <small>single hub address:port for RSS-like monitoring</small>
+                                       </div>
+                                       <div class="row">
+                                           <label>Announce Bots</label>
+                                           <input type="text" name="airdcpp_announce_bots" id="airdcpp_announce_bots" value="${config['airdcpp_announce_bots']}" size="50">
+                                           <small>nicknames to parse announcements from</small>
+                                       </div>
+                                       <div align="center" class="row">
+                                        <img name="airdcpp_statusicon" id="airdcpp_statusicon" src="images/success.png" style="float:right;visibility:hidden;" height="20" width="20" />
+                                        <input type="button" value="Test AirDC++" id="test_airdcpp" style="float:center" /></br>
+                                        <input type="text" name="airdcppstatus" style="text-align:center;font-size:11px;color:white;" id="airdcppstatus" size="50" DISABLED />
+                                        <div name="airdcppversion" id="airdcppversion" style="font-size:11px;" align="center">
+                                            <%
+                                                if mylar.CONFIG.AIRDCPP_VERSION is not None:
+                                                    airdcppv = 'last tested version: %s' % mylar.CONFIG.AIRDCPP_VERSION
+                                                else:
+                                                    airdcppv = ''
+                                            %>
+                                            <span>${airdcppv}</span>
+                                        </div>
+                                </div>
+                        </fieldset>                        <fieldset>
+                                <div class="row checkbox left clearfix">
                                      <input id="enable_ddl" type="checkbox" onclick="initConfigCheckbox($(this));" name="enable_ddl" value="1" ${config['enable_ddl']} /><legend>DDL (Direct Download)</legend>
                                 </div>
                                 <div class="config">
@@ -2010,6 +2062,25 @@
                                 $("#opdscredentials").slideUp();
                         }
                 });
+if ($("#enable_airdcpp").is(":checked"))
+{
+    $("#airdcpp_options").show();
+}
+else
+{
+    $("#airdcpp_options").hide();
+}
+
+$("#enable_airdcpp").click(function(){
+    if ($("#enable_airdcpp").is(":checked"))
+    {
+        $("#airdcpp_options").slideDown();
+    }
+    else
+    {
+        $("#airdcpp_options").slideUp();
+    }
+});
 
                 if ($("#enable_ddl").is(":checked"))
                         {
@@ -2727,6 +2798,38 @@
 
                 $('#annuals_on').click(function () {
                     annuals_integration();
+                });
+
+                $('#test_airdcpp').click(function () {
+                    var imagechk = document.getElementById("airdcpp_statusicon");
+                    var airdcpphost = document.getElementById("airdcpp_host").value;
+                    var airdcppuser = document.getElementById("airdcpp_username").value;
+                    var airdcpppass = document.getElementById("airdcpp_password").value;
+                    $.get("AirDCPPtest",
+                        { airdcpphost: airdcpphost, airdcppusername: airdcppuser, airdcpppassword: airdcpppass },
+                        function(data){
+                            if (data.error != undefined) {
+                                alert(data.error);
+                                return;
+                            }
+                            var obj = JSON.parse(data);
+                            var versionairdcpp = obj['version'];
+                            $('#airdcppstatus').val(obj['message']);
+                            $('#airdcppversion span').text('AirDC++ version: '+versionairdcpp);
+                            $('#ajaxMsg').removeClass();
+                            $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>"+obj['message']+"</div>");
+                            if (obj['status']){
+                                imagechk.src = "";
+                                imagechk.src = "images/success.png";
+                                imagechk.style.visibility = "visible";
+                                $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                            } else {
+                                imagechk.src = "";
+                                imagechk.src = "images/x_red.png";
+                                imagechk.style.visibility = "visible";
+                                $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                            }
+                    });
                 });
 
                 $('#test_nzbget').click(function () {

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -355,6 +355,16 @@ _CONFIG_DEFINITIONS = OrderedDict({
 
     'ENABLE_DDL': (bool, 'DDL', False),
     'ENABLE_GETCOMICS': (bool, 'DDL', False),
+    'ENABLE_6DCC': (bool, 'DDL', False),
+    'ENABLE_AIRDCPP': (bool, 'DDL', False),
+    'AIRDCPP_HOST': (str, 'DDL', 'http://localhost:5600'),
+    'AIRDCPP_USERNAME': (str, 'DDL', ""),
+    'AIRDCPP_PASSWORD': (str, 'DDL', ""),
+    'AIRDCPP_DOWNLOAD_DIR': (str, 'DDL', ""),
+    'AIRDCPP_HUBS': (str, 'DDL', "myhub1.com:6423,dchub://myhub2.com:411"),
+    'AIRDCPP_VERSION': (str, 'DDL', ""),
+    'AIRDCPP_ANNOUNCE_HUB': (str, 'DDL', ""),
+    'AIRDCPP_ANNOUNCE_BOTS': (str, 'DDL', ""),
     'ENABLE_EXTERNAL_SERVER': (bool, 'DDL', False),
     'EXTERNAL_SERVER': (str, 'DDL', None),
     'EXTERNAL_USERNAME': (str, 'DDL', None),
@@ -1807,8 +1817,11 @@ class Config(object):
             if self.ENABLE_EXTERNAL_SERVER:
                 PR.append('DDL(External)')
                 PR_NUM +=1
+        if self.ENABLE_AIRDCPP:
+            PR.append('AirDCPP')
+            PR_NUM += 1
 
-        PPR = ['Experimental', 'DDL(GetComics)', 'DDL(External)']
+        PPR = ['Experimental', 'DDL(GetComics)', 'DDL(External)', 'AirDCPP']
         if self.NEWZNAB:
             for ens in self.EXTRA_NEWZNABS:
                 if str(ens[5]) == '1': # if newznabs are enabled
@@ -2010,6 +2023,9 @@ class Config(object):
                if 'DDL(External)' in tmp_prov:
                    t_type = 'DDL(External)'
                    t_id = 201
+               if 'AirDCPP' in tmp_prov:
+                   t_type = 'AirDCPP'
+                   t_id = 202
                elif any(['experimental' in tmp_prov, 'Experimental' in tmp_prov]):
                    tmp_prov = 'experimental'
                    t_type = 'experimental'

--- a/mylar/downloaders/__init__.py
+++ b/mylar/downloaders/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# This file is part of Mylar.
+#
+# Mylar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Mylar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
+
+from mylar.downloaders import airdcpp

--- a/mylar/downloaders/airdcpp.py
+++ b/mylar/downloaders/airdcpp.py
@@ -1,0 +1,544 @@
+# -*- coding: utf-8 -*-
+# This file is part of Mylar.
+#
+# Mylar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Mylar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Mylar. If not, see <http://www.gnu.org/licenses/>.
+
+import requests
+import urllib.parse
+import os
+import sys
+import traceback
+import errno
+import re
+import time
+import datetime
+import json
+import mylar
+from mylar import db, logger, helpers, search_filer
+
+
+class AirDCPP(object):
+    def __init__(self, query=None, issueid=None, comicid=None, oneoff=False, provider_stat=None):
+        self.query = query
+        self.issueid = issueid
+        self.comicid = comicid
+        self.oneoff = oneoff
+        self.provider_stat = provider_stat
+        self.session = requests.Session()
+        self.headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36'}
+
+        self.current_search_instance_id = None
+
+        self.api_url = mylar.CONFIG.AIRDCPP_HOST
+        if not self.api_url.endswith('/'):
+            self.api_url += '/'
+        self.api_url += 'api/v1'
+
+        if mylar.CONFIG.AIRDCPP_USERNAME and mylar.CONFIG.AIRDCPP_PASSWORD:
+            self.session.auth = (mylar.CONFIG.AIRDCPP_USERNAME, mylar.CONFIG.AIRDCPP_PASSWORD)
+
+        self.search_format = ['"%s #%s (%s)"', '%s #%s (%s)', '%s #%s', '%s %s']
+        self.comic_extensions = ["cbr", "cbz"]
+
+    def search(self, is_info=None):
+        """
+        Search AirDC++ for comics matching the query
+
+        Parameters:
+        is_info (dict): Information about the comic to search for
+
+        Returns:
+        list: List of verified matches or 'no results' if none found
+        """
+        try:
+            for sf in self.search_format:
+                verified_matches = []
+                sf_issue = self.query['issue']
+
+                if sf.count('%s') == 3:
+                    if sf_issue is None:
+                        splits = sf.split(' ')
+                        splits.pop(1)
+                        queryline = ' '.join(splits) % (self.query['comicname'], self.query['year'])
+                    else:
+                        queryline = sf % (self.query['comicname'], sf_issue, self.query['year'])
+                else:
+                    sf_count = len([m.start() for m in re.finditer('(?=%s)', sf)])
+                    if sf_count == 0:
+                        queryline = sf
+                    elif sf_count == 2:
+                        queryline = sf % (self.query['comicname'], sf_issue)
+                    elif sf_count == 3:
+                        queryline = sf % (self.query['comicname'], sf_issue, self.query['year'])
+                    else:
+                        queryline = sf % (self.query['comicname'])
+
+                if not queryline:
+                    continue
+
+                logger.fdebug('[AIRDCPP-QUERY] Query set to: %s' % queryline)
+                result_generator = self.perform_search_queries(queryline)
+
+                sfs = search_filer.search_check()
+                match = sfs.check_for_first_result(
+                    result_generator, is_info, prefer_pack=mylar.CONFIG.PACK_PRIORITY
+                )
+
+                if match is not None:
+                    verified_matches = [match]
+                    logger.fdebug('verified_matches: %s' % (verified_matches,))
+                    break
+
+                # reuse the DDL query delay
+                logger.fdebug('sleep...%s%s' % (mylar.CONFIG.DDL_QUERY_DELAY, 's'))
+                time.sleep(mylar.CONFIG.DDL_QUERY_DELAY)
+
+            return verified_matches if verified_matches else 'no results'
+
+        except requests.exceptions.Timeout as e:
+            logger.warn('Timeout occurred fetching data from AirDC++: %s' % e)
+            return 'no results'
+        except requests.exceptions.ConnectionError as e:
+            logger.warn('[WARNING] Connection refused to AirDC++. Error returned as: %s' % e)
+            if any([errno.ETIMEDOUT, errno.ECONNREFUSED, errno.EHOSTDOWN, errno.EHOSTUNREACH]):
+                helpers.disable_provider('AirDCPP', 'Connection Refused.')
+            return 'no results'
+        except Exception as err:
+            logger.warn('[WARNING] Unable to connect to AirDC++. Error returned as: %s' % err)
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            filename, line_num, func_name, err_text = traceback.extract_tb(exc_tb)[-1]
+            logger.error('[ERROR] %s line %s in %s: %s' % (filename, line_num, func_name, err_text))
+            return 'no results'
+
+    def create_search_instance(self):
+        """
+        Create a search instance in AirDC++
+
+        Returns:
+        int: The search instance ID or None if failed
+        """
+        try:
+            url = f"{self.api_url}/search"
+
+            response = self.session.post(
+                url,
+                headers=self.headers,
+                timeout=30
+            )
+            if response.status_code == 200:
+                data = response.json()
+                logger.fdebug(f"[AIRDCPP] Created search instance: {data}")
+                return data.get('id')
+            else:
+                logger.warn(f"[AIRDCPP] Failed to create search instance: {response.status_code} - {response.text}")
+                return None
+
+        except Exception as e:
+            logger.error(f"[AIRDCPP] Error creating search instance: {e}")
+            return None
+
+    def search_hub(self, search_instance_id, queryline, file_type="file"):
+        """
+        Search hubs with the given query
+
+        Parameters:
+        search_instance_id (int): The search instance ID
+        queryline (str): The search query
+
+        Returns:
+        str: The search ID or None if failed
+        """
+        try:
+            # Prepare the search query payload
+            payload = {
+                "query": {
+                    "pattern": queryline,
+                    "file_type": file_type,
+                    "extensions": self.comic_extensions
+                },
+                "priority": 3
+            }
+            if len(mylar.CONFIG.AIRDCPP_HUBS) > 0:
+                payload["hub_urls"] = mylar.CONFIG.AIRDCPP_HUBS.split(',')
+            time.sleep(45)
+            response = self.session.post(
+                f"{self.api_url}/search/{search_instance_id}/hub_search",
+                json=payload,
+                headers=self.headers,
+                timeout=30
+            )
+            logger.fdebug(f"[AIRDCPP] Hub search payload prepared: {payload}")
+
+            if response.status_code == 200:
+                data = response.json()
+                logger.fdebug(f"[AIRDCPP] Hub search initiated: {data}")
+                return data.get('search_id')
+            else:
+                logger.warn(f"[AIRDCPP] Failed to search hub: {response.status_code} - {response.text}")
+                return None
+
+        except Exception as e:
+            logger.error(f"[AIRDCPP] Error searching hub: {e}")
+            return None
+
+    def get_search_results(self, search_instance_id, start=0, count=50):
+        """
+        Get search results from AirDC++
+
+        Parameters:
+        search_instance_id (int): The search instance ID
+        start (int): The start index for pagination
+        count (int): The number of results to return
+
+        Returns:
+        list: The search results or empty list if failed
+        """
+        try:
+            response = self.session.get(
+                f"{self.api_url}/search/{search_instance_id}/results/{start}/{count}",
+                headers=self.headers,
+                timeout=30
+            )
+
+            if response.status_code == 200:
+                data = response.json()
+                logger.info(f"[AIRDCPP] Got {len(data)} search results")
+                return data
+            else:
+                logger.warn(f"[AIRDCPP] Failed to get search results: {response.status_code} - {response.text}")
+                return []
+
+        except Exception as e:
+            logger.error(f"[AIRDCPP] Error getting search results: {e}")
+            return []
+
+    def perform_search_queries(self, queryline):
+        """
+        Perform the actual search query to AirDC++ API
+
+        Parameters:
+        queryline (str): The formatted search query
+
+        Yields:
+        dict: Search result entries
+        """
+        search_instance_id = self.create_search_instance()
+        if not search_instance_id:
+            logger.error("[AIRDCPP] Failed to create search instance")
+            return
+
+        # Store the search instance ID - this is needed for downloads
+        self.current_search_instance_id = search_instance_id
+        search_id = self.search_hub(search_instance_id, queryline)
+        if not search_id:
+            logger.error("[AIRDCPP] Failed to search hub")
+            return
+        logger.fdebug("[AIRDCPP] Waiting for search to be sent to hubs...")
+
+        # Wait for results - usually 10-15 seconds is enough
+        time.sleep(45)
+        results = self.get_search_results(search_instance_id)
+
+        if not results:
+            logger.fdebug("[AIRDCPP] No results found")
+            return
+
+        logger.fdebug(f"[AIRDCPP] Processing {len(results)} search results")
+
+        for result in results:
+            # Skip directories
+            if result.get('type', {}).get('id') == 'directory':
+                logger.fdebug(f"[AIRDCPP] Skipping directory: {result.get('name')}")
+                continue
+
+            # Only process CBR/CBZ files
+            file_extension = result.get('type', {}).get('str', '').lower()
+            if file_extension not in self.comic_extensions:
+                logger.fdebug(f"[AIRDCPP] Skipping non-comic file: {result.get('name')} ({file_extension})")
+                continue
+
+            size_bytes = result.get('size', 0)
+            if isinstance(size_bytes, (int, float)):
+                # Convert to MB and format as string like "25.5 MB"
+                size_mb = size_bytes / (1024 * 1024)
+                size_str = f"{size_mb:.1f} MB"
+            else:
+                size_str = str(size_bytes)
+
+            # Format the result for search_filer
+            formatted_result = {
+                'title': result.get('name', ''),
+                'link': result.get('id', ''),  # Using ID as the link
+                'size': size_str,
+                'size_bytes': size_bytes,
+                'pubdate': None,  # AirDC++ results done have dates
+                'site': 'AirDCPP',
+                'mode': 'direct',
+                'pack': False,
+                'issues': None,
+                'filename': result.get('name', ''),
+                'download': result.get('id', ''),  # Using ID for download
+                'id': result.get('id', ''),
+                # Add additional info that might be useful
+                'free_slots': result.get('slots', {}).get('free', 0),
+                'total_slots': result.get('slots', {}).get('total', 0),
+                'hits': result.get('hits', 0),
+                'search_instance_id': search_instance_id
+            }
+
+            logger.info(f"[AIRDCPP] Yielding result: {formatted_result['title']} "
+                        f"(size: {formatted_result['size']}, "
+                        f"slots: {formatted_result['free_slots']}/{formatted_result['total_slots']}, "
+                        f"hits: {formatted_result['hits']})")
+
+            yield formatted_result
+
+    def check_download_complete(self, bundle_id, filename, max_wait=1800, check_interval=5):
+        """
+        Check if a download is complete by monitoring the bundle status
+
+        Parameters:
+        bundle_id (int): The bundle ID from the download response
+        filename (str): The filename to check
+        max_wait (int): Maximum time to wait in seconds
+        check_interval (int): Time between checks in seconds
+
+        Returns:
+        bool: True if download is complete, False otherwise
+        """
+        if mylar.CONFIG.AIRDCPP_DOWNLOAD_DIR:
+            dl_location = mylar.CONFIG.AIRDCPP_DOWNLOAD_DIR
+        else:
+            dl_location = os.path.join(mylar.CONFIG.DDL_LOCATION, 'airdcc')
+
+        filepath = os.path.join(dl_location, filename)
+        start_time = time.time()
+
+        logger.info(f"[AIRDCPP] Checking download status for {filename}")
+
+        while time.time() - start_time < max_wait:
+            try:
+                response = self.session.get(
+                    f"{self.api_url}/queue/bundles/{bundle_id}",
+                    headers=self.headers,
+                    timeout=30
+                )
+
+                if response.status_code == 200:
+                    bundle_data = response.json()
+                    status = bundle_data.get('status', {})
+                    if status.get('completed', False):
+                        logger.info(f"[AIRDCPP] Download reported as completed by API")
+                        if os.path.exists(filepath):
+                            final_size = os.path.getsize(filepath)
+                            logger.info(f"[AIRDCPP] Download complete: {filename} ({final_size / (1024 * 1024):.2f} MB)")
+                            return True
+                        else:
+                            logger.warn(f"[AIRDCPP] Download completed but file not found: {filepath}")
+                            return False
+
+                    downloaded = bundle_data.get('downloaded_bytes', 0)
+                    total = bundle_data.get('size', 0)
+                    if total > 0:
+                        percentage = (downloaded / total) * 100
+                        logger.info(f"[AIRDCPP] Download progress: {percentage:.2f}% ({downloaded / (1024 * 1024):.2f}/{total / (1024 * 1024):.2f} MB)")
+
+                else:
+                    logger.warn(f"[AIRDCPP] Failed to get bundle status: {response.status_code}")
+
+            except Exception as e:
+                logger.warn(f"[AIRDCPP] Error checking download status via API: {e}")
+
+            time.sleep(check_interval)
+
+        logger.warn(f"[AIRDCPP] Download timeout for {filename} after {max_wait/60:.2f} minutes")
+        return False
+
+    def download(self, link, filename, id, issueid=None, site=None, search_instance_id=None):
+        """
+        Download a comic from AirDC++
+
+        Parameters:
+        link (str): The download link (TTH hash)
+        filename (str): The filename to save as
+        id (str): The ID of the comic
+        issueid (str, optional): The issue ID
+        site (str, optional): The site name
+        search_instance_id (str, optional): The search instance ID to use
+
+        Returns:
+        dict: Status of the download
+        """
+        logger.info(f"[AIRDCPP] Attempting to download {filename} with TTH: {link}")
+
+        if mylar.CONFIG.AIRDCPP_DOWNLOAD_DIR:
+            dl_location = mylar.CONFIG.AIRDCPP_DOWNLOAD_DIR
+        else:
+            dl_location = os.path.join(mylar.CONFIG.DDL_LOCATION, 'airdcpp')
+
+        dl_location = dl_location.replace('\\', '/')  # Convert Windows backslashes to forward slashes
+        if not dl_location.endswith('/'):
+            dl_location += '/'
+
+        if not os.path.isdir(dl_location):
+            checkdirectory = mylar.filechecker.validateAndCreateDirectory(dl_location, True)
+            if not checkdirectory:
+                logger.warn('[ABORTING] Error trying to validate/create AirDC++ download directory: %s.' % dl_location)
+                return {"success": False, "filename": filename, "path": None}
+
+        try:
+            # Use the previous search instance ID - mandatory because we need to get the TTH from the previous search
+            if search_instance_id is None:
+                search_instance_id = self.current_search_instance_id
+
+            payload = {
+                "target_directory": dl_location,
+                "target_name": filename,
+                "priority": 4
+            }
+
+            # Send the download request with the search instance and TTH as result_id
+            # The TTH hash is used directly as the result_id
+            response = self.session.post(
+                f"{self.api_url}/search/{search_instance_id}/results/{link}/download",
+                json=payload,
+                headers=self.headers,
+                timeout=30
+            )
+            logger.info(
+                f"[AIRDCPP] Initiating download with URL: {self.api_url}/search/{search_instance_id}/results/{link}/download")
+            logger.info(f"[AIRDCPP] Download request payload: {payload}")
+
+            if response.status_code != 200:
+                logger.error(f"[AIRDCPP] Failed to initiate download: {response.status_code} - {response.text}")
+                return {"success": False, "filename": filename, "path": None}
+
+            # Get the download response and extract bundle ID
+            download_data = response.json()
+            logger.info(f"[AIRDCPP] Download initiated: {download_data}")
+
+            bundle_id = download_data.get('bundle_info', {}).get('id')
+            if not bundle_id:
+                logger.error("[AIRDCPP] No bundle ID in download response")
+                return {"success": False, "filename": filename, "path": None}
+
+            # Check for download completion using bundle ID
+            download_complete = self.check_download_complete(bundle_id, filename)
+
+            if download_complete:
+                filepath = os.path.join(dl_location, filename)
+                if os.path.exists(filepath):
+                    # If the file exists, the download was successful
+                    logger.info(f"[AIRDCPP] Download completed successfully: {filepath}")
+
+                    # If issueid is provided, rename the file to include it
+                    if issueid:
+                        file, ext = os.path.splitext(filename)
+                        new_filename = f"{file}[__{issueid}__]{ext}"
+                        new_filepath = os.path.join(dl_location, new_filename)
+                        try:
+                            os.rename(filepath, new_filepath)
+                            filepath = new_filepath
+                            filename = new_filename
+                            logger.info(f"[AIRDCPP] File renamed to include issue ID: {new_filepath}")
+                        except Exception as e:
+                            logger.warn(f"[AIRDCPP] Unable to rename file: {e}")
+
+                    return {"success": True, "filename": filename, "path": filepath}
+                else:
+                    logger.error(f"[AIRDCPP] Download completed but file not found: {filepath}")
+                    return {"success": False, "filename": filename, "path": None}
+            else:
+                logger.error(f"[AIRDCPP] Download did not complete within the timeout period")
+                return {"success": False, "filename": filename, "path": None}
+
+        except Exception as e:
+            logger.error(f"[AIRDCPP] Error downloading file: {e}")
+            return {"success": False, "filename": filename, "path": None, "link_type_failure": site}
+
+    def rss_download(self, tth_hash, filename, issueid=None):
+        """
+        Download a file from AirDC++ using TTH hash from RSS
+        This bypasses the search and goes straight to download
+        """
+        logger.info(f"[AIRDCPP][RSS] Starting RSS download for TTH: {tth_hash}")
+
+        # Create search instance for the download
+        search_instance_id = self.create_search_instance()
+        if not search_instance_id:
+            logger.error("[AIRDCPP][RSS] Failed to create search instance")
+            return {"success": False, "filename": filename, "path": None}
+
+        # Store the search instance ID
+        self.current_search_instance_id = search_instance_id
+
+        # Search for the TTH hash using TTH file type
+        search_query = tth_hash
+        logger.info(f"[AIRDCPP][RSS] Searching for TTH: {search_query}")
+
+        # Search for the specific TTH with file_type="tth"
+        search_id = self.search_hub(search_instance_id, search_query, file_type="tth")
+        if not search_id:
+            logger.error("[AIRDCPP][RSS] Failed to initiate TTH search")
+            return {"success": False, "filename": filename, "path": None}
+
+        # Wait for search results (shorter wait since we're looking for specific TTH)
+        logger.info("[AIRDCPP][RSS] Waiting for TTH search results...")
+        time.sleep(15)  # Shorter wait for TTH search
+
+        # Get search results
+        results = self.get_search_results(search_instance_id)
+
+        if not results:
+            logger.warn(f"[AIRDCPP][RSS] No results found for TTH: {tth_hash}")
+            return {"success": False, "filename": filename, "path": None}
+
+        logger.info(f"[AIRDCPP][RSS] Found {len(results)} results for TTH search")
+
+        # Since we searched by TTH, any result is a match - just take the first one
+        if len(results) > 0:
+            result = results[0]
+            target_result_id = result.get('id', '')
+            result_name = result.get('name', '')
+
+            logger.info(f"[AIRDCPP][RSS] Using TTH search result: {result_name} (ID: {target_result_id})")
+
+            # Download using the found result ID
+            download_result = self.download(
+                link=target_result_id,
+                filename=result_name,
+                id=tth_hash,
+                issueid=issueid,
+                site='AirDCPP',
+                search_instance_id=search_instance_id
+            )
+
+            if download_result and download_result.get('success'):
+                logger.info(f"[AIRDCPP][RSS] Successfully downloaded via RSS: {filename}")
+                return download_result
+            else:
+                error_info = download_result.get('link_type_failure',
+                                                 'Unknown error') if download_result else 'No response'
+                logger.error(f"[AIRDCPP][RSS] Download failed: {error_info}")
+                return {"success": False, "filename": filename, "path": None}
+        else:
+            logger.error(f"[AIRDCPP][RSS] No results returned for TTH search: {tth_hash}")
+            return {"success": False, "filename": filename, "path": None}
+
+
+if __name__ == '__main__':
+    test = AirDCPP(query={'comicname': 'Batman', 'issue': '1', 'year': '2020'})
+    results = test.search()
+    print(f"Search results: {results}")

--- a/mylar/search_filer.py
+++ b/mylar/search_filer.py
@@ -145,6 +145,12 @@ class search_check(object):
                                     comsize_b = helpers.human2bytes(entry['size'])
                         elif entry['site'] == 'DDL(External)':
                             comsize_b = '0' #External links ! filesize
+                        elif entry['site'] == 'AirDCPP':
+                            # Use size_bytes if available, otherwise use the formatted size string
+                            if 'size_bytes' in entry and entry['size_bytes']:
+                                comsize_b = entry['size_bytes']
+                            else:
+                                comsize_b = helpers.human2bytes(entry['size'])
                     except Exception:
                         tmpsz = entry.enclosures[0]
                         comsize_b = tmpsz['length']
@@ -219,9 +225,9 @@ class search_check(object):
                     )
                     return None
 
-        if UseFuzzy == "1":
+        if UseFuzzy == "1" or nzbprov.lower() == 'airdcpp':
             logger.fdebug(
-                'Year has been fuzzied for this series,'
+                'Year has been fuzzied for this series, or provider is AirDC++'
                 ' ignoring store date comparison entirely.'
             )
             postdate_int = None
@@ -1116,6 +1122,8 @@ class search_check(object):
                             "ComicTitle": ComicTitle,
                             "entry": entry,
                             "provider_stat": provider_stat,
+                            # Add this line to preserve the search_instance_id
+                            "search_instance_id": entry.get('search_instance_id')
                         }
                 else:
                     #log2file = log2file + "issues don't match.." + "\n"
@@ -1151,5 +1159,5 @@ class search_check(object):
                     # (This reduces to prefer_pack == is_pack, but that's harder to grok)
                     return maybe_value
                 candidate = maybe_value
-        #logger.fdebug('candidate: %s' % candidate)
+        logger.info('candidate: %s' % candidate)
         return candidate

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6811,6 +6811,14 @@ class WebInterface(object):
                     "extra_newznabs": sorted(mylar.CONFIG.EXTRA_NEWZNABS, key=itemgetter(5), reverse=True),
                     "enable_ddl": helpers.checked(mylar.CONFIG.ENABLE_DDL),
                     "enable_getcomics": helpers.checked(mylar.CONFIG.ENABLE_GETCOMICS),
+                    "enable_airdcpp": helpers.checked(mylar.CONFIG.ENABLE_AIRDCPP),
+                    "airdcpp_host": mylar.CONFIG.AIRDCPP_HOST,
+                    "airdcpp_username": mylar.CONFIG.AIRDCPP_USERNAME,
+                    "airdcpp_password": mylar.CONFIG.AIRDCPP_PASSWORD,
+                    "airdcpp_download_dir": mylar.CONFIG.AIRDCPP_DOWNLOAD_DIR,
+                    "airdcpp_hubs": mylar.CONFIG.AIRDCPP_HUBS,
+                    "airdcpp_announce_hub": mylar.CONFIG.AIRDCPP_ANNOUNCE_HUB,
+                    "airdcpp_announce_bots": mylar.CONFIG.AIRDCPP_ANNOUNCE_BOTS,
                     "ddl_prefer_upscaled": helpers.checked(mylar.CONFIG.DDL_PREFER_UPSCALED),
                     "enable_external_server": helpers.checked(mylar.CONFIG.ENABLE_EXTERNAL_SERVER),
                     "external_server": mylar.CONFIG.EXTERNAL_SERVER,
@@ -7302,7 +7310,7 @@ class WebInterface(object):
                            'prowl_enabled', 'prowl_onsnatch', 'pushover_enabled', 'pushover_onsnatch', 'pushover_image', 'mattermost_enabled', 'mattermost_onsnatch', 'boxcar_enabled',
                            'boxcar_onsnatch', 'pushbullet_enabled', 'pushbullet_onsnatch', 'telegram_enabled', 'telegram_onsnatch', 'telegram_image', 'discord_enabled', 'discord_onsnatch', 'slack_enabled', 'slack_onsnatch',
                            'email_enabled', 'email_enc', 'email_ongrab', 'email_onpost', 'gotify_enabled', 'gotify_server_url', 'gotify_token', 'gotify_onsnatch', 'opds_enable', 'opds_authentication', 'opds_metainfo', 'opds_pagesize', 'enable_ddl',
-                           'enable_getcomics', 'enable_external_server', 'ddl_prefer_upscaled', 'deluge_pause'] #enable_public
+                           'enable_getcomics', 'enable_airdcpp', 'enable_external_server', 'ddl_prefer_upscaled', 'deluge_pause'] #enable_public
 
         for checked_config in checked_configs:
             if checked_config not in kwargs:
@@ -7479,6 +7487,96 @@ class WebInterface(object):
         return json.dumps({"status": True, "message": "Successfully verified API Key.", "version": str(version)})
 
     SABtest.exposed = True
+
+    def AirDCPPtest(self, airdcpphost=None, airdcppusername=None, airdcpppassword=None):
+        if airdcpphost is None:
+            airdcpphost = mylar.CONFIG.AIRDCPP_HOST
+        if airdcppusername is None:
+            airdcppusername = mylar.CONFIG.AIRDCPP_USERNAME
+        if airdcpppassword is None:
+            airdcpppassword = mylar.CONFIG.AIRDCPP_PASSWORD
+
+        logger.fdebug('Now attempting to test AirDC++ connection')
+        logger.fdebug('testing connection to AirDC++ @ ' + airdcpphost)
+
+        if not airdcpphost.endswith('/'):
+            airdcpphost = airdcpphost + '/'
+
+        api_url = airdcpphost
+        if not api_url.endswith('api/v1'):
+            api_url += 'api/v1'
+
+        query_url = f"{api_url}/system/system_info"
+
+        if airdcpphost.startswith('https'):
+            verify = True
+        else:
+            verify = False
+
+        version = 'Unknown'
+        try:
+            session = requests.Session()
+            if airdcppusername and airdcpppassword:
+                session.auth = (airdcppusername, airdcpppassword)
+
+            headers = {
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36'
+            }
+
+            r = session.get(query_url, headers=headers, verify=verify, timeout=30)
+        except Exception as e:
+            logger.warn('Error fetching data from %s: %s' % (query_url, e))
+            if requests.exceptions.SSLError:
+                logger.warn(
+                    'Cannot verify ssl certificate. Attempting to authenticate with no ssl-certificate verification.')
+                try:
+                    from requests.packages.urllib3 import disable_warnings
+                    disable_warnings()
+                except:
+                    logger.warn('Unable to disable https warnings. Expect some spam if using https providers.')
+
+                verify = False
+
+                try:
+                    session = requests.Session()
+                    if airdcppusername and airdcpppassword:
+                        session.auth = (airdcppusername, airdcpppassword)
+
+                    r = session.get(query_url, headers=headers, verify=verify, timeout=30)
+                except Exception as e:
+                    logger.warn('Error fetching data from %s: %s' % (airdcpphost, e))
+                    return json.dumps(
+                        {"status": False, "message": "Unable to retrieve data from AirDC++.", "version": str(version)})
+            else:
+                return json.dumps(
+                    {"status": False, "message": "Unable to retrieve data from AirDC++.", "version": str(version)})
+
+        logger.fdebug('status code: ' + str(r.status_code))
+
+        if str(r.status_code) != '200':
+            logger.warn('Unable to properly query AirDC++ @' + airdcpphost + ' [Status Code returned: ' + str(
+                r.status_code) + ']')
+            return json.dumps(
+                {"status": False, "message": "Invalid credentials or connection error.", "version": str(version)})
+        else:
+            data = r.json()
+            try:
+                # Try to extract version from the response
+                version = data.get('client_version', 'Unknown')
+                logger.info('AirDC++ version: %s' % version)
+
+                # Save the version to config
+                mylar.CONFIG.AIRDCPP_VERSION = version
+                mylar.CONFIG.writeconfig(values={'airdcpp_version': version})
+
+                return json.dumps(
+                    {"status": True, "message": "Successfully connected to AirDC++.", "version": str(version)})
+            except Exception as e:
+                logger.error('Error parsing AirDC++ response: %s' % e)
+                return json.dumps(
+                    {"status": False, "message": "Error parsing AirDC++ response.", "version": str(version)})
+
+    AirDCPPtest.exposed = True
 
     def NZBGet_test(self, nzbhost=None, nzbport=None, nzbusername=None, nzbpassword=None, nzbsub=None):
         if nzbhost is None:


### PR DESCRIPTION
Initial implementation of using AirDC++ Web to search and download. Also monitors release announcement hubs as if they were RSS feeds. Likely there are some things I am not doing correctly as I am not that familiar with the Mylar codebase, but I have tested it and verified it can search, download and post process, and that rss force + schedule work. I put it in Search Providers near DDL - it is both search and download so wasn't sure. 

My test environment was a dockerised verlihub and a pair of airdc++ containers. I used one container to be the search endpoint and the other to share the comics. Both connected to the test hub. I then created an API user in AirDC++ under Settings, System, Add User and put those credentials into Mylar. 

Features:
* Hub filter - important in case you don't want all your hubs to be searched by Mylar
* Search - creates a search instance, searches the hub with this instance, waits for it to get results
* RSS for Announce Hubs - use a release announcement hub like an RSS feed
* Download - this gets the TTH of the result and queues the bundle for download
* Post Process - leverages existing mylar post processing. Tested with Copy and Move
* Test button with version info

![image](https://github.com/user-attachments/assets/8162b01c-7477-4a5b-8e4f-81c700c1e2cc)


