### PR TITLE
Merge suggestion

### DIFF
--- a/data/interfaces/default/manage.html
+++ b/data/interfaces/default/manage.html
@@ -447,6 +447,7 @@
                         {
                                 $("#move_options").show();
                                 $("#path_options").hide();
+                                $("#imp_paths").prop("checked", false);
                         }
                 else
                         {
@@ -459,6 +460,7 @@
                         {
                                 $("#move_options").slideDown();
                                 $("#path_options").slideUp();
+                                $("#imp_paths").prop("checked", false);
                         }
                         else
                         {

--- a/data/interfaces/default/managecomics.html
+++ b/data/interfaces/default/managecomics.html
@@ -88,7 +88,7 @@
                                 <td class="hidden" id="stat_title">${comic['Status']}</td>
 				<td id="latest">${comic['LatestIssue']} (${comic['LatestDate']})</td>
                                 <td id="publisher">${comic['ComicPublisher']}</td>
-                                <td id="have" valign="center"><span title="${comic['percent']}"></span>${css}<div style="width:${comic['percent']}%"><div style="width:${comic['percent']}%"><div class="havetracks">${comic['haveissues']}/${comic['totalissues']}</div></div></div></td>
+                                <td id="have" valign="center" data-order="${comic['percent'] or 0}"><span title="${comic['percent']}"></span>${css}<div style="width:${comic['percent']}%"><div style="width:${comic['percent']}%"><div class="havetracks">${comic['haveissues']}/${comic['totalissues']}</div></div></div></td>
 				<td id="lastupdated">${comic['DateAdded']}</td>
 			</tr>
 		%endfor

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -159,7 +159,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'CV_ONLY': (bool, 'CV', True),
     'CV_ONETIMER': (bool, 'CV', True),
     'CVINFO': (bool, 'CV', False),
-    'CV_USER_AGENT': (str, 'CV', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36'),
+    'CV_USER_AGENT': (str, 'CV', 'comictagger image fetcher'),
     'IMPRINT_MAPPING_TYPE': (str, 'CV', 'CV'),  # either 'CV' for ComicVine or 'JSON' for imprints.json to choose which naming to use for imprints
 
     'LOG_DIR' : (str, 'Logs', None),
@@ -1548,7 +1548,9 @@ class Config(object):
 
         #make sure the user_agent is running a current version and write it to the .ComicTagger file for use with CT
         if '42.0.2311.135' in self.CV_USER_AGENT:
-            self.CV_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36'
+            self.CV_USER_AGENT = 'comictagger image fetcher'
+        if '122.0.0.0' in self.CV_USER_AGENT:
+            self.CV_USER_AGENT = 'comictagger image fetcher'
 
         ct_settingsfile = os.path.join(self.CT_SETTINGSPATH, 'settings')
         if os.path.exists(ct_settingsfile):

--- a/mylar/rsscheck.py
+++ b/mylar/rsscheck.py
@@ -414,6 +414,11 @@ def ddl(forcerss=False):
     for entry in feedme.entries:
         soup = BeautifulSoup(entry.summary, 'html.parser')
         orig_find = soup.find("p", {"style": "text-align: center;"})
+
+        # Non-comic posts don't have the centered header of data so can be skipped
+        if orig_find is None:
+            continue
+
         i = 0
         option_find = orig_find
         while True: #i <= 10:


### PR DESCRIPTION
Thought I would bundle together some changes that I think are fairly important (fixing issues that make noise in #support), and pretty clear cut so could go straight into nightly then push through to master.  Combines and cleans up the following PRs with a rebase on current p3-dev: #1739, #1735, #1733, #1732

On the subject of a push to master, might be time to do one?  The biggest new change in the current nightly is probably the airdcpp support.  A number of people have been using it to a degree of success, so I think it's safe to put in the wild, though it could do with being followed up with:
- Some documentation / user guide
- A solution for post-process move/copy/link options for DC++ given the desire to avoid file manipulation.  Not sure whether that should be a move to having a setting for every source, or just a specific override setting for airdcpp (&torrents?).  Leaning towards the latter, partly to highlight it to end users as a key consideration.

That would in turn enable pushing @barrelltitor's JD2 change into nightly to get some broader testing on it (+some other changes).