### PR TITLE
FIX: RSS feed fixes

### DIFF
--- a/mylar/rsscheck.py
+++ b/mylar/rsscheck.py
@@ -552,7 +552,7 @@ def nzbs(provider=None, forcerss=False):
                           'num':       '100'}
 
                 check = _parse_feed(site, url, bool(int(newznab_host[2])), params)
-                if check is False and 'rss' in url[-3:]:
+                if not check:
                     logger.fdebug('RSS url returning 403 error. Attempting to use API to get most recent items in lieu of RSS feed')
                     url = newznab_host[1].rstrip() + '/api'
                     params = {'t':         'search',
@@ -560,6 +560,7 @@ def nzbs(provider=None, forcerss=False):
                               'dl':        '1',
                               'apikey':    newznab_host[3].rstrip(),
                               'num':       '100'}
+                    
                     check = _parse_feed(site, url, bool(int(newznab_host[2])), params)
                 if check == 'disable':
                     helpers.disable_provider(site)
@@ -591,7 +592,9 @@ def nzbs(provider=None, forcerss=False):
                     link = entry.link
 
                     #Remove the API keys from the url to allow for possible api key changes
-                    link = link[:link.find('&i=')].strip()
+                    filter_patterns = ['&i=[0-9a-zA-Z]+', '&r=[0-9a-zA-Z]+']
+                    for pattern in filter_patterns:
+                        link = re.sub(pattern, '', link).strip()
 
                 feeddata.append({'Site': site,
                                  'Title': titlename,


### PR DESCRIPTION
Two issues fixed:
- RSS feeds that return a link with no &i or &r parameter were getting a character dropped by the str.find call, resulting in failed downloads as inevitably the API key was dropped.
- _parse_feed returns either None (on failure) or a string.  It's never a boolean, so the check for a problem URL was never passing (None != False), resulting in sources like althub (which have the RSS feed under a different URL) not working for RSS.  The string check was redundant as nothing can have changed that variable since those exact characters were added to the end.  The following debug message is arguably inaccurate (althub throws a 404 for example), but 🤷

An argument could be made whether it would be better to store the correct rss URL for newznab sources in config for each source and use that instead of defaulting to an API call, but realistically I doubt one call is any different in terms of speed/resource usage than the other as it'll all be the same ask on the other side of the service.  OTOH, if that's the case, why even bother with RSS at all, why not just do regular API calls to the search endpoint and use those?  Do some providers do caching of the RSS feed per category?  Is the search endpoint guaranteed to return in descending published order?