### PR TITLE
FIX: More stuck SAB downloads due to PP statuses

### DIFF
--- a/mylar/sabnzbd.py
+++ b/mylar/sabnzbd.py
@@ -276,7 +276,7 @@ class SABnzbd(object):
                 elif hq['nzo_id'] == sendresponse:
                     nzo_exists = True
                     logger.fdebug('nzo_id: %s found while processing queue in an unhandled status: %s' % (hq['nzo_id'], hq['status']))
-                    if any([hq['status'] == 'Queued', hq['status'] == 'Moving', hq['status'] == 'Extracting']) and roundtwo is False:
+                    if hq['Status'] in ['Queued', 'Moving', 'Extracting', 'QuickCheck', 'Repairing', 'Verifying'] and not roundtwo:
                         logger.fdebug('[%s(%s)] sleeping for %ss to allow the process to finish before trying again..' % (hq['status'], extract_counter, mylar.CONFIG.SAB_MOVING_DELAY))
                         time.sleep(mylar.CONFIG.SAB_MOVING_DELAY)
                         if hq['status'] == 'Extracting':


### PR DESCRIPTION
Some people (myself included) have reported downloads still getting stuck.  Managed to catch one that fell through the net - it was in the Verifying state.  I've added some more status codes to your previous fix to account for this.

Selected status codes based on the PP status strings here: https://github.com/sabnzbd/sabnzbd/blob/872cf835dfa1daeec43cddb0bc8377434c14bfde/sabnzbd/constants.py#L168

I left Fetching off the list as from reading my assumption is that should end up back in the queue API call.  I may be wrong.  Going to run this as my daily for a week or so to see if any still get stuck.