### PR TITLE
Update requirements.txt to add pyOpenSSL for SSL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ tenacity>=8.2.3
 tzlocal>=2.0.0
 urllib3<2
 user_agent2>=2021.12.11
+pyOpenSSL>=25.1.0


### PR DESCRIPTION
Currently, SSL is not working due to missing dependency pyOpenSSL in the requirements.