### PR TITLE
IMP: moved airdcpp variables into own section of config, IMP: removed '#' from airdcpp search terms

### DIFF
--- a/mylar/downloaders/airdcpp.py
+++ b/mylar/downloaders/airdcpp.py
@@ -49,7 +49,7 @@ class AirDCPP(object):
         if mylar.CONFIG.AIRDCPP_USERNAME and mylar.CONFIG.AIRDCPP_PASSWORD:
             self.session.auth = (mylar.CONFIG.AIRDCPP_USERNAME, mylar.CONFIG.AIRDCPP_PASSWORD)
 
-        self.search_format = ['"%s #%s (%s)"', '%s #%s (%s)', '%s #%s', '%s %s']
+        self.search_format = ['%s %s %s', '%s %s', '%s']
         self.comic_extensions = ["cbr", "cbz"]
 
     def search(self, is_info=None):


### PR DESCRIPTION
config will update to v15 and auto-convert existing airdcpp values into the new sections and reuse them immediately.

removed ``#`` from the airdcpp query search terms as including it garnered zero hits until the last iteration of searching (3 loops usually not results, fourth results).