### PR TITLE
[Feature] Send DDL downloads to JDownloader2

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -912,6 +912,23 @@
                                                 <input type="checkbox" id="ddl_prefer_upscaled" name="ddl_prefer_upscaled" value="1" ${config['ddl_prefer_upscaled']} /><label>Prefer HD-Upscale/HD-Digital <small>(if available></small></label>
                                            </div>
                                        </div>
+                                       <div class="row checkbox left clearfix">
+                                            <input type="checkbox" id="jd2_enable" onclick="initConfigCheckbox($(this));" name="jd2_enable" value="1" ${config['jd2_enable']} /><label>Send to JDownloader2</label>
+                                       </div>
+                                       <div class="config">
+                                           <div id="jd2_options" style="display:none">
+                                               <div class="row">
+                                                   <label>JDownloader2 URL</label>
+                                                   <input type="text" name="jd2_url" id="jd2_url" value="${config['jd2_url']}" size="30">
+                                                   <small>(ex. http://127.0.0.1:3128)</small>
+                                               </div>
+                                                <div class="row">
+                                                    <label>Download Path</label>
+                                                    <input type="text" name="jd2_dest_dir" id="jd2_dest_dir" value="${config['jd2_dest_dir']}" size="30">
+                                                    <small>absolute JD2 destination directory</small>
+                                                </div>
+                                           </div>
+                                       </div>
                                        %if mylar.EXT_SERVER:
                                        <div class="row checkbox left clearfix">
                                             <input type="checkbox" id="enable_external_server" onclick="initConfigCheckbox($this));" name="enable_external_server" value="1" ${config['enable_external_server']} /><label>Enable External Server</label>
@@ -2181,6 +2198,25 @@ $("#enable_airdcpp").click(function(){
                                 //document.getElementById("enable_getcomics").checked = false;
                                 $("#ddl_providers").slideUp();
                                 $("#gc_options").slideUp();
+                        }
+                });
+
+                if ($("#jd2_enable").is(":checked"))
+                        {
+                                $("#jd2_options").slideDown();
+                        }
+                else    {
+                                $("#jd2_options").slideUp();
+                        }
+
+                $("#jd2_enable").click(function(){
+                        if ($("#jd2_enable").is(":checked"))
+                        {
+                                $("#jd2_options").slideDown();
+                        }
+                        else
+                        {
+                                $("#jd2_options").slideUp();
                         }
                 });
 

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -140,11 +140,13 @@ NZBPOOL = None
 SEARCHPOOL = None
 PPPOOL = None
 DDLPOOL = None
+JD2POOL = None
 SNATCHED_QUEUE = queue.Queue()
 NZB_QUEUE = queue.Queue()
 PP_QUEUE = queue.Queue()
 SEARCH_QUEUE = queue.Queue()
 DDL_QUEUE = queue.Queue()
+JD2_QUEUE = queue.Queue()
 RETURN_THE_NZBQUEUE = queue.Queue()
 MASS_ADD = None
 ADD_LIST = queue.Queue()
@@ -247,9 +249,9 @@ def initialize(config_file):
     with INIT_LOCK:
 
         global CONFIG, _INITIALIZED, QUIET, CONFIG_FILE, MINIMUM_PY_VERSION, OS_DETECT, MAINTENANCE, CURRENT_VERSION, LATEST_VERSION, COMMITS_BEHIND, INSTALL_TYPE, IMPORTLOCK, PULLBYFILE, INKDROPS_32P, \
-               DONATEBUTTON, CURRENT_WEEKNUMBER, CURRENT_YEAR, UMASK, USER_AGENT, SNATCHED_QUEUE, NZB_QUEUE, PP_QUEUE, SEARCH_QUEUE, DDL_QUEUE, PULLNEW, COMICSORT, WANTED_TAB_OFF, CV_HEADERS, \
+               DONATEBUTTON, CURRENT_WEEKNUMBER, CURRENT_YEAR, UMASK, USER_AGENT, SNATCHED_QUEUE, NZB_QUEUE, PP_QUEUE, SEARCH_QUEUE, DDL_QUEUE, JD2_QUEUE, PULLNEW, COMICSORT, WANTED_TAB_OFF, CV_HEADERS, \
                IMPORTBUTTON, IMPORT_FILES, IMPORT_TOTALFILES, IMPORT_CID_COUNT, IMPORT_PARSED_COUNT, IMPORT_FAILURE_COUNT, CHECKENABLED, CVURL, DEMURL, EXPURL, WWTURL, WWT_CF_COOKIEVALUE, \
-               DDLPOOL, NZBPOOL, SNPOOL, PPPOOL, SEARCHPOOL, RETURN_THE_NZBQUEUE, MASS_ADD, ADD_LIST, MASS_REFRESH, REFRESH_QUEUE, SSE_KEY, \
+               DDLPOOL, JD2POOL, NZBPOOL, SNPOOL, PPPOOL, SEARCHPOOL, RETURN_THE_NZBQUEUE, MASS_ADD, ADD_LIST, MASS_REFRESH, REFRESH_QUEUE, SSE_KEY, \
                USE_SABNZBD, USE_NZBGET, USE_BLACKHOLE, USE_RTORRENT, USE_UTORRENT, USE_QBITTORRENT, USE_DELUGE, USE_TRANSMISSION, USE_WATCHDIR, SAB_PARAMS, PUBLISHER_IMPRINTS, \
                PROG_DIR, DATA_DIR, CMTAGGER_PATH, DOWNLOAD_APIKEY, LOCAL_IP, STATIC_COMICRN_VERSION, STATIC_APC_VERSION, KEYS_32P, AUTHKEY_32P, FEED_32P, FEEDINFO_32P, \
                MONITOR_STATUS, SEARCH_STATUS, RSS_STATUS, WEEKLY_STATUS, VERSION_STATUS, UPDATER_STATUS, FORCE_STATUS, DBUPDATE_INTERVAL, DB_BACKFILL, LOG_LANG, LOG_CHARSET, APILOCK, SEARCHLOCK, DDL_LOCK, LOG_LEVEL, \
@@ -603,6 +605,10 @@ def start():
             if CONFIG.ENABLE_DDL is True:
                 queue_schedule('ddl_queue', 'start')
 
+            if getattr(CONFIG, 'JD2_ENABLE', False) is True:
+                queue_schedule('jd2_queue', 'start')
+                mylar.JD2_QUEUE.put('startup')
+
             helpers.latestdate_fix()
 
             if CONFIG.ALT_PULL == 2:
@@ -776,6 +782,15 @@ def queue_schedule(queuetype, mode):
                 'DDL Download queue enabled & monitoring for requests....',
                 'Succesfully started DDL Download Queuer....',
             )
