### PR TITLE
CBL Reading List Import Screen

### DIFF
--- a/data/interfaces/carbon/css/style.css
+++ b/data/interfaces/carbon/css/style.css
@@ -1602,7 +1602,7 @@ div#artistheader h2 a {
   text-align: left;
   vertical-align: middle;
 }
-+#searchresults_table td#publisher {
+#searchresults_table td#publisher {
   width: 30px;
   text-align: center;
   vertical-align: middle;
@@ -1693,6 +1693,44 @@ div#artistheader h2 a {
   vertical-align: middle;
   text-align: left;
 }
+
+#cblimporttable th.list_index {
+  min-width: 50px;
+  text-align: center;
+}
+#cblimporttable td.list_index {
+  text-align: right;
+}
+#cblimporttable th.volume {
+  min-width: 325px;
+  text-align: left;
+}
+#cblimporttable td.volume {
+  text-align: left;
+}
+
+#cblimporttable th.issue {
+  min-width: 75px;
+  text-align: center;
+}
+#cblimporttable td.issue {
+  text-align: right;
+}
+#cblimporttable th.status {
+  min-width: 62px;
+  text-align: left;
+}
+#cblimporttable td.status {
+  text-align: left;
+}
+#cblimporttable th.action {
+  min-width: 325px;
+  text-align: left;
+}
+#cblimporttable td.action {
+  text-align: left;
+}
+
 #interactive_table th#series {
   max-width: 150px;
   vertical-align: middle;

