### PR TITLE
Filename could contain None due to series being None

### DIFF
--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -909,8 +909,6 @@ class GC(object):
             ' (go get some take-out)...' % (dl_selection, series, year, size)
         )
 
-        tmp_filename = '%s (%s)' % (series, year)
-
         links = []
 
         if link is None and possible_more.name == 'ul':
@@ -1098,6 +1096,8 @@ class GC(object):
                 # this is needed so that we assign some tmp filename
                 # (it will get renamed upon completion anyways)
                 #tmp_filename = comicinfo[0]['nzbtitle']
+                
+            tmp_filename = '%s (%s)' % (x['series'], x['year'])    
 
             mylar.DDL_QUEUE.put(
                 {


### PR DESCRIPTION
In some cases tmp_filename could be initialized when series = None, such as when set by this part of the code

```
                if looped_thru_once is False and lk['title'] == 'Read Online':
                    #logger.fdebug('read online section discovered...bypassing and ignoring...')
                    valid_links[multiple_links].update({'links': gather_links})
                    looped_thru_once = True
                    gather_links = []
                    i = 0
                    series = None
```

After this happens, you might never get another good link with a series name. I went through the debugger line by line to see what was going on.

tmp_filename is initialized waaaaaaaay before it's actually used, and it's only used in one place. I moved it to be initialized when it's actually needed and from the correct data.

x['series'] will never be none 

This simple change fixes the bug