+        elif queuetype == 'jd2_queue':
+            start(
+                "JD2POOL",
+                helpers.jd2_queue_monitor,
+                JD2_QUEUE,
+                "JD2-QUEUE",
+                'JD2 queue enabled & monitoring for requests....',
+                'Succesfully started JD2 Queuer....',
+            )
     else:
         if (queuetype == 'nzb_queue') or mode == 'shutdown':
             if all([mode!= 'shutdown', mylar.CONFIG.POST_PROCESSING is True]) and ( all([mylar.CONFIG.NZB_DOWNLOADER == 0, mylar.CONFIG.SAB_CLIENT_POST_PROCESSING is True]) or all([mylar.CONFIG.NZB_DOWNLOADER == 1, mylar.CONFIG.NZBGET_CLIENT_POST_PROCESSING is True]) ):
@@ -799,6 +814,10 @@ def queue_schedule(queuetype, mode):
             if all([mylar.CONFIG.ENABLE_DDL is True, mode != 'shutdown']):
                 return
             shutdown(mylar.DDLPOOL, mylar.DDL_QUEUE, 'DDL download queue')
+        if (queuetype == 'jd2_queue') or mode == 'shutdown':
+            if all([getattr(mylar.CONFIG, 'JD2_ENABLE', False) is True, mode != 'shutdown']):
+                return
+            shutdown(mylar.JD2POOL, mylar.JD2_QUEUE, 'JD2 queue')
 
 
 def sql_db():
@@ -837,7 +856,7 @@ def dbcheck():
     c.execute('CREATE TABLE IF NOT EXISTS jobhistory (JobName TEXT, prev_run_datetime timestamp, prev_run_timestamp REAL, next_run_datetime timestamp, next_run_timestamp REAL, last_run_completed TEXT, successful_completions TEXT, failed_completions TEXT, status TEXT, last_date timestamp)')
     c.execute('CREATE TABLE IF NOT EXISTS manualresults (provider TEXT, id TEXT, kind TEXT, comicname TEXT, volume TEXT, oneoff TEXT, fullprov TEXT, issuenumber TEXT, modcomicname TEXT, name TEXT, link TEXT, size TEXT, pack_numbers TEXT, pack_issuelist TEXT, comicyear TEXT, issuedate TEXT, tmpprov TEXT, pack TEXT, issueid TEXT, comicid TEXT, sarc TEXT, issuearcid TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS storyarcs(StoryArcID TEXT, ComicName TEXT, IssueNumber TEXT, SeriesYear TEXT, IssueYEAR TEXT, StoryArc TEXT, TotalIssues TEXT, Status TEXT, inCacheDir TEXT, Location TEXT, IssueArcID TEXT, ReadingOrder INT, IssueID TEXT, ComicID TEXT, ReleaseDate TEXT, IssueDate TEXT, Publisher TEXT, IssuePublisher TEXT, IssueName TEXT, CV_ArcID TEXT, Int_IssueNumber INT, DynamicComicName TEXT, Volume TEXT, Manual TEXT, DateAdded TEXT, DigitalDate TEXT, Type TEXT, Aliases TEXT, ArcImage TEXT)')
-    c.execute('CREATE TABLE IF NOT EXISTS ddl_info (ID TEXT UNIQUE, series TEXT, year TEXT, filename TEXT, size TEXT, issueid TEXT, comicid TEXT, link TEXT, status TEXT, remote_filesize TEXT, updated_date TEXT, mainlink TEXT, issues TEXT, site TEXT, submit_date TEXT, pack INTEGER, link_type TEXT, tmp_filename TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS ddl_info (ID TEXT UNIQUE, series TEXT, year TEXT, filename TEXT, size TEXT, issueid TEXT, comicid TEXT, link TEXT, status TEXT, remote_filesize TEXT, updated_date TEXT, mainlink TEXT, issues TEXT, site TEXT, submit_date TEXT, pack INTEGER, link_type TEXT, tmp_filename TEXT, jd2_job_id TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS exceptions_log(date TEXT UNIQUE, comicname TEXT, issuenumber TEXT, seriesyear TEXT, issueid TEXT, comicid TEXT, booktype TEXT, searchmode TEXT, error TEXT, error_text TEXT, filename TEXT, line_num TEXT, func_name TEXT, traceback TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS tmp_searches (query_id INTEGER, comicid INTEGER, comicname TEXT, publisher TEXT, publisherimprint TEXT, comicyear TEXT, issues TEXT, volume TEXT, deck TEXT, url TEXT, type TEXT, cvarcid TEXT, arclist TEXT, description TEXT, haveit TEXT, mode TEXT, searchtype TEXT, comicimage TEXT, thumbimage TEXT, PRIMARY KEY (query_id, comicid))')
     c.execute('CREATE TABLE IF NOT EXISTS notifs(session_id INT, date TEXT, event TEXT, comicid TEXT, comicname TEXT, issuenumber TEXT, seriesyear TEXT, status TEXT, message TEXT, PRIMARY KEY (session_id, date))')
