### PR TITLE
FIX: changed airdc++ search so it's part of the actual search check loop

### DIFF
--- a/mylar/search.py
+++ b/mylar/search.py
@@ -3193,16 +3193,16 @@ def searcher(
 
             if ddl_it['success'] is True:
                 logger.info(
-                    '[%s] Successfully snatched %s from DDL site. It is currently being queued'
+                    '[%s] Successfully snatched %s from External-DDL site. It is currently being queued'
                     ' to download in position %s' % (tnzbprov, nzbname, mylar.DDL_QUEUE.qsize())
                 )
             else:
-                logger.info('[%s] Failed to retrieve %s from the DDL site.' % (tnzbprov, nzbname))
+                logger.info('[%s] Failed to retrieve %s from the External-DDL site.' % (tnzbprov, nzbname))
                 return "ddl-fail"
 
         sent_to = "is downloading it directly via %s" % tnzbprov
 
-    if mylar.CONFIG.ENABLE_AIRDCPP and nzbprov.lower() == 'airdcpp':
+    elif mylar.CONFIG.ENABLE_AIRDCPP and nzbprov.lower() == 'airdcpp':
         if all([IssueID is None, IssueArcID is not None]):
             tmp_issueid = IssueArcID
         else:


### PR DESCRIPTION
Should be an ``elif`` instead of an ``if`` statement as otherwise it kicks off the sab/nzb options if they're enabled in addition to anything prior to the airdc++ check (basically torrents, blackhole, usenet, ddl)