### PR TITLE
Check folder watch warning at page load, case insensitive Windows path checks

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -2003,16 +2003,23 @@
         <script>
             function pathIsParentOf(path, childPath) {
                 // Strip trailing slashes
-                re = new RegExp("\${sep}$", "g");
+                var flags = ("${mylar.OS_DETECT}" == "Windows" ? "gi" : "g")
+
+                re = new RegExp("\${sep}$", flags);
                 path = path.replace(re, "");
                 childPath = childPath.replace(re, "");
+
+                if ("${mylar.OS_DETECT}" == "Windows") {
+                    path = path.toLowerCase();
+                    childPath = childPath.toLowerCase();
+                }
 
                 if (path == childPath) return true;
 
                 if (childPath.startsWith(path)) {
                     // Check that if they have a common parent, they are not different paths with a common substring
-                    re = new RegExp("\${sep}[^\${sep}]*$", "g");
-                    pathParent = path.replace(re, "");
+                    re = new RegExp("\${sep}[^\${sep}]*$", flags);
+                    pathParent = path.replace(re, "");                    
                     childPathParent = childPath.replace(re, "");
 
                     if (pathParent == childPathParent) {
@@ -3301,8 +3308,7 @@ $("#enable_airdcpp").click(function(){
                     $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
                 });
 
-                $('input[name="check_folder"]').on('change keyup paste', function() {
-                    check_folder = $(this).val() //$('input[name="check_folder"]').val()
+                function checkCheckFolder(check_folder) {
                     comic_folder = $('#destination_dir').val()
                     sab_folder = $('input[name="sab_directory"]').val()
 
@@ -3313,6 +3319,12 @@ $("#enable_airdcpp").click(function(){
                         $('#check_folder_warning').css("display", "none");
                     }
                 
+                };
+
+                checkCheckFolder("${config['check_folder']}");
+
+                $('input[name="check_folder"]').on('change keyup paste', function() {
+                    checkCheckFolder($(this).val());
                 });
 
                 $('#mattermost_test').click(function () {


### PR DESCRIPTION
Well, I feel vindicated that today someone has a problem with their watch path being the same as their download path.  It did make me realise it should check on page load as well for people already in the bad place.  Also case insensitivity for Windows hosts.

It doesn't check DDL download folders, but then if someone has changed config.ini then that's really on them.