@@ -1568,6 +1587,11 @@ def dbcheck():
         c.execute('SELECT tmp_filename from ddl_info')
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE ddl_info ADD COLUMN tmp_filename TEXT')
+
+    try:
+        c.execute('SELECT jd2_job_id from ddl_info')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE ddl_info ADD COLUMN jd2_job_id TEXT')
 
     ## -- provider_searches Table --
     try:

--- a/mylar/carepackage.py
+++ b/mylar/carepackage.py
@@ -89,6 +89,7 @@ class carePackage(object):
                             ('DDL', 'flaresolverr_url'),
                             ('DDL', 'http_proxy'),
                             ('DDL', 'https_proxy'),
+                            ('DDL', 'jd2_url'),
                             ('DCPP', 'airdcpp_host'),
                             ('DCPP', 'airdcpp_download_dir'),
                             ('DCPP', 'airdcpp_hubs'),

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -375,6 +375,9 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'ENABLE_PROXY': (bool, 'DDL', False),
     'HTTP_PROXY': (str, 'DDL', None),
     'HTTPS_PROXY': (str, 'DDL', None),
+    'JD2_ENABLE': (bool, 'DDL', False),
+    'JD2_DEST_DIR': (str, 'DDL', None),
+    'JD2_URL': (str, 'DDL', None),
 
     'ENABLE_AIRDCPP': (bool, 'DCPP', False),
     'AIRDCPP_HOST': (str, 'DCPP', ""),
@@ -1605,6 +1608,13 @@ class Config(object):
                 mylar.queue_schedule('ddl_queue', 'start')
             elif self.ENABLE_DDL is False:
                 mylar.queue_schedule('ddl_queue', 'stop')
+
+            if getattr(self, 'JD2_ENABLE', False) is True:
+                if not getattr(self, 'JD2_DEST_DIR', None):
+                    self.JD2_DEST_DIR = mylar.CONFIG.DDL_LOCATION
+                mylar.queue_schedule('jd2_queue', 'start')
+            else:
+                mylar.queue_schedule('jd2_queue', 'stop')
 
         if self.FOLDER_FORMAT is None:
             setattr(self, 'FOLDER_FORMAT', '$Series ($Year)')

--- a/mylar/downloaders/jdownloader2.py
+++ b/mylar/downloaders/jdownloader2.py
@@ -6,6 +6,7 @@
 import json
 import os
 import datetime
+import time
 from typing import Any, Dict, List, Optional
 
 import requests
@@ -76,6 +77,7 @@ class JDownloader2(object):
                         data = payload.get('data', payload)
                         if isinstance(data, dict):
                             job_id = data.get('id') or data.get('jobID')
+                            time.sleep(1)
                 except Exception as json_err:
                     logger.warn('[JD2] Unable to decode submit response JSON: %s', json_err)
                     
@@ -96,7 +98,7 @@ class JDownloader2(object):
                     {'id': record_id},
                 )
             except Exception as err:
-                logger.error('[JD2] Unable to update database for job id %s for record %s: %s', job_key, record_id, err)
+                logger.error('[JD2] Unable to update database for job id %s for record %s: %s', job_id, record_id, err)
                 return {'status': False, 'jobid': None, 'error': err}
     
         return {'status': True, 'jobid': str(job_id), 'payload': payload}