--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -362,7 +362,7 @@
                     if (data.status == 'success'){
                         $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
                         console.log('data.comicid:'+data.comicid)
-                        if ( ( tt.value != "config" ) && (data.tables == 'both' || data.tables == 'tables') && ( document.body.innerHTML.search(data.comicid) || tt.value == "history" || tt.value == "search_results") ){
+                        if ( ( tt.value != "config" ) && ( tt.value != "cblimport") && (data.tables == 'both' || data.tables == 'tables') && ( document.body.innerHTML.search(data.comicid) || tt.value == "history" || tt.value == "search_results") ){
                             console.log('reloading table1...');
                             reload_table();
                         }

--- a/data/interfaces/default/cblimport.html
+++ b/data/interfaces/default/cblimport.html
@@ -1,0 +1,225 @@
+<%inherit file="base.html" />
+<%!
+	import mylar
+        from mylar import db
+	from mylar.helpers import checked
+%>
+<%def name="body()">
+    <input type="hidden" id="page_name" value="cblimport" />
+    <div id="paddingheader">
+		<h1 class="clearfix">CBL Import</h1>
+	</div>
+    <ul>
+        <li>Import a CBL reading list and add volumes/issues to your wanted list.  It expects a CBL to contain ComicVine IDs such as in those on the <a href="https://github.com/DieselTech/CBL-ReadingLists" target="_blank" >CBL-ReadingLists</a> repository.</li>
+        <li>Issues that already exist in a state of Downloaded/Wanted/Snatched will not be affected.</li>
+        <li>Adding of volumes and updating issue status will happen in the background, so you can leave this page once submitted for processing.</li>        
+    </ul>
+    <br >
+	<hr />
+    <div class="configtable" style="width:960px;height:225px;">
+        <div style="float:right;margin-right:25px;width:400px;">
+            <legend>Import Status</legend>
+            <div id="status_text" style="display: inline">
+                No reading list loaded
+            </div>
+
+        </div>
+        <div id="list_select">
+            <legend>Control</legend>
+            <input type="file" id="cblfileinput" name="cblfile" accept=".cbl" style="display:none" />
+            <input id="cblfileselectbutton" type="button"  value="Upload A CBL File" />
+            <span id="cblfilenamelabel" style="display:inline; width: 300px">No file selected</span><br >
+            <span id="cblfilenameerror" style="width: 300px; color: red"></span>
+            
+            <br >
+            <br >
+
+            <div class="row checkbox">
+                <input type="checkbox" ${'' if mylar.CONFIG.AUTOWANT_ALL else 'disabled'} name="issuesonly" style="vertical-align: middle; margin: 3px; margin-top: -1px;" id="issuesonly" value="1" ${checked(mylar.CONFIG.CBL_IMPORT_ISSUESONLY)} />
+                <label for="issuesonly" style="width:200px;">Only mark issues from list as wanted</label>
+                <%
+                    tooltip = "Overrides the 'Automatically Mark All Issues as Wanted' setting when adding a new volume"
+                %>
+                <a href="#" title="${tooltip}"><img src="images/info32.png" height="16" alt="" /></a>
+            </div>
+            <div class="row checkbox">
+                <input type="checkbox" name="ignorearchived" style="vertical-align: middle; margin: 3px; margin-top: -1px;" id="ignorearchived" value="1" ${checked(mylar.CONFIG.CBL_IMPORT_IGNOREARCHIVED)} />
+                <label for="ignorearchived" style="width:200px;">Do not mark Archived issues as Wanted</label>                    
+            </div>
+            
+        </div>
+        <br >
+        <input id="processlistbutton" type="button" value="Import Reading List" style="display:none" />   
+        <label id="processlistconfirm" style="display:none">Reading List Submitted for Processing</label>
+    </div>
+    
+    <br >
+    <hr />
+    <div class="table_wrapper">
+        <table class="display" id="cblimporttable">
+            <thead>
+                    <tr>
+                            <th class="list_index">Entry</th>
+                            <th class="volume">Volume</th>
+                            <th class="issue">Issue #</th>
+                            <th class="status">Status</th>
+                            <th class="action">Action</th>
+                    </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+</%def>
+<%def name="headIncludes()">
+        <link rel="stylesheet" href="interfaces/${interface}/css/data_table.css">
+</%def>
+
+<%def name="javascriptIncludes()">
+        <script src="js/libs/jquery.dataTables.min.js"></script>
+        <script>
+            function cblUpload() {
+                var cblImportTableBody = $('#cblimporttable > tbody')
+                cblImportTableBody.empty();
+                $('#cblfilenameerror').text("");
+                $('#processlistbutton').toggle(false);
+                $('#status_text').text("No reading list loaded");
+                $('#processlistconfirm').toggle(false);
+                $('#cblimporttable').DataTable().clear();
+
+                var file = null;
+
+                if ($(this).prop('files').length == 0) {
+                    $('#cblfilenamelabel').text("No File Selected");
+                    $('#status_text').text("No Reading List Loaded")
+                    return
+                } else {
+                    file = $(this).prop('files')[0]
+                    $('#cblfilenamelabel').text(file.name);
+                }
+
+                formdata = new FormData();
+                formdata.append("cblFile",file);
+                formdata.append("issuesonly",document.getElementById("issuesonly").checked);
+                formdata.append("ignorearchived",document.getElementById("ignorearchived").checked);
+
+                $.when($.ajax({
+                 type: "POST",
+                 url: "checkCBLFile",
+                 data: formdata,
+                 processData: false,
+                 contentType: false,
+                 error: function(data)
+                     {
+                       alert('ERROR'+data.responseText);
+                     },
+                })).done(function(data) {
+                    var json = $.parseJSON(data);
+
+                    if (json['status'] == 'error') {
+                        $('#status_text').html(json['message']);
+                    } 
+                    else {
+                        $('#status_text').html(json['message']);
+                        $('#cblfilenameerror').text(json['warning_text'])
+
+                        var dataTable = $('#cblimporttable').DataTable();
+                        dataTable.rows.add(json['results']);
+                        dataTable.rows().every( function ( rowIdx, tableLoop, rowLoop ) {
+                            var data = this.data();
+                            $(this.node()).addClass(data[3]);
+                        } );
+                        dataTable.draw(false);
+                        
+                        $('#processlistbutton').toggle(true);
+                    }
+                });
+            }
+        </script>
+        <script>
+            function processCBL() {
+                file = $('#cblfileinput').prop('files')[0]
+
+                formdata = new FormData();
+                formdata.append("cblFile",file);
+                formdata.append("issuesonly",document.getElementById("issuesonly").checked);
+                formdata.append("ignorearchived",document.getElementById("ignorearchived").checked);
+
+                $.when($.ajax({
+                 type: "POST",
+                 url: "processCBLFile",
+                 data: formdata,
+                 processData: false,
+                 contentType: false,
+                 success : function(data) {},
+                 error: function(data)
+                     {
+                       alert('ERROR'+data.responseText);
+                     },
+                })).done(function(data) {
+                    var json = $.parseJSON(data);
+
+                    $('#status_text').html(json['message']);
+                    $('#cblfilenameerror').text(json['warning_text'])
+                });
+
+                $('#processlistbutton').toggle(false);
+                $('#processlistconfirm').toggle(true)
+            }
+        </script>
+        <script>
+        function triggerFileSelect() {
+            $(cblfileinput).click();
+        }
+            
+        function initThisPage() {
+                jQuery( "#tabs" ).tabs();
+                initActions();
+                
+                $('#cblfileinput').change(cblUpload);
+                $('#cblfileselectbutton').click(triggerFileSelect);
+                $('#cblfilenamelabel').click(triggerFileSelect);
+                $('#processlistbutton').click(processCBL);
+                
+                $('#cblimporttable').dataTable(
+                        {
+                                destroy: true,
+                                sDom: '<"clear"Af><"clear"lp><"clear">rt<"clear"ip>',
+                                //"aoColumnDefs": [
+                                //  { 'bSortable': false, 'aTargets': [ 0 , 2 ] },
+                                //  { 'bVisible': false, 'aTargets': [2] },
+                                //  { 'sType': 'numeric', 'aTargets': [2] },
+                                //  { 'iDataSort': [2], 'aTargets': [3] }
+                                //],
+                                LengthMenu: [[10, 25, 50, -1], [10, 25, 50, 'All' ]],
+                                Language: {
+                                        LengthMenu:"Show _MENU_ results per page",
+                                        EmptyTable: "No results",
+                                        Info:"Showing _START_ to _END_ of _TOTAL_ results",
+                                        InfoEmpty:"Showing 0 to 0 of 0 results",
+                                        InfoFiltered:"(filtered from _MAX_ total results)",
+                                        Search : ""},
+                                columns: [
+                                    {className: "list_index"},
+                                    {className: "volume"},
+                                    {className: "issue"},
+                                    {className: "status"},
+                                    {className: "action"}
+                                ],
+                                StateSave: true,
+                                stateDuration: 0,
+                                pageLength: 50,
+                                pagingType: "simple_numbers",
+                                aaSorting: [0, 'asc']
+                        });
+                resetFilters("result");                
+        }
+
+        $(document).ready(function(){
+            initThisPage();
+        });
+        $(window).load(function(){
+            initFancybox();
+        });
+     </script>
+
+</%def>

--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -1631,6 +1631,44 @@ div#artistheader h2 a {
   vertical-align: middle;
   text-align: left;
 }
+
+#cblimporttable th.list_index {
+  min-width: 50px;
+  text-align: center;
+}
+#cblimporttable td.list_index {
+  text-align: right;
+}
+#cblimporttable th.volume {
+  min-width: 325px;
+  text-align: left;
+}
+#cblimporttable td.volume {
+  text-align: left;
+}
+
+#cblimporttable th.issue {
+  min-width: 75px;
+  text-align: center;
+}
+#cblimporttable td.issue {
+  text-align: right;
+}
+#cblimporttable th.status {
+  min-width: 62px;
+  text-align: left;
+}
+#cblimporttable td.status {
+  text-align: left;
+}
+#cblimporttable th.action {
+  min-width: 325px;
+  text-align: left;
+}
+#cblimporttable td.action {
+  text-align: left;
+}
+
 #downloads_table th#title {
   max-width: 150px;
   vertical-align: middle;

