### PR TITLE
FIX: Quick fix for 2026 This Week page loading

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -2716,7 +2716,7 @@ def weekly_info(week=None, year=None, current=None):
         year = int(year)
     else:
         #find the given week number for the current day
-        weeknumber = current_weeknumber
+        weeknumber = int(current_weeknumber)
         year = int(todaydate.strftime("%Y"))
 
     #monkey patch for 2018/2019 - week 52/week 0


### PR DESCRIPTION
Quick fix to resolve This Week not loading after the new year due to a missing cast.  This does not fix the underlying problem of year/week mapping for the new year and WS as that will need to be a unified solution.

To close #1753