### PR TITLE
Fix ddl cleanup + add keep html cache config option

### DIFF
--- a/mylar/config.py
+++ b/mylar/config.py
@@ -97,6 +97,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'SHOW_ICONS': (bool, 'General', False),
     'FORMAT_BOOKTYPE': (bool, 'General', True),
     'CLEANUP_CACHE': (bool, 'General', True),
+    'KEEP_HTML_CACHE': (bool, 'General', False),
     'CLEANUP_STRAYS': (bool, 'General', False),
     'SECURE_DIR': (str, 'General', None),
     'ENCRYPT_PASSWORDS': (bool, 'General', False),

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3045,14 +3045,21 @@ def ddl_downloader(queue):
             time.sleep(5)
 
 def ddl_cleanup(record_id):
-   # remove html file from cache if it's successful
-   tlnk = 'getcomics-%s.html' % id
-   try:
-       os.remove(os.path.join(mylar.CONFIG.CACHE_DIR, 'html_cache', tlnk))
-   except Exception as e:
-       logger.fdebug('[HTML-cleanup] Unable to remove html used for item from html_cache folder.'
-                     ' Manual removal required or set `cleanup_cache=True` in the config.ini to'
-                     ' clean cache items on every startup. If this was a Retry - ignore this.')
+    if getattr(mylar.CONFIG, 'KEEP_HTML_CACHE', False):
+        logger.fdebug('[HTML-cleanup] KEEP_HTML_CACHE enabled; skipping removal for %s.', record_id)
+        return
+
+    tlnk = 'getcomics-%s.html' % record_id
+    cache_path = os.path.join(mylar.CONFIG.CACHE_DIR, 'html_cache', tlnk)
+    try:
+        os.remove(cache_path)
+    except FileNotFoundError:
+        logger.fdebug('[HTML-cleanup] %s not found in html_cache. Nothing to remove.', tlnk)
+    except Exception as e:
+        logger.fdebug('[HTML-cleanup] Unable to remove %s from html_cache: %s. '
+                    'Manual removal required or set `cleanup_cache=True` in the config.ini to '
+                    'clean cache items on every startup. If this was a Retry - ignore this.',
+                    tlnk, e)
 
 
 def jd2_queue_monitor(queue):

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6826,6 +6826,7 @@ class WebInterface(object):
                     "launch_browser": helpers.checked(mylar.CONFIG.LAUNCH_BROWSER),
                     "auto_update": helpers.checked(mylar.CONFIG.AUTO_UPDATE),
                     "max_logsize": mylar.CONFIG.MAX_LOGSIZE,
+                    "keep_html_cache": helpers.checked(mylar.CONFIG.KEEP_HTML_CACHE),
                     "annuals_on": helpers.checked(mylar.CONFIG.ANNUALS_ON),
                     "enable_check_folder": helpers.checked(mylar.CONFIG.ENABLE_CHECK_FOLDER),
                     "check_folder": mylar.CONFIG.CHECK_FOLDER,
@@ -7395,7 +7396,7 @@ class WebInterface(object):
 
 
     def configUpdate(self, **kwargs):
-        checked_configs = ['enable_https', 'launch_browser', 'backup_on_start', 'syno_fix', 'auto_update', 'annuals_on', 'api_enabled', 'nzb_startup_search',
+        checked_configs = ['enable_https', 'launch_browser', 'backup_on_start', 'keep_html_cache', 'syno_fix', 'auto_update', 'annuals_on', 'api_enabled', 'nzb_startup_search',
                            'enforce_perms', 'sab_to_mylar', 'torrent_local', 'torrent_seedbox', 'rtorrent_ssl', 'rtorrent_verify', 'rtorrent_startonload',
                            'enable_torrents', 'enable_rss', 'experimental', 'enable_torrent_search', 'enable_32p', 'enable_torznab',
                            'newznab', 'use_minsize', 'use_maxsize', 'ddump', 'failed_download_handling', 'sab_client_post_processing', 'nzbget_client_post_processing',

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -321,6 +321,15 @@ def test_ddl_cleanup(when, monkeypatch):
     helpers.ddl_cleanup('1234')
     verify(os, times=1).remove(os.path.join(os.getcwd(), "html_cache", "getcomics-1234.html"))
 
+# shouldn't delete if keep html cache is enabled
+@pytest.mark.unit
+def test_ddl_cleanup_keep_cache(monkeypatch):
+    monkeypatch.setattr(mylar, "CONFIG", mylar.config.Config("./nothing"))
+    monkeypatch.setattr(mylar.CONFIG, "CACHE_DIR", os.getcwd(), raising=False)
+    monkeypatch.setattr(mylar.CONFIG, "KEEP_HTML_CACHE", True, raising=False)
+    helpers.ddl_cleanup('1234')
+    verify(os, times=0).remove(os.path.join(os.getcwd(), "html_cache", "getcomics-1234.html"))
+
 
 class MockEnvOnSnatchScript():
     def __enter__(self):


### PR DESCRIPTION
You know the saying, a longstanding bug is a feature. I like keeping the HTML cache and probably more people do, so an option was added for this as well