--- a/data/interfaces/default/manage.html
+++ b/data/interfaces/default/manage.html
@@ -211,6 +211,7 @@
                           <a href="readlist">Reading List Management</a><br/>
                           <a href="storyarc_main">Story Arc Management</a><br/>
                           <a href="importResults">Import Results Management</a>
+                          <a href="cblimport">CBL Import</a>
                         </div>
                     </fieldset>
                 </td>

--- a/data/interfaces/default/storyarc.html
+++ b/data/interfaces/default/storyarc.html
@@ -9,7 +9,8 @@
 <%def name="headerIncludes()">
 	<div id="subhead_container">
 		<div id="subhead_menu">
-                        <a id="menu_link_refresh" href="readlist">Reading List Management</a>
+            <a id="menu_link_refresh" href="cblimport">CBL Import</a>            
+            <a id="menu_link_refresh" href="readlist">Reading List Management</a>
 		</div>
 	</div>	
 </%def>

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -148,6 +148,7 @@ DDL_QUEUE = queue.Queue()
 RETURN_THE_NZBQUEUE = queue.Queue()
 MASS_ADD = None
 ADD_LIST = queue.Queue()
+ISSUE_WATCH_LIST = queue.Queue()
 MASS_REFRESH = None
 REFRESH_QUEUE = queue.Queue()
 DDL_QUEUED = []

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -447,6 +447,9 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'OPDS_METAINFO': (bool, 'OPDS', False),
     'OPDS_PAGESIZE': (int, 'OPDS', 30),
 
