### PR TITLE
Tweaked search delay check to no longer give misleading warning on manually triggered searches

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -4130,6 +4130,7 @@ def check_the_search_delay(manual=False):
     if (
         mylar.CONFIG.SEARCH_DELAY == 'None'
         or mylar.CONFIG.SEARCH_DELAY is None
+        or manual
     ):
         pause_the_search = 30  # in seconds
     elif str(mylar.CONFIG.SEARCH_DELAY).isdigit() and manual is False:


### PR DESCRIPTION
I've now seen someone question this warning at least twice, so might as well prevent it happening again :)

Adds manual searches into the default 30s case.

Fixes #1649 