### PR TITLE
Add an optional paging parameter to the findComic API endpoint

### DIFF
--- a/API_REFERENCE
+++ b/API_REFERENCE
@@ -63,7 +63,7 @@ restart (restart mylar)
 update (update mylar - you may want to check the install type in get version and not allow this if type==exe)
 
 downloadIssue&id=$issueid (download that issue to your browser)
-findComic&name=$comicname (Find comics)
+findComic&name=$comicname[&page=$page] (Find comics)
 
 getStoryArc (List all story arcs)
 getStoryArc&customOnly=1 (List custom story arcs)

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -1079,12 +1079,22 @@ class Api(object):
             else:
                 self.data = self._failureResponse('Failed to return a image')
 
-    def _findComic(self, name, issue=None, type_=None, mode=None, serinfo=None):
+    def _findComic(self, name, issue=None, type_=None, mode=None, serinfo=None, page=None, pagesize=100):
         # set defaults
         if type_ is None:
             type_ = 'comic'
         if mode is None:
             mode = 'series'
+        if page is not None:
+            try:
+                page = int(page)
+            except (ValueError, TypeError):
+                page = None
+        if pagesize is not None:
+            try:
+                pagesize = int(pagesize)
+            except (ValueError, TypeError):
+                pagesize = 100
 
         # Dont do shit if name is missing
         if len(name) == 0:
@@ -1092,13 +1102,13 @@ class Api(object):
             return
 
         if type_ == 'comic' and mode == 'series':
-            searchresults = mb.findComic(name, mode, issue=issue)
+            searchresults = mb.findComic(name, mode, issue=issue, page=page, pagesize=pagesize)
         elif type_ == 'comic' and mode == 'pullseries':
-            searchresults = mb.findComic(name, mode, issue=issue)
+            searchresults = mb.findComic(name, mode, issue=issue, page=page, pagesize=pagesize)
         elif type_ == 'comic' and mode == 'want':
-            searchresults = mb.findComic(name, mode, issue=issue)
+            searchresults = mb.findComic(name, mode, issue=issue, page=page, pagesize=pagesize)
         elif type_ == 'story_arc':
-            searchresults = mb.findComic(name, mode, issue=None, search_type='story_arc')
+            searchresults = mb.findComic(name, mode, issue=None, search_type='story_arc', page=page, pagesize=pagesize)
 
         searchresults = sorted(searchresults, key=itemgetter('comicyear', 'issues'), reverse=True)
         self.data = searchresults

--- a/mylar/mb.py
+++ b/mylar/mb.py
@@ -98,7 +98,7 @@ def pullsearch(comicapi, comicquery, offset, search_type):
     else:
         return dom
 
-def findComic(name, mode, issue, limityear=None, search_type=None, annual_check=False):
+def findComic(name, mode, issue, limityear=None, search_type=None, annual_check=False, page=None, pagesize=100):
 
     #with mb_lock:
     comicResults = None
@@ -155,10 +155,17 @@ def findComic(name, mode, issue, limityear=None, search_type=None, annual_check=
     logger.fdebug("there are " + str(totalResults) + " search results...")
     if not totalResults:
         return False
-    if int(totalResults) > 1000:
+    if int(totalResults) > 1000 and page is None:
         logger.warn('Search returned more than 1000 hits [' + str(totalResults) + ']. Only displaying first 1000 results - use more specifics or the exact ComicID if required.')
         totalResults = 1000
     countResults = 0
+    if page is not None and page > 0:
+        # Limit results to a specific page
+        # Search results are limited to 100 per page by default
+        # pagesize is only used when requesting a specific page
+        pagesize = max(1, min(100, pagesize))
+        countResults = (page - 1) * pagesize
+        totalResults = min(countResults + pagesize, int(totalResults))
     while (countResults < int(totalResults)):
         #logger.fdebug("querying " + str(countResults))
         if countResults > 0:
@@ -508,6 +515,9 @@ def findComic(name, mode, issue, limityear=None, search_type=None, annual_check=
                 n+=1
         #search results are limited to 100 and by pagination now...let's account for this.
         countResults = countResults + 100
+
+    if page is not None:
+        return comiclist[:pagesize]
 
     return comiclist
 


### PR DESCRIPTION
This is a bit hacky, but I wanted to minimize any sort of alterations to the default use case.