+    'CBL_IMPORT_ISSUESONLY' : (bool, 'CBLImport', True),
+    'CBL_IMPORT_IGNOREARCHIVED' : (bool, 'CBLImport', False),
+
 })
 
 _BAD_DEFINITIONS = OrderedDict({

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -48,30 +48,74 @@ def is_exists(comicid):
     else:
         return False
 
-def addvialist(queue):
+def addvialist(seriesQueue, issueWantQueue):
     while True:
-        if queue.qsize() >= 1:
+        if seriesQueue.qsize() >= 1:
             time.sleep(3)
-            item = queue.get(True)
+            item = seriesQueue.get(True)
             if item == 'exit':
                 break
             if item['comicname'] is not None:
                 if item['seriesyear'] is not None:
-                    logger.info('[MASS-ADD][1/%s] Now adding %s (%s) [%s] ' % (queue.qsize()+1, item['comicname'], item['seriesyear'], item['comicid']))
+                    logger.info('[MASS-ADD][1/%s] Now adding %s (%s) [%s] ' % (seriesQueue.qsize()+1, item['comicname'], item['seriesyear'], item['comicid']))
                     mylar.GLOBAL_MESSAGES = {'status': 'success', 'event': 'addbyid', 'comicname': item['comicname'], 'seriesyear': item['seriesyear'], 'comicid': item['comicid'], 'tables': 'None', 'message': 'Now adding %s (%s)' % (urllib.parse.unquote_plus(item['comicname']), item['seriesyear'])}
                 else:
-                    logger.info('[MASS-ADD][1/%s] Now adding %s [%s] ' % (queue.qsize()+1, item['comicname'], item['comicid']))
+                    logger.info('[MASS-ADD][1/%s] Now adding %s [%s] ' % (seriesQueue.qsize()+1, item['comicname'], item['comicid']))
                     mylar.GLOBAL_MESSAGES = {'status': 'success', 'event': 'addbyid', 'comicname': item['comicname'], 'seriesyear': item['seriesyear'], 'comicid': item['comicid'], 'tables': 'None', 'message': 'Now adding %s' % (urllib.parse.unquote_plus(item['comicname']))}
             else:
-                logger.info('[MASS-ADD][1/%s] Now adding ComicID: %s ' % (queue.qsize()+1, item['comicid']))
+                logger.info('[MASS-ADD][1/%s] Now adding ComicID: %s ' % (seriesQueue.qsize()+1, item['comicid']))
                 mylar.GLOBAL_MESSAGES = {'status': 'success', 'event': 'addbyid', 'comicname': item['comicname'], 'seriesyear': item['seriesyear'], 'comicid': item['comicid'], 'tables': 'None', 'message': 'Now adding via ComicID %s' % (item['comicid'])}
 
-            addComictoDB(item['comicid'])
+            if 'suppress_addall' in item.keys():
+                addComictoDB(item['comicid'], suppress_addall=item['suppress_addall'])
+            else:
+                addComictoDB(item['comicid'])
+        elif issueWantQueue.qsize() > 0:
+            time.sleep(1)
+            issueItem = issueWantQueue.get(True)
+            markIssueWantedById(issueItem)
         else:
             mylar.ADD_LIST.put('exit')
     return False
 
-def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=None, calledfrom=None, annload=None, chkwant=None, issuechk=None, issuetype=None, latestissueinfo=None, csyear=None, fixed_type=None):
+def markIssueWantedById(issueId):
+    myDB = db.DBConnection()
+    issue = myDB.selectone("SELECT i.IssueId, c.ComicName, i.Issue_Number, c.ComicID, c.ComicYear, i.Status FROM issues i LEFT JOIN comics c ON i.ComicID=c.ComicID WHERE i.IssueID=?", [issueId]).fetchone()
+    annual_check = False
+    if issue is None:
+        issue = myDB.selectone("SELECT a.IssueId, c.ComicName, a.ReleaseComicName, a.Issue_Number, c.ComicID, c.ComicYear, a.Status FROM annuals a LEFT JOIN comics c ON a.ComicID=c.ComicID WHERE a.IssueID=? AND NOT a.Deleted", [issueId]).fetchone()
+        if issue is None:
+            logger.warning(f'Tried setting wanted status for issue with ID {issueId} in MASS-ADD thread but could not find issue')
+            return
+        else:
+            annual_check = True
+            comicname = issue['ReleaseComicName']
+            issuenumber = issue['Issue_Number']
+            comicid = issue['ComicID']
+    else:
+        comicname = issue['ComicName']
+        issuenumber = issue['Issue_Number']
+        comicid = issue['ComicID']
+
+    match issue['Status']:
+        case 'Downloaded' | 'Wanted' | 'Snatched' | 'Failed':
+            logger.info(f"Tried setting wanted status for {comicname} [ID:{comicid}] issue #{issuenumber} in MASS-ADD thread but it is already in the {issue['Status']} state")
+            return
+        case _:
+            logger.info(f"Changing status of {comicname} [ID:{comicid}] issue #{issuenumber} from {issue['Status']} to Wanted")
+
+    controlValueDict = {'IssueID' : issueId}
+    newValueDict = {'Status' : 'Wanted'}
+
+    if annual_check:
+        myDB.upsert("annuals", newValueDict, controlValueDict)
+    else:
+        myDB.upsert("issues", newValueDict, controlValueDict)
+
+    logger.fdebug(f"Finished changing status of {comicname} [ID:{comicid}] issue #{issuenumber} to Wanted")
+    
+
+def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=None, calledfrom=None, annload=None, chkwant=None, issuechk=None, issuetype=None, latestissueinfo=None, csyear=None, fixed_type=None, suppress_addall=None):
     myDB = db.DBConnection()
 
     controlValueDict = {"ComicID":     comicid}
@@ -505,11 +549,11 @@ def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=No
         if issued is None:
             logger.warn('Unable to retrieve data from ComicVine. Get your own API key already!')
             return {'status': 'incomplete'}
-    logger.info('Sucessfully retrieved issue details for ' + comic['ComicName'])
+    logger.info('Successfully retrieved issue details for ' + comic['ComicName'])
 
     #move to own function so can call independently to only refresh issue data
     #issued is from cv.getComic, comic['ComicName'] & comicid would both be already known to do independent call.