--- a/mylar/downloaders/jdownloader2.py
+++ b/mylar/downloaders/jdownloader2.py
@@ -1,0 +1,174 @@
+#  This file is part of Mylar.
+#
+#  Provides a lightweight wrapper around the JDownloader2 remote API so
+#  GetComics links can be handed off for downloading.
+
+import json
+import os
+import datetime
+from typing import Any, Dict, List, Optional
+
+import requests
+
+import mylar
+from mylar import db, logger
+
+
+class JDownloader2(object):
+    """Simple helper for submitting links to JDownloader2 and polling status."""
+
+    LINKGRABBER_ENDPOINT = 'linkgrabberv2/addLinks'
+    LINKGRABBER_QUERY_ENDPOINT = 'linkgrabberv2/queryLinks'
+    DOWNLOADS_ENDPOINT = 'downloadsV2/queryLinks'
+
+    def __init__(self, base_url: Optional[str] = None, timeout: int = 30, session: Optional[requests.Session] = None):
+        self.base_url = (base_url or mylar.CONFIG.JD2_URL or '').rstrip('/')
+        if not self.base_url:
+            raise ValueError('JD2 URL is not configured')
+        self.timeout = timeout
+        self.session = session or requests.Session()
+
+        self.destination_root = mylar.CONFIG.JD2_DEST_DIR
+        self.destination_folder = None
+        if self.destination_root:
+            self.destination_folder = self.destination_root
+            try:
+                os.makedirs(self.destination_folder, exist_ok=True)
+            except Exception as err:
+                logger.warn('[JD2] Unable to ensure destination folder exists: %s', err)
+                self.destination_folder = None
+
+    def _url(self, endpoint: str) -> str:
+        return f"{self.base_url}/{endpoint.lstrip('/')}"
+
+    def submit(self, links: dict, package_name: str, record_id: Optional[str] = None) -> Dict[str, Any]:
+        """Submit a link to JD2 and return the assigned job id (if any)."""
+        query = {
+            'assignJobID': True,
+            'autostart': True,
+            'packageName': package_name,
+           
+        }
+        if self.destination_folder:
+            query['destinationFolder'] = self.destination_folder
+        endpoint = self._url(self.LINKGRABBER_ENDPOINT)
+        payload = None
+        job_id = None
+        
+        for url, priority in links.items():
+            query['priority'] = priority
+            query['links'] = url
+            params = {'query': json.dumps(query)}
+            try:
+                resp = self.session.get(
+                    endpoint,
+                    params=params,
+                    timeout=self.timeout,
+                )
+                resp.raise_for_status()
+            except Exception as err:
+                logger.error('[JD2] Failed to submit %s (url=%s params=%s): %s', package_name, endpoint, params, err)
+                continue
+            if payload is None or job_id is None:
+                try:
+                    payload = resp.json() or None
+                    if isinstance(payload, dict):
+                        data = payload.get('data', payload)
+                        if isinstance(data, dict):
+                            job_id = data.get('id') or data.get('jobID')
+                except Exception as json_err:
+                    logger.warn('[JD2] Unable to decode submit response JSON: %s', json_err)
+                    
+        if job_id is None:
+            logger.error('[JD2] No job id returned for %s', package_name)
+            return {'status': False, 'jobid': None, 'error': err}
+
+        if record_id:
+            try:
+                myDB = db.DBConnection()
+                myDB.upsert(
+                    'ddl_info',
+                    {
+                        'jd2_job_id': str(job_id),
+                        'status': 'Queued',
+                        'updated_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M'),
+                    },
+                    {'id': record_id},
+                )
+            except Exception as err:
+                logger.error('[JD2] Unable to update database for job id %s for record %s: %s', job_key, record_id, err)
+                return {'status': False, 'jobid': None, 'error': err}
+    
+        return {'status': True, 'jobid': str(job_id), 'payload': payload}
+
+    def query_links(self, id: str) -> Dict[str, Any]:
+
+        query = {
+            "jobUUIDs": list(id),
+        }
+
+        endpoint = self._url(self.LINKGRABBER_QUERY_ENDPOINT)
+        try:
+            response = requests.get(endpoint, params=json.dumps(query), timeout=self.timeout)
+            response.raise_for_status()
+        except Exception as err:
+            logger.error(
+                "[JD2] Failed to query links (url=%s id=%s): %s",
+                endpoint,
+                id,
+                err,
+            )
+            
+        try:
+            payload = response.json() or {}
+        except Exception as json_err:
+            logger.warning("[JD2] Unable to decode links JSON: %s", json_err)
+            payload = {}
+
+        data = payload.get("data", payload if isinstance(payload, list) else [])
+        result = data if isinstance(data, list) else []
+        return result
+
+    def query(self, job_ids: List[str]) -> List[Dict[str, Any]]:
+        if not job_ids:
+            return []
+        query = {
+            'jobUUID': True,
+            'jobUUIDs': job_ids,
+            'status': True,
+            'maxResults': 1000,
+            'startAt': 0,
+        }
+        endpoint = self._url(self.DOWNLOADS_ENDPOINT)
+        params = {'queryParams': json.dumps(query)}
+        try:
+            resp = self.session.get(
+                endpoint,
+                params=params,
+                timeout=self.timeout,
+            )
+            resp.raise_for_status()
+        except Exception as err:
+            logger.error('[JD2] Failed to query job ids %s (url=%s params=%s): %s', job_ids, endpoint, params, err)
+            return []
+
+        try:
+            payload = resp.json() or {}
+        except Exception as json_err:
+            logger.warn('[JD2] Unable to decode query response JSON: %s', json_err)
+            payload = {}
+
+
+        data = payload.get('data', payload if isinstance(payload, list) else [])
+        return data if isinstance(data, list) else []
+
+    def status(self, job_id: str) -> Dict[str, Any]:
+        """Return the JD2 status for the given job id."""
+        if job_id is None:
+            return {'found': False, 'status': None, 'data': None}
+        packages = self.query([job_id])
+        if not packages:
+            return {'found': False, 'status': None, 'data': None}
+        package = packages[0]
+        status = package.get('status') if isinstance(package, dict) else None
+        return {'found': True, 'status': status, 'data': package}

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -31,6 +31,7 @@ import json
 import mylar
 from operator import itemgetter
 from mylar import db, logger, helpers, search_filer
+from mylar.downloaders.jdownloader2 import JDownloader2
 
 class GC(object):
 
@@ -158,6 +159,15 @@ class GC(object):
         self.pack_receipts = ['+ TPBs', '+TPBs', '+ TPB', '+TPB', 'TPB', '+ Deluxe Books', '+ Annuals', '+Annuals', ' & ']
 
         self.provider_stat = provider_stat
+
+        self.jd2 = None
+        if mylar.CONFIG.JD2_ENABLE and mylar.CONFIG.JD2_URL:
+            try:
+                self.jd2 = JDownloader2(base_url=mylar.CONFIG.JD2_URL)
+                logger.fdebug('[JD2] Initialized JD2 helper in GetComics.')
+            except Exception as err:
+                logger.warn('[JD2] Unable to initialize helper: %s', err)
+                self.jd2 = None
 
     def search(self,is_info=None):
 
@@ -1099,26 +1109,68 @@ class GC(object):
                 # (it will get renamed upon completion anyways)
                 #tmp_filename = comicinfo[0]['nzbtitle']
 
