### PR TITLE
Support multi-column sorting on non-alphaindex home page

### DIFF
--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -184,6 +184,7 @@
                     },
 
                 ],
+                "aaSorting" : [5, "desc"],
                 "paginationType": "simple_numbers",
                 "displayLength": 25,
                 "stateSave": true,


### PR DESCRIPTION
Multi column sorting for the volume datatable on the home screen (to enable sort by Comic, then Year)