### PR TITLE
Add support for AirDC++ configuration options in carepackage

### DIFF
--- a/mylar/carepackage.py
+++ b/mylar/carepackage.py
@@ -67,6 +67,8 @@ class carePackage(object):
                             ('DISCORD', 'discord_webhook_url'),
                             ('DDL', 'external_username'),
                             ('DDL', 'external_apikey'),
+                            ('DCPP', 'airdcpp_username'),
+                            ('DCPP', 'airdcpp_password')
                             }
         self.hostname_list = {
                             ('SABnzbd', 'sab_host'),
@@ -87,6 +89,11 @@ class carePackage(object):
                             ('DDL', 'flaresolverr_url'),
                             ('DDL', 'http_proxy'),
                             ('DDL', 'https_proxy'),
+                            ('DCPP', 'airdcpp_host'),
+                            ('DCPP', 'airdcpp_download_dir'),
+                            ('DCPP', 'airdcpp_hubs'),
+                            ('DCPP', 'airdcpp_announce_hub'),
+                            ('DCPP', 'airdcpp_announce_bots')
                              }
 
     def loaders(self):


### PR DESCRIPTION
Values from airdcpp are now obfuscated in carepackages:

```
[DCPP]
enable_airdcpp = True
airdcpp_host = xXX[REMOVED]XXx
airdcpp_username = xXX[REMOVED]XXx
airdcpp_password = xXX[REMOVED]XXx
airdcpp_download_dir = xXX[REMOVED]XXx
airdcpp_hubs = xXX[REMOVED]XXx
airdcpp_version = AirDC++w 2.13.3 x86_64
airdcpp_announce_hub = xXX[REMOVED]XXx
```