-            mylar.DDL_QUEUE.put(
-                {
-                    'link': x['links'],
-                    'mainlink': mainlink,
-                    'series': x['series'],
-                    'year': x['year'],
-                    'size': x['size'],
-                    'comicid': self.comicid,
-                    'issueid': self.issueid,
-                    'oneoff': self.oneoff,
-                    'id': mod_id,
-                    'link_type': link_type,
-                    'filename': tmp_filename,
-                    'comicinfo': comicinfo,
-                    'packinfo': packinfo,
-                    'site': 'DDL(GetComics)',
-                    'remote_filesize': 0,
-                    'resume': None,
-                }
-            )
+            queue_payload = {
+                'link': x['links'],
+                'mainlink': mainlink,
+                'series': x['series'],
+                'year': x['year'],
+                'size': x['size'],
+                'comicid': self.comicid,
+                'issueid': self.issueid,
+                'oneoff': self.oneoff,
+                'id': mod_id,
+                'link_type': link_type,
+                'filename': tmp_filename,
+                'comicinfo': comicinfo,
+                'packinfo': packinfo,
+                'site': 'DDL(GetComics)',
+                'remote_filesize': 0,
+                'resume': None,
+            }
+
+            if self.jd2 is not None:
+                package_name = '%s (%s) - %s' % (x['series'], x['year'], mod_id)
+                logger.info('[JD2] Submitting %s to JD2', package_name)
+                
+                jd2_priority_links = {}
+                jd2_priority_list = ["HIGHEST", "HIGH", "DEFAULT", "LOWEST"]
+                jd2_priority_map = {}
+                
+                for i, site in enumerate(mylar.CONFIG.DDL_PRIORITY_ORDER):
+                    jd2_priority_map[site] = jd2_priority_list[i] if i < len(jd2_priority_list) else "LOWEST"
+                    
+                if isinstance(tmp_links, list):
+                    for entry in tmp_links:
+                        if isinstance(entry, dict):
+                            url = entry.get('links')
+                            jd2_lt_site = entry.get('site').lower()
+                            if any([jd2_lt_site == 'main server', jd2_lt_site == 'download now', jd2_lt_site == 'mirror download']):
+                                jd2_priority_links[url] = jd2_priority_map['main']
+                            else:
+                                jd2_priority_links[url] = jd2_priority_map[jd2_lt_site]
+                                
+                submit_result = self.jd2.submit(jd2_priority_links, package_name, record_id=mod_id)
+                
+                if not submit_result.get('status'):
+                    logger.warn('[JD2] Submission failed for %s; falling back to internal queue. Details: %s', package_name, submit_result)
+                    mylar.DDL_QUEUE.put(queue_payload)
+                else:
+                    logger.debug('[JD2] Submission response for %s: %s', package_name, submit_result)
+                    job_id = submit_result.get('jobid')
+                    if job_id:
+                        jd2_queue_payload = dict(queue_payload)
+                        jd2_queue_payload.update({
+                            'jd2_job_id': job_id,
+                        })
+                        try:
+                            mylar.JD2_QUEUE.put(jd2_queue_payload)
+                            logger.info('[JD2] Enqueued %s for monitoring.', package_name)
+                        except Exception as err:
+                            logger.warn('[JD2] Unable to enqueue %s for monitoring: %s', package_name, err)
+                    else:
+                        logger.warn('[JD2] Submission for %s returned no job id; JD2 monitoring unavailable.', package_name)
+            else:
+                mylar.DDL_QUEUE.put(queue_payload)
             cnt += 1
 
         return {'success': True, 'site': link_type}

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -1129,8 +1129,6 @@ class GC(object):
             }
 
             if self.jd2 is not None:
-                package_name = '%s (%s) - %s' % (x['series'], x['year'], mod_id)
-                logger.info('[JD2] Submitting %s to JD2', package_name)
                 
                 jd2_priority_links = {}
                 jd2_priority_list = ["HIGHEST", "HIGH", "DEFAULT", "LOWEST"]
@@ -1148,27 +1146,17 @@ class GC(object):
                                 jd2_priority_links[url] = jd2_priority_map['main']
                             else:
                                 jd2_priority_links[url] = jd2_priority_map[jd2_lt_site]
-                                
-                submit_result = self.jd2.submit(jd2_priority_links, package_name, record_id=mod_id)
-                
-                if not submit_result.get('status'):
-                    logger.warn('[JD2] Submission failed for %s; falling back to internal queue. Details: %s', package_name, submit_result)
-                    mylar.DDL_QUEUE.put(queue_payload)
-                else:
-                    logger.debug('[JD2] Submission response for %s: %s', package_name, submit_result)
-                    job_id = submit_result.get('jobid')
-                    if job_id:
-                        jd2_queue_payload = dict(queue_payload)
-                        jd2_queue_payload.update({
-                            'jd2_job_id': job_id,
-                        })
-                        try:
-                            mylar.JD2_QUEUE.put(jd2_queue_payload)
-                            logger.info('[JD2] Enqueued %s for monitoring.', package_name)
-                        except Exception as err:
-                            logger.warn('[JD2] Unable to enqueue %s for monitoring: %s', package_name, err)
-                    else:
-                        logger.warn('[JD2] Submission for %s returned no job id; JD2 monitoring unavailable.', package_name)
+            
+                jd2_queue_payload = dict(queue_payload)
+                jd2_queue_payload.update({
+                    'jd2_job_id': 0,
+                    'jd2_priority_links': jd2_priority_links,
+                })
+                try:
+                    mylar.JD2_QUEUE.put(jd2_queue_payload)
+                    logger.info('[JD2] Enqueued %s for downloading.', tmp_filename)
+                except Exception as err:
+                    logger.warn('[JD2] Unable to enqueue %s for downloading: %s', tmp_filename, err)
             else:
                 mylar.DDL_QUEUE.put(queue_payload)
             cnt += 1

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -50,6 +50,7 @@ import mylar
 from . import logger
 from mylar import db, sabnzbd, nzbget, process, getcomics, getimage
 from mylar.downloaders import mega, pixeldrain, mediafire
+from mylar.downloaders.jdownloader2 import JDownloader2
 
 
 def multikeysort(items, columns):
@@ -3043,7 +3044,7 @@ def ddl_downloader(queue):
         else:
             time.sleep(5)
 