-    updateddata = updateissuedata(comicid, comic['ComicName'], issued, comicIssues, calledfrom, SeriesYear=SeriesYear, latestissueinfo=latestissueinfo, serieslast_updated=serieslast_updated, series_status=series_status)
+    updateddata = updateissuedata(comicid, comic['ComicName'], issued, comicIssues, calledfrom, SeriesYear=SeriesYear, latestissueinfo=latestissueinfo, serieslast_updated=serieslast_updated, series_status=series_status, suppress_addall=suppress_addall)
     try:
         if updateddata['status'] == 'failure':
             logger.warn('Unable to properly retrieve issue details - this is usually due to either irregular issue numbering, or problems with CV')
@@ -903,7 +947,7 @@ def GCDimport(gcomicid, pullupd=None, imported=None, ogcname=None):
     if pullupd is None:
         helpers.ComicSort(sequence='update')
 
-    logger.info("Sucessfully retrieved issue details for " + ComicName)
+    logger.info("Successfully retrieved issue details for " + ComicName)
     n = 0
     iscnt = int(comicIssues)
     issnum = []
@@ -1060,7 +1104,7 @@ def GCDimport(gcomicid, pullupd=None, imported=None, ogcname=None):
         logger.info("Finished grabbing what I could.")
 
 
-def issue_collection(issuedata, nostatus, serieslast_updated=None):
+def issue_collection(issuedata, nostatus, serieslast_updated=None, suppress_addall=None):
     #make sure serieslast_updated is in the correct format
     try:
         serieslast_updated = datetime.datetime.strptime(serieslast_updated, "%Y-%m-%d %H:%M:%S").strftime('%Y-%m-%d')
@@ -1130,7 +1174,7 @@ def issue_collection(issuedata, nostatus, serieslast_updated=None):
                             newValueDict['Status'] = "Skipped"
                             logger.fdebug('[PAUSE-CHECK-ISSUE-STATUS] Series is paused, setting status for new issue #%s to Skipped' % (issue['Issue_Number']))
                         else:
-                            if mylar.CONFIG.AUTOWANT_ALL:
+                            if mylar.CONFIG.AUTOWANT_ALL and not suppress_addall:
                                 newValueDict['Status'] = "Wanted"
                             elif serieslast_updated is None:
                                 #logger.fdebug('serieslast_update is None. Setting to Skipped')
@@ -1277,7 +1321,7 @@ def manualAnnual(manual_comicid=None, comicname=None, comicyear=None, comicid=No
     return
 
 
-def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, calledfrom=None, issuechk=None, issuetype=None, SeriesYear=None, latestissueinfo=None, serieslast_updated=None, series_status=None):
+def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, calledfrom=None, issuechk=None, issuetype=None, SeriesYear=None, latestissueinfo=None, serieslast_updated=None, series_status=None, suppress_addall=None):
     annualchk = []
     weeklyissue_check = []
     db_already_open = False
