### PR TITLE
FIX: SQLite3 single quoted string literals

### DIFF
--- a/mylar/api.py
+++ b/mylar/api.py
@@ -342,20 +342,20 @@ class Api(object):
         else:
             self.id = kwargs['id']
 
-        comicQuery = '{select} WHERE ComicID="{id}" ORDER BY ComicSortName COLLATE NOCASE'.format(
+        comicQuery = "{select} WHERE ComicID='{id}' ORDER BY ComicSortName COLLATE NOCASE".format(
             select = self._selectForComics(),
             id = self.id
         )
         comic = self._resultsFromQuery(comicQuery)
 
-        issuesQuery = '{select} WHERE ComicID="{id}" ORDER BY Int_IssueNumber DESC'.format(
+        issuesQuery = "{select} WHERE ComicID='{id}' ORDER BY Int_IssueNumber DESC".format(
             select = self._selectForIssues(),
             id = self.id
         )
         issues = self._resultsFromQuery(issuesQuery)
 
         if mylar.CONFIG.ANNUALS_ON:
-            annualsQuery = '{select} WHERE ComicID="{id}"'.format(
+            annualsQuery = "{select} WHERE ComicID='{id}'".format(
                 select = self._selectForAnnuals(),
                 id = self.id
             )
@@ -454,15 +454,15 @@ class Api(object):
 
         try:
             myDB = db.DBConnection()
-            delchk = myDB.selectone('SELECT ComicName, ComicYear, ComicLocation FROM comics where ComicID="' + self.id + '"').fetchone()
+            delchk = myDB.selectone(f"SELECT ComicName, ComicYear, ComicLocation FROM comics where ComicID='{self.id}'").fetchone()
             if not delchk:
                 logger.error('ComicID %s not found in watchlist.' %  self.id)
                 self.data = self._failureResponse('ComicID %s not found in watchlist.' % self.id)
                 return
             logger.fdebug('Deletion request received for %s (%s) [%s]' % (delchk['ComicName'], delchk['ComicYear'], self.id))
-            myDB.action('DELETE from comics WHERE ComicID="' + self.id + '"')
-            myDB.action('DELETE from issues WHERE ComicID="' + self.id + '"')
-            myDB.action('DELETE from upcoming WHERE ComicID="' + self.id + '"')
+            myDB.action(f"DELETE from comics WHERE ComicID='{self.id}'")
+            myDB.action(f"DELETE from issues WHERE ComicID='{self.id}'")
+            myDB.action(f"DELETE from upcoming WHERE ComicID='{self.id}'")
             if directory_del is True:
                 if os.path.exists(delchk['ComicLocation']):
                     shutil.rmtree(delchk['ComicLocation'])
@@ -604,7 +604,7 @@ class Api(object):
             if comicid.startswith('4050-'):
                 comicid = re.sub('4050-', '', comicid).strip()
 
-            chkdb = myDB.selectone('SELECT ComicName, ComicYear FROM comics WHERE ComicID="' + comicid + '"').fetchone()
+            chkdb = myDB.selectone(f"SELECT ComicName, ComicYear FROM comics WHERE ComicID='{comicid}'").fetchone()
             if not chkdb:
                 notfound.append({'comicid': comicid})
             else:
@@ -665,7 +665,7 @@ class Api(object):
             booktype = booktype.lower()
 
         myDB = db.DBConnection()
-        btresp = myDB.selectone('SELECT ComicName, ComicYear, Type, Corrected_Type FROM Comics WHERE ComicID="' + self.id +'"').fetchone()
+        btresp = myDB.selectone(f"SELECT ComicName, ComicYear, Type, Corrected_Type FROM Comics WHERE ComicID='{self.id}'").fetchone()
         if not btresp:
             self.data = self._failureResponse('Unable to locate ComicID %s within watchlist' % self.id)
             return
@@ -1043,7 +1043,7 @@ class Api(object):
                 return
         else:
             # If we cant find the image, lets check the db for a url.
-            comic = self._resultsFromQuery('SELECT * from comics WHERE ComicID="' + self.id + '"')
+            comic = self._resultsFromQuery(f"SELECT * from comics WHERE ComicID='{self.id}'")
 
             # Try every img url in the db
             try:
@@ -1098,7 +1098,7 @@ class Api(object):
 
         self.id = id
         # Fetch a list of dicts from issues table
-        i = self._resultsFromQuery('SELECT * from issues WHERE issueID="' + self.id + '"')
+        i = self._resultsFromQuery(f"SELECT * from issues WHERE issueID='{self.id}'")
 
         if not len(i):
             self.data = self._failureResponse('Couldnt find a issue with issueID %s' % self.id)
@@ -1112,7 +1112,7 @@ class Api(object):
         # Check the issue is downloaded
         if issuelocation is not None:
             # Find the comic location
-            comic = self._resultsFromQuery('SELECT * from comics WHERE comicID="' + issue['ComicID'] + '"')[0]
+            comic = self._resultsFromQuery(f"SELECT * from comics WHERE comicID='{issue['ComicID']}'")[0]
             comiclocation = comic.get('ComicLocation')
             f = os.path.join(comiclocation, issuelocation)
             if not os.path.isfile(f):
@@ -1154,13 +1154,13 @@ class Api(object):
     def _getStoryArc(self, **kwargs):
         if not 'id' in kwargs:
             if 'customOnly' in kwargs and kwargs['customOnly']:
-                self.data = self._resultsFromQuery('SELECT StoryArcID, StoryArc, MAX(ReadingOrder) AS HighestOrder from storyarcs WHERE StoryArcID LIKE "C%" GROUP BY StoryArcID ORDER BY StoryArc')
+                self.data = self._resultsFromQuery("SELECT StoryArcID, StoryArc, MAX(ReadingOrder) AS HighestOrder from storyarcs WHERE StoryArcID LIKE 'C%' GROUP BY StoryArcID ORDER BY StoryArc")
             else:
-                self.data = self._resultsFromQuery('SELECT StoryArcID, StoryArc, MAX(ReadingOrder) AS HighestOrder from storyarcs GROUP BY StoryArcID ORDER BY StoryArc')
+                self.data = self._resultsFromQuery("SELECT StoryArcID, StoryArc, MAX(ReadingOrder) AS HighestOrder from storyarcs GROUP BY StoryArcID ORDER BY StoryArc")
         else:
             self.id = kwargs['id']
-            self.data = self._resultsFromQuery('SELECT StoryArc, ReadingOrder, ComicID, ComicName, IssueNumber, IssueID, \
-                                            IssueDate, IssueName, IssuePublisher from storyarcs WHERE StoryArcID="' + self.id + '" ORDER BY ReadingOrder')
+            self.data = self._resultsFromQuery(f"SELECT StoryArc, ReadingOrder, ComicID, ComicName, IssueNumber, IssueID, \
+                                               IssueDate, IssueName, IssuePublisher from storyarcs WHERE StoryArcID='{self.id}' ORDER BY ReadingOrder")
         return
 
     def _addStoryArc(self, **kwargs):
@@ -1174,7 +1174,7 @@ class Api(object):
                 storyarcname = kwargs.pop('storyarcname')
         else:
             self.id = kwargs.pop('id')
-            arc = self._resultsFromQuery('SELECT * from storyarcs WHERE StoryArcID="' + self.id + '" ORDER by ReadingOrder')
+            arc = self._resultsFromQuery(f"SELECT * from storyarcs WHERE StoryArcID='{self.id}' ORDER by ReadingOrder")
             storyarcname = arc[0]['StoryArc']
             issuecount = len(arc)
         if not 'issues' in kwargs and not 'arclist' in kwargs:
@@ -1930,10 +1930,10 @@ class REST(object):
                     else:
                         return('No Comic with the ID %s :-(' % comic_id)
                 elif issuemode == 'issues':
-                    self.issues = self._dic_from_query('SELECT * from issues where comicid="' + comic_id + '"')
+                    self.issues = self._dic_from_query(f"SELECT * from issues where comicid='{comic_id}'")
                     return json.dumps(self.issues, ensure_ascii=False)
                 elif issuemode == 'issue' and issue_id is not None:
-                    self.issues = self._dic_from_query('SELECT * from issues where comicid="' + comic_id + '" and issueid="' + issue_id + '"')
+                    self.issues = self._dic_from_query(f"SELECT * from issues where comicid='{comic_id}' and issueid='{issue_id}'")
                     return json.dumps(self.issues, ensure_ascii=False)
                 else:
                     return('Nothing to do.')

--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -332,7 +332,7 @@ class FileHandlers(object):
 
     def series_folder_collision_detection(self, comlocation, comicid, booktype, comicyear, volume):
         myDB = db.DBConnection()
-        chk = myDB.select('SELECT * FROM comics WHERE ComicLocation LIKE "%'+comlocation+'%" AND ComicID !=?', [comicid])
+        chk = myDB.select(f"SELECT * FROM comics WHERE ComicLocation LIKE '%{comlocation}%' AND ComicID !=?", [comicid])
 
         tryit = None
         if chk:

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -2840,7 +2840,7 @@ def weekly_info(week=None, year=None, current=None):
 def latestdate_update():
     #import db
     myDB = db.DBConnection()
-    ccheck = myDB.select('SELECT a.ComicID, b.IssueID, a.LatestDate, b.ReleaseDate, b.Issue_Number from comics as a left join issues as b on a.comicid=b.comicid where a.LatestDate < b.ReleaseDate or a.LatestDate like "%Unknown%" group by a.ComicID')
+    ccheck = myDB.select("SELECT a.ComicID, b.IssueID, a.LatestDate, b.ReleaseDate, b.Issue_Number from comics as a left join issues as b on a.comicid=b.comicid where a.LatestDate < b.ReleaseDate or a.LatestDate like '%Unknown%' group by a.ComicID")
     if ccheck is None or len(ccheck) == 0:
         return
     logger.info('Now preparing to update ' + str(len(ccheck)) + ' series that have out-of-date latest date information.')

--- a/mylar/librarysync.py
+++ b/mylar/librarysync.py
@@ -61,7 +61,7 @@ def libraryScan(dir=None, append=False, ComicID=None, ComicName=None, cron=None,
             if any(files.lower().endswith('.' + x.lower()) for x in extensions):
                 comicpath = os.path.join(r, files)
                 if mylar.CONFIG.IMP_PATHS is True:
-                    if myDB.select('SELECT * FROM comics JOIN issues WHERE issues.Status="Downloaded" AND ComicLocation=? AND issues.Location=?', [r, files]):
+                    if myDB.select("SELECT * FROM comics JOIN issues WHERE issues.Status='Downloaded' AND ComicLocation=? AND issues.Location=?", [r, files]):
                         logger.info('Skipped known issue path: %s' % comicpath)
                         continue
 

--- a/mylar/opds.py
+++ b/mylar/opds.py
@@ -371,9 +371,9 @@ class OPDS(object):
         if not comic:
             self.data = self._error_with_message('Comic Not Found')
             return
-        issues = self._dic_from_query('SELECT * from issues WHERE ComicID="' + kwargs['comicid'] + '"order by Int_IssueNumber DESC')
+        issues = self._dic_from_query(f"SELECT * from issues WHERE ComicID='{kwargs['comicid']}' order by Int_IssueNumber DESC")
         if mylar.CONFIG.ANNUALS_ON:
-            annuals = self._dic_from_query('SELECT * FROM annuals WHERE ComicID="' + kwargs['comicid'] + '"')
+            annuals = self._dic_from_query(f"SELECT * FROM annuals WHERE ComicID='{kwargs['comicid']}'")
         else:
             annuals = []
         for annual in annuals:

--- a/mylar/readinglist.py
+++ b/mylar/readinglist.py
@@ -146,7 +146,7 @@ class Readinglist(object):
         sendlist = []
 
         if self.filelist is None:
-            rl = myDB.select('SELECT issues.IssueID, comics.ComicID, comics.ComicLocation, issues.Location FROM readlist LEFT JOIN issues ON issues.IssueID = readlist.IssueID LEFT JOIN comics on comics.ComicID = issues.ComicID WHERE readlist.Status="Added"')
+            rl = myDB.select("SELECT issues.IssueID, comics.ComicID, comics.ComicLocation, issues.Location FROM readlist LEFT JOIN issues ON issues.IssueID = readlist.IssueID LEFT JOIN comics on comics.ComicID = issues.ComicID WHERE readlist.Status='Added'")
             if rl is None:
                 logger.info(module + ' No issues have been marked to be synced. Aborting syncfiles')
                 return

--- a/mylar/rsscheck.py
+++ b/mylar/rsscheck.py
@@ -722,7 +722,7 @@ def ddl_dbsearch(seriesname, issue, comicid=None, nzbprov=None, oneoff=False):
     dsearch_removed = re.sub('\s+', ' ', dsearch_rem2)
     dsearch_seriesname = re.sub('[\'\!\@\#\$\%\:\-\;\/\\=\?\&\.\s\,]', '%', dsearch_removed)
     dsearch = '%' + dsearch_seriesname + '%'
-    dresults = myDB.select('SELECT * FROM rssdb WHERE ComicName like ? COLLATE NOCASE AND Site="DDL(GetComics)"', [dsearch])
+    dresults = myDB.select("SELECT * FROM rssdb WHERE ComicName like ? COLLATE NOCASE AND Site='DDL(GetComics)'", [dsearch])
     ddltheinfo = []
     ddlinfo = {}
     if not dresults:

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -1617,12 +1617,12 @@ def searchforissue(issueid=None, new=False, rsschecker=None, manual=False):
                         and mylar.CONFIG.FAILED_AUTO
                     ):
                         issues_1 = myDB.select(
-                            'SELECT * from issues WHERE Status="Wanted" OR'
-                            ' Status="Failed"'
+                            "SELECT * from issues WHERE Status='Wanted' OR"
+                            " Status='Failed'"
                         )
                     else:
                         issues_1 = myDB.select(
-                            'SELECT * from issues WHERE Status="Wanted"'
+                            "SELECT * from issues WHERE Status='Wanted'"
                         )
                     for iss in issues_1:
                         checkit = searchforissue_checker(
@@ -1673,12 +1673,12 @@ def searchforissue(issueid=None, new=False, rsschecker=None, manual=False):
                             and mylar.CONFIG.FAILED_AUTO
                         ):
                             issues_2 = myDB.select(
-                                'SELECT * from storyarcs WHERE Status="Wanted" OR'
-                                ' Status="Failed"'
+                                "SELECT * from storyarcs WHERE Status='Wanted' OR" 
+                                " Status='Failed'"
                             )
                         else:
                             issues_2 = myDB.select(
-                                'SELECT * from storyarcs WHERE Status="Wanted"'
+                                "SELECT * from storyarcs WHERE Status='Wanted'"
                             )
                         cnt = 0
                         for iss in issues_2:
@@ -1730,12 +1730,11 @@ def searchforissue(issueid=None, new=False, rsschecker=None, manual=False):
                         and mylar.CONFIG.FAILED_AUTO
                     ):
                         issues_3 = myDB.select(
-                            'SELECT * from annuals WHERE Status="Wanted" OR'
-                            ' Status="Failed AND NOT Deleted"'
+                            "SELECT * from annuals WHERE Status IN ('Wanted', 'Failed') AND NOT Deleted"
                         )
                     else:
                         issues_3 = myDB.select(
-                            'SELECT * from annuals WHERE Status="Wanted AND NOT Deleted"'
+                            "SELECT * from annuals WHERE Status='Wanted' AND NOT Deleted"
                         )
                     for iss in issues_3:
                         checkit = searchforissue_checker(

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -64,7 +64,7 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
         if mylar.CONFIG.UPDATE_ENDED:
             logger.info('Updating only Continuing Series (option enabled) - this might cause problems with the pull-list matching for rebooted series')
             comiclist = []
-            completelist = myDB.select('SELECT LatestDate, ComicPublished, ForceContinuing, NewPublish, LastUpdated, ComicID, ComicName, Corrected_SeriesYear, Corrected_Type, ComicYear, Status from comics WHERE Status="Active" or Status="Loading" order by LastUpdated DESC, LatestDate ASC')
+            completelist = myDB.select("SELECT LatestDate, ComicPublished, ForceContinuing, NewPublish, LastUpdated, ComicID, ComicName, Corrected_SeriesYear, Corrected_Type, ComicYear, Status from comics WHERE Status='Active' or Status='Loading' order by LastUpdated DESC, LatestDate ASC")
             for comlist in completelist:
                 if comlist['LatestDate'] is None:
                     recentstatus = 'Loading'
@@ -98,7 +98,7 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
                                       "Corrected_Type":        comlist['Corrected_Type']})
 
         else:
-            comiclist = myDB.select('SELECT LatestDate, LastUpdated, ComicID, ComicName, ComicYear, Corrected_SeriesYear, Corrected_Type, Status from comics WHERE Status="Active" or Status="Loading" order by LastUpdated DESC, latestDate ASC')
+            comiclist = myDB.select("SELECT LatestDate, LastUpdated, ComicID, ComicName, ComicYear, Corrected_SeriesYear, Corrected_Type, Status from comics WHERE Status='Active' or Status='Loading' order by LastUpdated DESC, latestDate ASC")
     else:
         comiclist = []
         comiclisting = ComicIDList

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -2030,7 +2030,7 @@ class WebInterface(object):
                 myDB.action('DELETE from annuals WHERE ComicID=?', [ComicID])
             myDB.action('DELETE from upcoming WHERE ComicID=?', [ComicID])
             myDB.action('DELETE from readlist WHERE ComicID=?', [ComicID])
-            myDB.action('UPDATE weekly SET Status="Skipped" WHERE ComicID=? AND Status="Wanted"', [ComicID])
+            myDB.action("UPDATE weekly SET Status='Skipped' WHERE ComicID=? AND Status='Wanted'", [ComicID])
             if delete_dir: #mylar.CONFIG.DELETE_REMOVE_DIR:
                 logger.fdebug('Remove directory on series removal enabled.')
                 if seriesdir is not None:
@@ -4424,7 +4424,7 @@ class WebInterface(object):
                     DynamicName = v
                     if volume is None or volume == 'None':
                         logger.info('Removing ' + ComicName + ' from the Import list')
-                        myDB.action('DELETE from importresults WHERE DynamicName=? AND (Volume is NULL OR Volume="None")', [DynamicName])
+                        myDB.action("DELETE from importresults WHERE DynamicName=? AND (Volume is NULL OR Volume='None')", [DynamicName])
                     else:
                         logger.info('Removing ' + ComicName + ' [' + str(volume) + '] from the Import list')
                         myDB.action('DELETE from importresults WHERE DynamicName=? AND Volume=?', [DynamicName, volume])
@@ -6160,7 +6160,7 @@ class WebInterface(object):
             logname = ComicName + '[' + str(volume) + ']'
         logger.info("Removing import data for Comic: " + logname)
         if volume is None or volume == 'None':
-            myDB.action('DELETE from importresults WHERE DynamicName=? AND Status=? AND (Volume is NULL OR Volume="None")', [DynamicName, Status])
+            myDB.action("DELETE from importresults WHERE DynamicName=? AND Status=? AND (Volume is NULL OR Volume='None')", [DynamicName, Status])
         else:
             myDB.action('DELETE from importresults WHERE DynamicName=? AND Volume=? AND Status=?', [DynamicName, volume, Status])
         raise cherrypy.HTTPRedirect("importResults")
@@ -9562,7 +9562,7 @@ class WebInterface(object):
                 myDB.action("DELETE FROM annuals WHERE ComicID=?", [comicid])
             myDB.action('DELETE from upcoming WHERE ComicID=?', [comicid])
             myDB.action('DELETE from readlist WHERE ComicID=?', [comicid])
-            myDB.action('UPDATE weekly SET Status="Skipped" WHERE ComicID=? AND Status="Wanted"', [comicid])
+            myDB.action("UPDATE weekly SET Status='Skipped' WHERE ComicID=? AND Status='Wanted'", [comicid])
             warnings = 0
             if delete_dir:
                 logger.fdebug('Remove directory on series removal enabled.')


### PR DESCRIPTION
This is an attempt to resolve #1641 without resorting to changing the sqlite config in a future python version.

- Hunted down as many uses of double quoting for string literals in queries as I could with some regexfu in an attempt to restore compatibility for FreeBSD / prepare for any future risk of sqlite3 quote support changing in images.  In general just took the approach of switching query strings from single quoted python strings to double quoted python strings (to avoid escapes for the sake of escapes).  In some cases did some cleanup for readability (concatenation -> f-strings).
- Fix in search.py (searchforissue) to a couple of queries that were malformed.  Based their fix on the logic used in a previous loop case.