-def ddl_cleanup(id):
+def ddl_cleanup(record_id):
    # remove html file from cache if it's successful
    tlnk = 'getcomics-%s.html' % id
    try:
@@ -3052,6 +3053,185 @@ def ddl_cleanup(id):
        logger.fdebug('[HTML-cleanup] Unable to remove html used for item from html_cache folder.'
                      ' Manual removal required or set `cleanup_cache=True` in the config.ini to'
                      ' clean cache items on every startup. If this was a Retry - ignore this.')
+
+
+def jd2_queue_monitor(queue):
+    jd2_client = None
+    myDB = db.DBConnection()
+    while True:
+        if queue.qsize() >= 1:
+            item = queue.get(True)
+            if item == 'exit':
+                logger.info('[JD2-QUEUE] Cleaning up workers for shutdown')
+                break
+            if item == 'startup':
+                try:
+                    pending_jd2 = myDB.select(
+                        "SELECT * FROM ddl_info WHERE jd2_job_id IS NOT NULL AND status = 'Queued'"
+                    )
+
+                except Exception as err:
+                    logger.warn('[JD2-QUEUE] Unable to repopulate JD2 monitor queue: %s', err)
+                else:
+                    logger.info('[JD2-QUEUE] Repopulating JD2 monitor queue')
+                    for job in pending_jd2 or []:
+                        job_data = dict(job)
+                        job_id = job_data.get('jd2_job_id')
+                        record_id = job_data.get('ID') or job_data.get('id')
+                        series = job_data.get('series')
+                        year = job_data.get('year')
+                        filename = job_data.get('tmp_filename') or job_data.get('filename')
+                        if not filename:
+                            if series and year:
+                                filename = f"{series} ({year}) - {record_id}"
+                            elif series:
+                                filename = series
+                            elif record_id:
+                                filename = str(record_id)
+                        queue_payload = {
+                            'link': job_data.get('link'),
+                            'mainlink': job_data.get('mainlink'),
+                            'series': series,
+                            'year': year,
+                            'size': job_data.get('size'),
+                            'comicid': job_data.get('comicid'),
+                            'issueid': job_data.get('issueid'),
+                            'oneoff': job_data.get('oneoff'),
+                            'id': record_id,
+                            'link_type': job_data.get('link_type'),
+                            'filename': filename,
+                            'comicinfo': job_data.get('comicinfo'),
+                            'packinfo': job_data.get('packinfo'),
+                            'site': job_data.get('site') or 'DDL(GetComics)',
+                            'remote_filesize': job_data.get('remote_filesize') or 0,
+                            'resume': None,
+                            'jd2_job_id': job_id,
+                        }
+                        jd2_queue_payload = dict(queue_payload)
+                        queue.put(jd2_queue_payload)
+                continue
+            logger.info('[JD2-QUEUE] Now loading from queue: %s' % item)
+            record_id = item.get('ID') or item.get('id')
+            job_id = item.get('jd2_job_id') if isinstance(item, dict) else None
+            if jd2_client is None:
+                try:
+                    jd2_client = JDownloader2()
+                except Exception as err:
+                    logger.warn('[JD2-QUEUE] Unable to initialize JD2 client: %s', err)
+                    jd2_client = None
+
+            if jd2_client is not None and job_id:
+                try:
+                    status_payload = jd2_client.status(job_id)
+                except Exception as err:
+                    logger.warn('[JD2-QUEUE] Error polling job %s: %s', job_id, err)
+                else:
+                    logger.info('[JD2-QUEUE] status update for job %s (record %s): %s', job_id, record_id, status_payload)
+                    job_status = (status_payload or {}).get('status')
+                    job_found = (status_payload or {}).get('found')
+                    
+                    completed_states = {'FINISHED', 'Finished', 'finished', 'DONE', 'Done', 'Extraction OK', '[SHA256] CRC OK', 'Finished(Mirror)'}
+                    failed_states = {'ERROR', 'FAILED', 'Error', 'Failed'}
+
+                    if not job_found:
+                        stale = False
+                        try:
+                            row = myDB.selectone("SELECT updated_date FROM ddl_info WHERE id=?", [record_id]).fetchone()
+                        except Exception as err:
+                            logger.warning('JD2 stale check failed for record %s: %s', record_id, err)
+                            updated_str = None
+                        else:
+                            if row is None:
+                                logger.info('[JD2-QUEUE] No ddl_info entry found for id %s; dropping job %s from monitoring.', record_id, job_id)
+                                continue
+                            updated_str = row['updated_date']
+
+                        if updated_str:
+                            try:
+                                updated_dt = datetime.datetime.strptime(updated_str, '%Y-%m-%d %H:%M')
+                            except Exception:
+                                stale = False
+                            else:
+                                stale = (datetime.datetime.now() - updated_dt) >= datetime.timedelta(minutes=3)
+
+                        if stale:
+                            if myDB is not None:
+                                myDB.upsert(
+                                    'ddl_info',
+                                    {
+                                        'status': 'Failed',
+                                        'updated_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M'),
+                                    },
+                                    {'id': record_id},
+                                )
+                            continue
+
+                        queue.put(item)
+                        time.sleep(10)
+                        continue
+                    
+                    if job_status in completed_states:
+                        myDB.upsert(
+                                'ddl_info',
+                                {
+                                    'status': 'Completed',
+                                    'updated_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M'),
+                                },
+                                {'id': record_id},
+                            )
+                        logger.info('[JD2-QUEUE] Download for %s completed; status marked as Completed.', record_id)
+                        
+                        if not isinstance(item, dict):
+                            logger.warn('[JD2-QUEUE] Unexpected item type %s for job %s; skipping post-processing.', type(item), job_id)
+                            continue
+
+                        if mylar.CONFIG.POST_PROCESSING is True:
+                            dest_root = getattr(mylar.CONFIG, 'JD2_DEST_DIR', None) or None
+                            folder_name = item.get('filename') or '%s (%s) - %s' % (series, year, record_id)
+                            nzb_folder = os.path.join(dest_root, folder_name)
+                            job_filename = (status_payload or {}).get('data').get('name')
+                            
+                            if nzb_folder:
+                                try:
+                                    mylar.PP_QUEUE.put({
+                                        'nzb_name': job_filename or 'Manual Run',
+                                        'nzb_folder': nzb_folder,
+                                        'failed': False,
+                                        'issueid': item.get('issueid'),
+                                        'comicid': item.get('comicid'),
+                                        'apicall': True,
+                                        'ddl': True,
+                                        'download_info': {'provider': 'JD2', 'id': record_id, 'job_id': job_id},
+                                    })
+                                    logger.info('[JD2-QUEUE] Submitted %s for post-processing (folder: %s).', filename, nzb_folder)
+                                except Exception as err:
+                                    logger.warn('[JD2-QUEUE] Unable to enqueue %s for post-processing: %s', filename, err)
+                            else:
+                                logger.warn('[JD2-QUEUE] JD2 destination is not configured; skipping post-processing enqueue for %s.', filename)
+                        else:
+                            logger.info('[JD2-QUEUE] Post-processing disabled, please manually handle your files.')
+                        continue
+
+                    if job_status in failed_states:
+                        myDB.upsert(
+                                'ddl_info',
+                                {
+                                    'status': 'Failed',
+                                    'updated_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M'),
+                                },
+                                {'id': record_id},
+                            )
+                        logger.warn('[JD2-QUEUE] Download %s reported failure state (%s).', filename, job_status)
+                        continue
+
+                    if job_status not in completed_states:
+                        time.sleep(10)
+                        queue.put(item)
+                        continue
+            else:
+                logger.warn('[JD2-QUEUE] Missing JD2 client or job id for item: %s', item)
+        else:
+            time.sleep(10)
 
 
 def postprocess_main(queue):