@@ -1602,10 +1646,10 @@ def updateissuedata(comicid, comicname=None, issued=None, comicIssues=None, call
         #if calledfrom == 'weeklycheck':
         if len(issuedata) >= 1 and not calledfrom  == 'dbupdate':
             logger.fdebug('initiating issue updating - info & status')
-            issue_collection(issuedata, nostatus='False', serieslast_updated=serieslast_updated)
+            issue_collection(issuedata, nostatus='False', serieslast_updated=serieslast_updated, suppress_addall=suppress_addall)
         else:
             logger.fdebug('initiating issue updating - just the info')
-            issue_collection(issuedata, nostatus='True', serieslast_updated=serieslast_updated)
+            issue_collection(issuedata, nostatus='True', serieslast_updated=serieslast_updated, suppress_addall=suppress_addall)
 
         styear = str(SeriesYear)
         if firstdate is not None:
@@ -1978,10 +2022,17 @@ def importer_thread(serieslist):
 
     if threaded_call is True:
         logger.info('[MASS-ADD] MASS_ADD thread not started. Started & submitting.')
-        mylar.MASS_ADD = threading.Thread(target=addvialist, args=(mylar.ADD_LIST,), name="mass-add")
+        mylar.MASS_ADD = threading.Thread(target=addvialist, args=(mylar.ADD_LIST, mylar.ISSUE_WATCH_LIST), name="mass-add")
         mylar.MASS_ADD.start()
         if not mylar.MASS_ADD:
             mylar.MASS_ADD.join(5)
+
+def issue_watcher_thread(issuelist):
+    # Issues to be watched in the future but are waiting for MASS_ADD to complete the serieslist backlog
+    if type(issuelist) != list:
+        issuelist = [issuelist]
+
+    list(map(mylar.ISSUE_WATCH_LIST.put, issuelist))
 
 
 def refresh_thread(serieslist):

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -35,6 +35,8 @@ from mako.template import Template
 from mako.lookup import TemplateLookup
 from mako import exceptions
 
+import traceback
+
 import time
 import random
 import threading
@@ -45,6 +47,8 @@ import shutil
 import fnmatch
 import simplejson as simplejson
 from operator import itemgetter
+
+import xml.etree.ElementTree as ET
 
 import mylar
 from mylar import (
@@ -1381,7 +1385,7 @@ class WebInterface(object):
         raise cherrypy.HTTPRedirect("comicDetails?ComicID=%s" % comicid)
     addComic.exposed = True
 
-    def addbyid(self, comicid, calledby=None, imported=None, ogcname=None, nothread=False, seriesyear=None, query_id=None, com_location=None, booktype=None, markupcoming=None, markall=None):
+    def addbyid(self, comicid, calledby=None, imported=None, ogcname=None, nothread=False, seriesyear=None, query_id=None, com_location=None, booktype=None, markupcoming=None, markall=None, suppress_addall=None):
         mismatch = "no"
         if com_location == 'null':
             com_location = None
@@ -1476,7 +1480,10 @@ class WebInterface(object):
             watch = []
             #if not any(ext['comicid'] == ComicID for ext in mylar.REFRESH_LIST):
             if not {"comicid": comicid, "comicname": ogcname} in mylar.ADD_LIST.queue:
-                watch.append({"comicid": comicid, "comicname": ogcname, "seriesyear": seriesyear})
+                comic_request = {"comicid": comicid, "comicname": ogcname, "seriesyear": seriesyear}
+                if suppress_addall:
+                    comic_request['suppress_addall'] = suppress_addall
+                watch.append(comic_request)
 
             if len(watch) > 0:
                 if all([ogcname != 'None', ogcname is not None]):
@@ -4345,6 +4352,10 @@ class WebInterface(object):
 
         return serve_template(templatename="managefailed.html", title="Failed DB Management", failed=results)
     manageFailed.exposed = True
+
+    def cblimport(self):
+        return serve_template(templatename="cblimport.html", title="CBL Import")
+    cblimport.exposed = True
 
     def flushImports(self):
         myDB = db.DBConnection()
@@ -9491,3 +9502,238 @@ class WebInterface(object):
             linemsg = 'Successfully Paused %s (%s) due to CV removal' % (comicname, comicyear)
             return json.dumps({'status': 'success', 'message': linemsg})
     fix_cv_removed.exposed = True
+
+    def checkCBLFile(self, cblFile, ignorearchived=False, issuesonly=False):
+        try:
+            cblXML = ET.parse(cblFile.file)
+            cblRoot = cblXML.getroot()
+        except ET.ParseError as e:
+            return json.dumps({'status': 'error', 'message' : f'XML Parsing Error: {e}'})            
+        
+        # Formdata only sends strings ...
+        ignorearchived = True if ignorearchived == 'true' else False
+        issuesonly = True if issuesonly == 'true' else False
+
+        results = []
+
+        try:
+            books = cblRoot.findall(".//Book")
+            # Using this to try to reduce unnecessary repeat DB calls.  Alternatively, could pre-pull a single call from Issues and reference that.  Potato potato.
+            volume_cache = {}
+            newvol_count = 0
+            missing_issue_count = 0
+
+            # Debatable whether it's worth doing this validation in its own loop to avoid wasted DB calls.
+            for book in books:
+                databaseEntry = book.find(".//Database[@Name='cv']")
+                if databaseEntry is None:
+                    return json.dumps({'status': 'error', 'message' : f'CBL Processing Error: No CV identifiers for entry {books.index(book)}'})            
+
+            myDB = db.DBConnection()
+
+            for book in books:
+                databaseEntry = book.find(".//Database[@Name='cv']")
+                
+                issueIndex = books.index(book)
+                volumeName = book.get('Series')
+                volumeYear = book.get('Volume')
+                issueNumber = book.get('Number')
+                cvSeriesID = databaseEntry.get('Series')
+                cvIssueID = databaseEntry.get('Issue')
+
+                if cvSeriesID in volume_cache.keys():
+                    vol_exists = volume_cache[cvSeriesID]
+                else:
+                    comic = myDB.selectone('SELECT * FROM comics WHERE ComicID=?', [cvSeriesID]).fetchone()
+                    vol_exists = False if comic is None else True
+                    volume_cache[cvSeriesID] = vol_exists
+                    if not vol_exists:
+                        newvol_count += 1
+                
+                if vol_exists:
+                    issue = myDB.selectone('SELECT * FROM issues WHERE IssueID=?', [cvIssueID]).fetchone()
+
+                    # Check in case the issue is an integrated annual
+                    if issue is None:
+                        issue = myDB.selectone('SELECT * FROM annuals WHERE IssueID=?', [cvIssueID]).fetchone()
+
+                    iss_exists = False if issue is None else True
+
+                    if iss_exists:
+                        iss_status = issue['Status']
+                        
+                        match iss_status:
+                            case 'Downloaded' | 'Wanted' | 'Snatched' | 'Failed':
+                                action_text = 'No action needed'
+                            case 'Archived':
+                                if ignorearchived :
+                                    action_text = 'No action needed' 
+                                else:
+                                    action_text = "Mark issue as Wanted"
+                                    missing_issue_count += 1
+                            case _:
+                                missing_issue_count += 1
+                                action_text = 'Mark issue as Wanted'
+                else:
+                    iss_exists = False
+                    iss_status = 'Missing'
+                    missing_issue_count += 1
+                    action_text = 'Add volume & mark issue as Wanted'
+                
+
+                # List to return to import table display: Entry, Volume, Issue, Status, Action
+                results.append([issueIndex, 
+                                f'<a href="{"comicDetails?ComicID=" if vol_exists else "https://comicvine.com/volume/4050-"}{cvSeriesID}" target="{"_self" if vol_exists else "_blank"}">{volumeName} ({volumeYear})</a>',
+                                issueNumber,
+                                iss_status,
+                                action_text])
+
+        except Exception as e:
+            return json.dumps({'status': 'error', 'message' : f'Error processing CBL file.  Unhandled Exception: {str(e)}'})
+        
+        if newvol_count > 200:
+            warning_text = 'Attempting to add more than 200 series may cause problems due to CV API limits.  Consider breaking up this list into smaller parts.'
+        elif newvol_count > 100:
+            warning_text = 'Attempting to add a lot of new series.  Consider your CV API limits before triggering the import.'
+        else:
+            warning_text = ''
+
+        return json.dumps({'status': 'success', 'warning_text' : warning_text, 'missing_volumes' : newvol_count, 'missing_issues' : missing_issue_count, 'results' : results,
+                           'message' : f'''CBL File "{cblFile.filename}" read successfully <br >
+                           <br >
+                           Total Volumes: {len(volume_cache.keys())} <br >                           
+                           Missing Volumes: {newvol_count} <br >
+                           <br >
+                           Total Issues: {len(results)} <br >
+                           Issues Not Currently Wanted: {missing_issue_count} <br >'''})
+    
+    checkCBLFile.exposed = True
+
+    # Assume this has been validated by check function
+    def processCBLFile(self, cblFile, ignorearchived=False, issuesonly=False):
+        # Track the volumes as they're added or queued
+        volume_index = {}
+        counters = {'volumes_added' : 0, 'issues_watched' : 0, 'issues_to_be_watched' : 0, 'issues_skipped' : 0}
+
+        # Formdata only sends strings ...
+        ignorearchived = True if ignorearchived == 'true' else False
+        issuesonly = True if issuesonly == 'true' else False
+
+        logger.info(f'Processing CBL File {cblFile.filename} to set up volumes and wanted issues')
+        warning_text = ''
+        warnings = {}
+
+        try:
+            cblXML = ET.parse(cblFile.file)
+            cblRoot = cblXML.getroot()
+        except ET.ParseError as e:
+            return json.dumps({'status': 'error', 'message' : f'XML Parsing Error: {e}', 'warning_text' : warning_text})
+            
+        try:
+            books = cblRoot.findall(".//Book")
+            
+            myDB = db.DBConnection()
+            
+            # Process the CBL File and build a dictionary of Wanted Issue IDs keyed on the ComicID
+            for book in books:
+                databaseEntry = book.find(".//Database[@Name='cv']")
+                if databaseEntry is None:
+                    return json.dumps({'status': 'error', 'message' : f'CBL Processing Error: No CV identifiers for entry {books.index(book)}', 'warning_text' : warning_text})            
+                
+                volumeName = book.get('Series')
+                volumeYear = book.get('Volume')
+                issueNumber = book.get('Number')
+                cvSeriesID = databaseEntry.get('Series')
+                cvIssueID = databaseEntry.get('Issue')
+
+                checkIssue = False
+                if cvSeriesID in volume_index.keys():
+                    # If we've seen this volume before, and already marked it for adding
+                    if volume_index[cvSeriesID]['NewVol']:
+                        logger.fdebug(f'CBL File: Volume "{volumeName} ({volumeYear})" to be added, Issue #{issueNumber} to be marked as Wanted')
+                        counters['issues_to_be_watched'] += 1
+                        # If Auto Want is on and not suppressed, we can avoid queueing this for addition
+                        if (issuesonly and mylar.CONFIG.AUTOWANT_ALL) or not mylar.CONFIG.AUTOWANT_ALL:
+                            volume_index[cvSeriesID]['IssueIDs'].append(cvIssueID)
+                    else:
+                        checkIssue = True
+                else:
+                    volume = myDB.selectone('SELECT * FROM comics WHERE ComicID=?', [cvSeriesID]).fetchone()
+                    if volume is None:
+                        logger.fdebug(f'CBL File: Volume "{volumeName} ({volumeYear})" does not exist exist.  Adding Volume, and Issue #{issueNumber} to be marked as Wanted')
+                        
+                        issueList = []
+                        # If Auto Want is on and not suppressed, we can avoid queueing this for addition
+                        if (issuesonly and mylar.CONFIG.AUTOWANT_ALL) or not mylar.CONFIG.AUTOWANT_ALL:
+                            issueList.append(cvIssueID)
+                        
+                        volume_index[cvSeriesID] = {'NewVol' : True, 'VolumeName' : volumeName, 'VolumeYear' : volumeYear, 'IssueIDs' : issueList}
+                        counters['volumes_added'] += 1
+                        counters['issues_to_be_watched'] += 1
+                    else:
+                        volume_index[cvSeriesID] = {'NewVol' : False, 'VolumeName' : volumeName, 'VolumeYear' : volumeYear, 'IssueIDs' : []}
+                        checkIssue = True
+                    
+                if checkIssue:
+                    issue = myDB.selectone('SELECT * FROM issues WHERE IssueID=?', [cvIssueID]).fetchone()
+
+                    # Check in case the issue is an integrated annual
+                    if issue is None:
+                        issue = myDB.selectone('SELECT * FROM annuals WHERE IssueID=?', [cvIssueID]).fetchone()
+
+                    if issue is None:
+                        logger.warning(f'CBL File: Volume "{volumeName} ({volumeYear})" exists but could not find Issue #{issueNumber} with ID {cvIssueID}')
+                        warnings.add(f'Some issues of existing volumes could not be found.  Check logs for details.')
+                    else:
+                        wantissue = False
+                        match issue['Status']:
+                            case 'Downloaded' | 'Wanted' | 'Snatched' | 'Failed':
+                                logger.fdebug(f'CBL File: Volume "{volumeName} ({volumeYear})" exists, Issue #{issueNumber} already Wanted')
+                                counters['issues_skipped'] += 1
+                            case 'Archived':
+                                if ignorearchived :
+                                    logger.fdebug(f'CBL File: Volume "{volumeName} ({volumeYear})" exists, Issue #{issueNumber} Archived.  Ignoring')
+                                    counters['issues_skipped'] += 1
+                                else:
+                                    wantissue = True
+                            case _:
+                                wantissue = True
+                        
+                        if wantissue:
+                            logger.fdebug(f'CBL File: Volume "{volumeName} ({volumeYear})" already exists, Issue #{issueNumber} to be marked as Wanted')
+                            counters['issues_watched'] += 1
+                            volume_index[cvSeriesID]['IssueIDs'].append(cvIssueID)
+
+            # No more holding back, let's get this stuff queued!
+            logger.fdebug(f"Finished analysing CBL File, adding volumes and issues to MASS-ADD queues")
+            for comicId,data in volume_index.items():
+                if data['NewVol']:
+                    comic_request = [{"comicid": comicId, "comicname": data['VolumeName'], "seriesyear": data['VolumeYear'], 'suppress_addall' : (issuesonly and mylar.CONFIG.AUTOWANT_ALL)}]
+                    importer.importer_thread(comic_request)
+
+                if len(data['IssueIDs']) > 0:
+                    importer.issue_watcher_thread(data['IssueIDs'])
+
+
+            # Give the MASS-ADD thread a little nudge in case it's not been started as we added no volumes
+            importer.importer_thread([])
+
+        except Exception as e:
+            logger.fdebug(f"Unhandled exception when processing CBL Reading List {cblFile.filename}:\n {traceback.format_exc()}")
+            return json.dumps({'status' : 'error', 'message' : f"Unhandled exception when processing CBL Reading List {cblFile.filename}: {str(e)}", 'warning_text' : warning_text})
+
+        logger.fdebug(f"Saving CBL import settings: CBL_IMPORT_ISSUESONLY={issuesonly}, CBL_IMPORT_IGNORE_ARCHIVED={ignorearchived}")
+        mylar.CONFIG.CBL_IMPORT_ISSUESONLY = issuesonly
+        mylar.CONFIG.CBL_IMPORT_IGNOREARCHIVED = ignorearchived
+        mylar.CONFIG.writeconfig(values={'CBL_IMPORT_ISSUESONLY': mylar.CONFIG.CBL_IMPORT_ISSUESONLY, 'CBL_IMPORT_IGNOREARCHIVED': mylar.CONFIG.CBL_IMPORT_IGNOREARCHIVED})
+
+        warning_text = '<br >'.join(warnings)
+        return json.dumps({'status': 'success', 'message' : f'''CBL File "{cblFile.filename}" fully imported <br >
+                           <br >
+                           Issues Already Watched: {counters['issues_skipped']} <br > 
+                           Existing Volume Issues to Watch: {counters['issues_watched']} <br >
+                           New Volumes Queued to Add: {counters['volumes_added']} <br >
+                           New Volume Issues to Watch: {counters['issues_to_be_watched']} <br > ''', 
+                           'warning_text' : warning_text})
+
+    processCBLFile.exposed = True


### PR DESCRIPTION
A new screen for importing CBL reading lists.  Depends on lists that are well populated with CV ID data (i.e. it doesn't attempt any lookup by names).

- Accessible via either Manage->Advanced->CBL Import or StoryArcs->CBL Import
- Uses the MASS-ADD queue to add series and then toggle wanted status for issues once it is dry
- Does not actively prevent someone trying to add more than the CV limit, but does offer some warnings at >100 or >200 volumes being added in one list
- Options to suppress autowant-all when adding volumes if it is enabled in settings (default is to do so)

Couple of random little typo fixes buried in there as well.