### PR TITLE
Ability to add an instance name to the browser title

### DIFF
--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -11,7 +11,7 @@
 	<meta charset="UTF-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 	
-	<title>Mylar - ${title}</title>
+	<title>Mylar ${f'- {mylar.CONFIG.INSTANCE_NAME} ' if mylar.CONFIG.INSTANCE_NAME else ''}- ${title}</title>
 	<meta name="description" content="Mylar 'default' interface - made by Elmar Kouwenhoven" />
 	<meta name="author" content="Elmar Kouwenhoven" />
 	

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -262,6 +262,11 @@
                                       %endfor
                                     </select>
                                  </div>
+                                <div class="row">
+                                    <label>Instance Name</label>
+                                    <input type="text" name="instance_name" id="instance_name" value="${config['instance_name']}" size="30">
+                                    <small>Use to add an additional string to the browser title</small>
+                                </div>
                     		 </fieldset>
                          <fieldset>
                              <legend>Annual Handling</legend>

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -146,6 +146,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'LOGIN_TIMEOUT': (int, 'Interface', 43800),
     'ALPHAINDEX': (bool, 'Interface', True),
     'CHERRYPY_LOGGING': (bool, 'Interface', False),
+    'INSTANCE_NAME': (str, 'Interface', None),
 
     'API_ENABLED' : (bool, 'API', False),
     'API_KEY' : (str, 'API', None),

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6752,6 +6752,7 @@ class WebInterface(object):
                     "http_port": mylar.CONFIG.HTTP_PORT,
                     "http_root": mylar.CONFIG.HTTP_ROOT,
                     "http_pass": mylar.CONFIG.HTTP_PASSWORD,
+                    "instance_name" : mylar.CONFIG.INSTANCE_NAME,
                     "enable_https": helpers.checked(mylar.CONFIG.ENABLE_HTTPS),
                     "https_cert": mylar.CONFIG.HTTPS_CERT,
                     "https_key": mylar.CONFIG.HTTPS_KEY,


### PR DESCRIPTION
One of those "didn't know I wanted it until I wanted it features".  Possibly useful for those who run multiple instances of mylar for manga/western/publisher distinctions.  Definitely useful for me when I run multiple for different versions, branches, config, etc.

Just adds a configurable string between "Mylar" and the page name in the title bar (e.g. `Mylar - Dev Instance - Home`).