@@ -3296,6 +3476,7 @@ def queue_info():
             ("AUTO-COMPLETE-NZB", mylar.NZBPOOL, mylar.NZB_QUEUE),
             ("AUTO-SNATCHER", mylar.SNPOOL, mylar.SNATCHED_QUEUE),
             ("DDL-QUEUE", mylar.DDLPOOL, mylar.DDL_QUEUE),
+            ("JD2-QUEUE", mylar.JD2POOL, mylar.JD2_QUEUE),
             ("POST-PROCESS-QUEUE", mylar.PPPOOL, mylar.PP_QUEUE),
             ("SEARCH-QUEUE", mylar.SEARCHPOOL, mylar.SEARCH_QUEUE),
         ]
@@ -5111,4 +5292,3 @@ class ThreadWithReturnValue(Thread):
     def join(self):
         Thread.join(self)
         return self._return
-

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3184,12 +3184,12 @@ def jd2_queue_monitor(queue):
                         if not isinstance(item, dict):
                             logger.warn('[JD2-QUEUE] Unexpected item type %s for job %s; skipping post-processing.', type(item), job_id)
                             continue
-
+                        job_filename = (status_payload or {}).get('data').get('name')
                         if mylar.CONFIG.POST_PROCESSING is True:
                             dest_root = getattr(mylar.CONFIG, 'JD2_DEST_DIR', None) or None
                             folder_name = item.get('filename') or '%s (%s) - %s' % (series, year, record_id)
                             nzb_folder = os.path.join(dest_root, folder_name)
-                            job_filename = (status_payload or {}).get('data').get('name')
+                            
                             
                             if nzb_folder:
                                 try:
@@ -3203,11 +3203,11 @@ def jd2_queue_monitor(queue):
                                         'ddl': True,
                                         'download_info': {'provider': 'JD2', 'id': record_id, 'job_id': job_id},
                                     })
-                                    logger.info('[JD2-QUEUE] Submitted %s for post-processing (folder: %s).', filename, nzb_folder)
+                                    logger.info('[JD2-QUEUE] Submitted %s for post-processing (folder: %s).', job_filename, nzb_folder)
                                 except Exception as err:
-                                    logger.warn('[JD2-QUEUE] Unable to enqueue %s for post-processing: %s', filename, err)
+                                    logger.warn('[JD2-QUEUE] Unable to enqueue %s for post-processing: %s', job_filename, err)
                             else:
-                                logger.warn('[JD2-QUEUE] JD2 destination is not configured; skipping post-processing enqueue for %s.', filename)
+                                logger.warn('[JD2-QUEUE] JD2 destination is not configured; skipping post-processing enqueue for %s.', job_filename)
                         else:
                             logger.info('[JD2-QUEUE] Post-processing disabled, please manually handle your files.')
                         continue
@@ -3221,7 +3221,7 @@ def jd2_queue_monitor(queue):
                                 },
                                 {'id': record_id},
                             )
-                        logger.warn('[JD2-QUEUE] Download %s reported failure state (%s).', filename, job_status)
+                        logger.warn('[JD2-QUEUE] Download %s reported failure state (%s).', job_filename, job_status)
                         continue
 
                     if job_status not in completed_states:

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3056,7 +3056,7 @@ def ddl_cleanup(record_id):
 
 
 def jd2_queue_monitor(queue):
-    jd2_client = None
+    jd2_client = JDownloader2()
     myDB = db.DBConnection()
     while True:
         if queue.qsize() >= 1:
@@ -3107,18 +3107,43 @@ def jd2_queue_monitor(queue):
                             'resume': None,
                             'jd2_job_id': job_id,
                         }
