### PR TITLE
Save the currently selected letter and paging for alphaindex mode

### DIFF
--- a/data/css/alphabetSearch.css
+++ b/data/css/alphabetSearch.css
@@ -25,6 +25,10 @@ div.alphabet span.empty {
         color: red;
 }
 
+div.alphabet span.empty.active {
+        color: orangered;
+}
+
 div.alphabetInfo {
         display: block;
         position: absolute;

--- a/data/interfaces/default/index-alphaindex.html
+++ b/data/interfaces/default/index-alphaindex.html
@@ -176,7 +176,27 @@
 			"stateDuration": 0,
                         "pageLength": 25,
                         "pagingType": "simple_numbers",
-                        alphabetSearch: { column:1 }
+                        alphabetSearch: { column:1 },
+                        "stateSaveParams": function(settings, data) {
+                            data.selected = $('span.active').index()
+                        },
+                        "initComplete": function() {
+                            var api = this.api();
+                            var state = api.state.loaded();
+
+                            if (state != undefined) {
+                                if (state.selected != undefined) {
+                                    $('div.alphabet span:eq(' + state.selected + ')').click();
+                                };
+
+                                if (state.start !== 0) {
+                                    api.page(state.start / state.length).draw(false);
+                                };
+                                api.state.save();
+                            } else {
+                                $('div.alphabet span:eq(0)').click();
+                            }
+                        }  
 		     });
                  } else {
                      var table = $('#series_table').dataTable( {


### PR DESCRIPTION
 - Stores the current alphabet index selection in local storage and restores on page load
 - Orange text colour for selected Alpha page if 0 items to differentiate between other empty pages
 - Default to page 0 (None) on first load / with no state

Resolves #1613 