### PR TITLE
Fix: Sort "have" by percent amount on ManageComics page

### DIFF
--- a/data/interfaces/default/managecomics.html
+++ b/data/interfaces/default/managecomics.html
@@ -88,7 +88,7 @@
                                 <td class="hidden" id="stat_title">${comic['Status']}</td>
 				<td id="latest">${comic['LatestIssue']} (${comic['LatestDate']})</td>
                                 <td id="publisher">${comic['ComicPublisher']}</td>
-                                <td id="have" valign="center"><span title="${comic['percent']}"></span>${css}<div style="width:${comic['percent']}%"><div style="width:${comic['percent']}%"><div class="havetracks">${comic['haveissues']}/${comic['totalissues']}</div></div></div></td>
+                                <td id="have" valign="center" data-order="${comic['percent'] or 0}"><span title="${comic['percent']}"></span>${css}<div style="width:${comic['percent']}%"><div style="width:${comic['percent']}%"><div class="havetracks">${comic['haveissues']}/${comic['totalissues']}</div></div></div></td>
 				<td id="lastupdated">${comic['DateAdded']}</td>
 			</tr>
 		%endfor


### PR DESCRIPTION
Fixes #1721

Currently the manage comics page does string sorting on the field, so if you have 194/242 and 5/6 and 1/1 you will get the sorting
1/1 192/242/5/6 

The sorting order should be based on the percent, not on string comparison. Simple change