### PR TITLE
FIX: DDL RSS fix to skip non-file posts

### DIFF
--- a/mylar/rsscheck.py
+++ b/mylar/rsscheck.py
@@ -414,6 +414,11 @@ def ddl(forcerss=False):
     for entry in feedme.entries:
         soup = BeautifulSoup(entry.summary, 'html.parser')
         orig_find = soup.find("p", {"style": "text-align: center;"})
+
+        # Non-comic posts don't have the centered header of data so can be skipped
+        if orig_find is None:
+            continue
+
         i = 0
         option_find = orig_find
         while True: #i <= 10:


### PR DESCRIPTION
The DDL feed processing was throwing an exception because of the missing header paragraph in non-file posts.  Not sure if other non-file posts have shown up in the feed before or if it normally filters (the culprit in this case was tagged as "News" whereas previous things like site updates are tagged as "Blog").  Regardless, will skip an entry if it doesn't have that expected centered paragraph of year + size data.