### PR TITLE
Fix exception on single wanted issue submit, revert button text on refresh

### DIFF
--- a/data/interfaces/default/upcoming.html
+++ b/data/interfaces/default/upcoming.html
@@ -240,6 +240,8 @@
                      },
             })).done(function(data) {
                  reload_table();
+                 fc = document.getElementById("menu_link_scan");
+                 fc.getElementsByClassName('ui-button-text')[0].innerText = "Force Check Tier-1";
             });
         }
 

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -4517,6 +4517,9 @@ class WebInterface(object):
         else:
             myDB = db.DBConnection()
 
+            if not isinstance(issueIds, list):
+                issueIds = [issueIds]
+
             for issueId in issueIds:
                 issue_data = myDB.selectone("SELECT C.Type, C.ComicYear, I.ComicName, I.Issue_Number, I.ComicID, I.IssueID FROM comics as C INNER JOIN issues as I on C.ComicID = I.ComicID WHERE I.IssueID=?", [issueId]).fetchone()
                 passInfo = {'issueid': issueId,
@@ -8090,6 +8093,9 @@ class WebInterface(object):
                      'ComicVersion': cinfo['ComicVersion'],
                      'AgeRating': cinfo['AgeRating'],
                      'meta_dir': cinfo['ComicLocation']}
+        
+        if not isinstance(IssueIDs, list):
+            IssueIDs = [IssueIDs]
         
         issueList = ', '.join(IssueIDs)
         groupinfo = myDB.select(f'SELECT IssueID, Location FROM issues WHERE ComicID={ComicID} and IssueID IN ({issueList}) and Location is not NULL')


### PR DESCRIPTION
I had missed a very obvious case of selecting a single issue on the wanted page for checking causing the issueIds to not be passed as a list.  Clearly I've been using the magnifying glass too much ...