### PR TITLE
FIX: Story Arcs with annual issues didn't work when annual integration is on

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -1986,12 +1986,12 @@ def listLibrary(comicid=None):
     myDB = db.DBConnection()
     if comicid is None:
         if mylar.CONFIG.ANNUALS_ON is True:
-            list = myDB.select("SELECT a.comicid, b.releasecomicid, a.status FROM Comics AS a LEFT JOIN annuals AS b on a.comicid=b.comicid group by a.comicid")
+            list = myDB.select("SELECT a.comicid, b.releasecomicid, a.status FROM Comics AS a LEFT JOIN annuals AS b on a.comicid=b.comicid group by a.comicid, b.releasecomicid")
         else:
             list = myDB.select("SELECT comicid, status FROM Comics group by comicid")
     else:
         if mylar.CONFIG.ANNUALS_ON is True:
-            list = myDB.select("SELECT a.comicid, b.releasecomicid, a.status FROM Comics AS a LEFT JOIN annuals AS b on a.comicid=b.comicid WHERE a.comicid=? group by a.comicid", [re.sub('4050-', '', comicid).strip()])
+            list = myDB.select("SELECT a.comicid, b.releasecomicid, a.status FROM Comics AS a LEFT JOIN annuals AS b on a.comicid=b.comicid WHERE a.comicid=? group by a.comicid, b.releasecomicid", [re.sub('4050-', '', comicid).strip()])
         else:
             list = myDB.select("SELECT comicid, status FROM Comics WHERE comicid=? group by comicid", [re.sub('4050-', '', comicid).strip()])
 

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5495,7 +5495,7 @@ class WebInterface(object):
             for m_arc in arc_match:
                 #now we cycle through the issues looking for a match.
                 if m_arc['match_annual']:
-                    issue = myDB.selectone("SELECT a.Issue_Number, a.Status, a.IssueID, a.ComicName, a.IssueDate, a.Location, b.readingorder FROM annuals AS a INNER JOIN storyarcs AS b ON a.comicid = b.comicid where a.comicid=? and a.issue_number=? and a.issueid=?", [m_arc['match_id'], m_arc['match_issue'], m_arc['match_issueid']]).fetchone()
+                    issue = myDB.selectone("SELECT a.Issue_Number, a.Status, a.IssueID, a.ComicName, a.IssueDate, a.Location, b.readingorder FROM annuals AS a INNER JOIN storyarcs AS b ON a.releasecomicid = b.comicid where a.comicid=? and a.issue_number=? and a.issueid=?", [m_arc['match_id'], m_arc['match_issue'], m_arc['match_issueid']]).fetchone()
                 else:
                     issue = myDB.selectone("SELECT a.Issue_Number, a.Status, a.IssueID, a.ComicName, a.IssueDate, a.Location, b.readingorder FROM issues AS a INNER JOIN storyarcs AS b ON a.comicid = b.comicid where a.comicid=? and a.issue_number=?", [m_arc['match_id'], m_arc['match_issue']]).fetchone()
                 if issue is None: pass


### PR DESCRIPTION
When annual integration is enabled, a story arc issue is an annual, it will sometimes match issues and sometimes will not. I debugged this, and found that this one line was not returning an issue in these cases. Looking at the DB, it was failing to match up the id between the annuals and storyarcs tables correctly. It was looking at the annuals table's comicid (which is the main comic series id) instead of the releasecomicid (which is the annual series id). Changing this to releasecomicid causes it to properly match.

After this change, I stood up the server locally with my entire DB, and tried searching for missing on several story arcs, some with annuals and some without. I also tried refreshing several story arcs. Saw no errors or issues, and the bug was fixed.