-                        jd2_queue_payload = dict(queue_payload)
-                        queue.put(jd2_queue_payload)
+                        queue.put(queue_payload)
                 continue
+            # if the job id is 0 it's a special case where we need to run the download with self.jd2.submit(jd2_priority_links, package_name, record_id=mod_id). 
+            
+            
+            if item.get('jd2_job_id') == 0:
+                jd2_priority_links = item.get('jd2_priority_links')
+                queue_payload = dict(item)
+                queue_payload.pop('jd2_job_id', None)
+                queue_payload.pop('jd2_priority_links', None)
+                if not jd2_priority_links:
+                    logger.warn('Priority links don\'t exist; cannot process JD2 job. Falling back to DDL queue.')
+                    mylar.DDL_QUEUE.put(queue_payload)
+                    continue
+                record_id = item.get('id') or item.get('ID')
+                package_name = '%s (%s) - %s' % (item.get('series'), item.get('year'), record_id)
+                submit_result = jd2_client.submit(jd2_priority_links, package_name, record_id)
+                
+                if not submit_result.get('status'):
+                    logger.warn('[JD2] Submission failed for %s; falling back to DDL queue. Details: %s', package_name, submit_result)
+                    mylar.DDL_QUEUE.put(queue_payload)
+                else:
+                    logger.debug('[JD2] Submission response for %s: %s', package_name, submit_result)
+                    job_id = submit_result.get('jobid')
+                    if not job_id:
+                        mylar.DDL_QUEUE.put(queue_payload)
+                        continue
+                    queue_payload['jd2_job_id'] = job_id
+                    mylar.JD2_QUEUE.put(queue_payload)
+                    logger.info('[JD2] JD2 job %s submitted for %s', job_id, package_name)
+                    time.sleep(10) # allow the job to start
+                    continue
+                    
             logger.info('[JD2-QUEUE] Now loading from queue: %s' % item)
             record_id = item.get('ID') or item.get('id')
             job_id = item.get('jd2_job_id') if isinstance(item, dict) else None
-            if jd2_client is None:
-                try:
-                    jd2_client = JDownloader2()
-                except Exception as err:
-                    logger.warn('[JD2-QUEUE] Unable to initialize JD2 client: %s', err)
-                    jd2_client = None
+            
 
             if jd2_client is not None and job_id:
                 try:
@@ -3187,7 +3212,11 @@ def jd2_queue_monitor(queue):
                         job_filename = (status_payload or {}).get('data').get('name')
                         if mylar.CONFIG.POST_PROCESSING is True:
                             dest_root = getattr(mylar.CONFIG, 'JD2_DEST_DIR', None) or None
-                            folder_name = item.get('filename') or '%s (%s) - %s' % (series, year, record_id)
+                            folder_name = (
+                                "%s - %s" % (item.get('filename'), record_id)
+                                if item.get('filename')
+                                else "%s (%s) - %s" % (series, year, record_id)
+                            )
                             nzb_folder = os.path.join(dest_root, folder_name)
                             
                             

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6912,6 +6912,9 @@ class WebInterface(object):
                     "airdcpp_announce_hub": mylar.CONFIG.AIRDCPP_ANNOUNCE_HUB,
                     "airdcpp_announce_bots": mylar.CONFIG.AIRDCPP_ANNOUNCE_BOTS,
                     "ddl_prefer_upscaled": helpers.checked(mylar.CONFIG.DDL_PREFER_UPSCALED),
+                    "jd2_enable": helpers.checked(mylar.CONFIG.JD2_ENABLE),
+                    "jd2_url": mylar.CONFIG.JD2_URL or "",
+                    "jd2_dest_dir": mylar.CONFIG.JD2_DEST_DIR or "",
                     "enable_external_server": helpers.checked(mylar.CONFIG.ENABLE_EXTERNAL_SERVER),
                     "external_server": mylar.CONFIG.EXTERNAL_SERVER,
                     "external_username": mylar.CONFIG.EXTERNAL_USERNAME,
@@ -7402,7 +7405,7 @@ class WebInterface(object):
                            'prowl_enabled', 'prowl_onsnatch', 'pushover_enabled', 'pushover_onsnatch', 'pushover_image', 'mattermost_enabled', 'mattermost_onsnatch', 'boxcar_enabled',
                            'boxcar_onsnatch', 'pushbullet_enabled', 'pushbullet_onsnatch', 'telegram_enabled', 'telegram_onsnatch', 'telegram_image', 'discord_enabled', 'discord_onsnatch', 'slack_enabled', 'slack_onsnatch',
                            'email_enabled', 'email_enc', 'email_ongrab', 'email_onpost', 'gotify_enabled', 'gotify_server_url', 'gotify_token', 'gotify_onsnatch', 'opds_enable', 'opds_authentication', 'opds_metainfo', 'opds_pagesize', 'enable_ddl',
-                           'enable_getcomics', 'enable_airdcpp', 'enable_external_server', 'ddl_prefer_upscaled', 'deluge_pause'] #enable_public
+                           'enable_getcomics', 'enable_airdcpp', 'jd2_enable', 'enable_external_server', 'ddl_prefer_upscaled', 'deluge_pause'] #enable_public
 
         for checked_config in checked_configs:
             if checked_config not in kwargs:


### PR DESCRIPTION
So this might need the options removed from the UI as well since this would be more of a power user feature, but this allows you to send off downloads to jdownloader 2  and monitor their completion

It picks the queue back up on startup and automatically fails any failed or unstarted downloads

It sends all mirrors to jdownloader so it can pick the best one, this solves the issue where the best link is dead

I saw there's an external downloader option somewhere in the code but I found nowhere in the code actually using it, it seems to be just a random variable

I finally started using mylar for ddls after adding this in, works like a charm so far