### PR TITLE
FIX: check_folder value causing js error on settings page for Windows path

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -3335,7 +3335,7 @@ $("#enable_airdcpp").click(function(){
                 
                 };
 
-                checkCheckFolder("${config['check_folder']}");
+                checkCheckFolder($('input[name="check_folder"]').val());
 
                 $('input[name="check_folder"]').on('change keyup paste', function() {
                     checkCheckFolder($(this).val());


### PR DESCRIPTION
Fixes #1719 