### PR TITLE
IMP: Add Easynews as a DDL provider for direct comic downloads

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -868,6 +868,23 @@
                                           </div>
                                        </div>
                                        %endif
+                                       <div class="row checkbox left clearfix">
+                                            <input type="checkbox" id="enable_easynews" onclick="initConfigCheckbox($(this));" name="enable_easynews" value="1" ${config['enable_easynews']} /><label>Enable Easynews</label>
+                                       </div>
+                                       <div id="easynews_options" style="display:none">
+                                           <div class="row">
+                                              <label>Username</label>
+                                              <input type="text" name="easynews_username" id="easynews_username" value="${config['easynews_username']}" size="30">
+                                           </div>
+                                           <div class="row">
+                                              <label>Password</label>
+                                              <input type="password" name="easynews_password" id="easynews_password" value="${config['easynews_password']}" size="30">
+                                           </div>
+                                           <div align="center" class="row">
+                                              <input type="button" value="Test Easynews" id="test_easynews" />
+                                              <input type="text" name="easynewsstatus" id="easynewsstatus" style="text-align:center;font-size:11px;color:white;" size="50" DISABLED />
+                                           </div>
+                                       </div>
                                    </div>
                                 </div>
                         </fieldset>
@@ -2109,6 +2126,34 @@
                                 //document.getElementById("enable_getcomics").checked = false;
                                 $("#external_options").slideUp();
                         }
+                });
+
+                if ($("#enable_easynews").is(":checked"))
+                        {
+                                $("#easynews_options").show();
+                        }
+                else    {
+                                $("#easynews_options").hide();
+                        }
+
+                $("#enable_easynews").click(function(){
+                        if ($("#enable_easynews").is(":checked"))
+                        {
+                                $("#easynews_options").slideDown();
+                        }
+                        else
+                        {
+                                $("#easynews_options").slideUp();
+                        }
+                });
+
+                $('#test_easynews').click(function(){
+                    var username = $("#easynews_username").val();
+                    var password = $("#easynews_password").val();
+                    $.get("testeasynews", {username: username, password: password}, function(data){
+                        var obj = JSON.parse(data);
+                        $('#easynewsstatus').val(obj['message']);
+                    });
                 });
 
                 if ($("#cbr2cbz_only").is(":checked"))

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -373,6 +373,9 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'ENABLE_PROXY': (bool, 'DDL', False),
     'HTTP_PROXY': (str, 'DDL', None),
     'HTTPS_PROXY': (str, 'DDL', None),
+    'ENABLE_EASYNEWS': (bool, 'DDL', False),
+    'EASYNEWS_USERNAME': (str, 'DDL', None),
+    'EASYNEWS_PASSWORD': (str, 'DDL', None),
 
     'AUTO_SNATCH': (bool, 'AutoSnatch', False),
     'AUTO_SNATCH_SCRIPT': (str, 'AutoSnatch', None),
@@ -1105,6 +1108,7 @@ class Config(object):
                             'OPDS_PASSWORD':         ('OPDS', 'opds_password', self.OPDS_PASSWORD),
                             'PP_SSHPASSWD':          ('AutoSnatch', 'pp_sshpasswd', self.PP_SSHPASSWD),
                             'EMAIL_PASSWORD':        ('Email','email_password', self.EMAIL_PASSWORD),
+                            'EASYNEWS_PASSWORD':     ('DDL', 'easynews_password', self.EASYNEWS_PASSWORD),
                             })
 
         new_encrypted = 0
@@ -1813,8 +1817,11 @@ class Config(object):
             if self.ENABLE_EXTERNAL_SERVER:
                 PR.append('DDL(External)')
                 PR_NUM +=1
+            if self.ENABLE_EASYNEWS:
+                PR.append('DDL(Easynews)')
+                PR_NUM +=1
 
-        PPR = ['Experimental', 'DDL(GetComics)', 'DDL(External)']
+        PPR = ['Experimental', 'DDL(GetComics)', 'DDL(External)', 'DDL(Easynews)']
         if self.NEWZNAB:
             for ens in self.EXTRA_NEWZNABS:
                 if str(ens[5]) == '1': # if newznabs are enabled
@@ -2013,9 +2020,12 @@ class Config(object):
                if 'DDL(GetComics)' in tmp_prov:
                    t_type = 'DDL'
                    t_id = 200
-               if 'DDL(External)' in tmp_prov:
+               elif 'DDL(External)' in tmp_prov:
                    t_type = 'DDL(External)'
                    t_id = 201
+               elif 'DDL(Easynews)' in tmp_prov:
+                   t_type = 'DDL'
+                   t_id = 202
                elif any(['experimental' in tmp_prov, 'Experimental' in tmp_prov]):
                    tmp_prov = 'experimental'
                    t_type = 'experimental'

--- a/mylar/easynews.py
+++ b/mylar/easynews.py
@@ -1,0 +1,372 @@
+# -*- coding: utf-8 -*-
+# This file is part of Mylar.
+#
+# Mylar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Mylar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import requests
+import os
+import re
+import time
+import datetime
+import zipfile
+import mylar
+from mylar import db, logger, helpers, search_filer
+
+
+class Easynews(object):
+
+    def __init__(self, query=None, issueid=None, comicid=None, oneoff=False, provider_stat=None):
+
+        self.session = requests.Session()
+        self.session.auth = (mylar.CONFIG.EASYNEWS_USERNAME or '', mylar.CONFIG.EASYNEWS_PASSWORD or '')
+
+        if mylar.CONFIG.ENABLE_PROXY:
+            self.session.proxies.update({
+                'http':  mylar.CONFIG.HTTP_PROXY,
+                'https': mylar.CONFIG.HTTPS_PROXY
+            })
+
+        self.base_url = 'https://members.easynews.com/2.0/search/solr-search/advanced'
+        self.file_extensions = 'cbr,cbz,cb7,pdf'
+
+        self.query = query  # {'comicname', 'issue', 'year'}
+        self.comicid = comicid
+        self.issueid = issueid
+        self.oneoff = oneoff
+        self.provider_stat = provider_stat
+
+        self.search_format = ['"%s #%s (%s)"', '%s #%s (%s)', '%s #%s', '%s %s']
+
+    def search(self, is_info=None):
+        try:
+            if is_info is not None:
+                if is_info['chktpb'] == 0:
+                    logger.debug('[DDL(Easynews)] removing query from loop that accounts for no issue number')
+                else:
+                    self.search_format.insert(0, self.query['comicname'])
+                    logger.debug('[DDL(Easynews)] setting no issue number query to be first due to no issue number')
+
+            for sf in self.search_format:
+                verified_matches = []
+                sf_issue = self.query['issue']
+
+                if is_info['chktpb'] == 1 and self.query['comicname'] == sf:
+                    comicname = re.sub(r'[\&\:\?\,\/\-]', '', self.query['comicname'])
+                    comicname = re.sub("\\band\\b", '', comicname, flags=re.I)
+                    comicname = re.sub("\\bthe\\b", '', comicname, flags=re.I)
+                    queryline = re.sub(r'\s+', ' ', comicname)
+                else:
+                    if any([self.query['issue'] == 'None', self.query['issue'] is None]):
+                        sf_issue = None
+                    if sf.count('%s') == 3:
+                        if sf_issue is None:
+                            splits = sf.split(' ')
+                            splits.pop(1)
+                            queryline = ' '.join(splits) % (self.query['comicname'], self.query['year'])
+                        else:
+                            queryline = sf % (self.query['comicname'], sf_issue, self.query['year'])
+                    else:
+                        sf_count = len([m.start() for m in re.finditer('(?=%s)', sf)])
+                        if sf_count == 0:
+                            queryline = sf
+                        elif sf_count == 2:
+                            queryline = sf % (self.query['comicname'], sf_issue)
+                        elif sf_count == 3:
+                            queryline = sf % (self.query['comicname'], sf_issue, self.query['year'])
+                        else:
+                            queryline = sf % (self.query['comicname'])
+
+                if not queryline:
+                    continue
+
+                logger.fdebug('[DDL(Easynews)-QUERY] Query set to: %s' % queryline)
+
+                result_generator = self.perform_search_queries(queryline)
+                sfs = search_filer.search_check()
+                match = sfs.check_for_first_result(
+                    result_generator, is_info, prefer_pack=False
+                )
+                if match is not None:
+                    verified_matches = [match]
+                    logger.fdebug('[DDL(Easynews)] verified_matches: %s' % (verified_matches,))
+                    break
+                logger.fdebug('[DDL(Easynews)] sleep...%s%s' % (mylar.CONFIG.DDL_QUERY_DELAY, 's'))
+                time.sleep(mylar.CONFIG.DDL_QUERY_DELAY)
+
+        except requests.exceptions.Timeout as e:
+            logger.warn('[DDL(Easynews)] Timeout occured fetching data: %s' % e)
+            return 'no results'
+        except requests.exceptions.ConnectionError as e:
+            logger.warn('[DDL(Easynews)] Connection error: %s' % e)
+            return 'no results'
+        except Exception as err:
+            logger.warn('[DDL(Easynews)] Error during search: %s' % err)
+            return 'no results'
+        else:
+            return verified_matches if verified_matches else 'no results'
+
+    def perform_search_queries(self, queryline):
+        page_number = 1
+        per_page = 250
+
+        while True:
+            pause_the_search = mylar.CONFIG.DDL_QUERY_DELAY
+            diff = mylar.search.check_time(self.provider_stat['lastrun'])
+            if diff < pause_the_search:
+                logger.warn('[PROVIDER-SEARCH-DELAY][DDL(Easynews)] Waiting %s seconds before next search...' % (pause_the_search - int(diff)))
+                time.sleep(pause_the_search - int(diff))
+            else:
+                logger.fdebug('[PROVIDER-SEARCH-DELAY][DDL(Easynews)] Last search took place %s seconds ago. We\'re clear...' % (int(diff)))
+
+            params = {
+                'gps': queryline,
+                'fex': self.file_extensions,
+                'pby': per_page,
+                'pno': page_number,
+                's1': 'dsize',
+                's1d': '-',
+                'spamf': 1,
+                'st': 'adv',
+                'sb': 1,
+            }
+
+            try:
+                response = self.session.get(
+                    self.base_url,
+                    params=params,
+                    timeout=(30, 30)
+                )
+            except Exception as e:
+                logger.warn('[DDL(Easynews)] Error fetching search page %s: %s' % (page_number, e))
+                break
+
+            if response.status_code != 200:
+                logger.warn('[DDL(Easynews)] Search returned status %s' % response.status_code)
+                if response.status_code == 401:
+                    logger.warn('[DDL(Easynews)] Authentication failed. Check username/password.')
+                break
+
+            write_time = time.time()
+            mylar.search.last_run_check(write={'DDL(Easynews)': {'id': 202, 'active': True, 'lastrun': write_time, 'type': 'DDL', 'hits': self.provider_stat['hits']+1}})
+            self.provider_stat['lastrun'] = write_time
+
+            try:
+                data = response.json()
+            except Exception as e:
+                logger.warn('[DDL(Easynews)] Failed to parse JSON response: %s' % e)
+                break
+
+            dl_farm = data.get('dlFarm')
+            dl_port = data.get('dlPort')
+            results = data.get('data', [])
+
+            if not results:
+                logger.fdebug('[DDL(Easynews)] No results on page %s' % page_number)
+                break
+
+            logger.info('[DDL(Easynews)] Found %s results on page %s' % (len(results), page_number))
+
+            for item in results:
+                normalized = self._normalize_result(item, dl_farm, dl_port)
+                if normalized is not None:
+                    yield normalized
+
+            if len(results) < per_page:
+                break
+
+            page_number += 1
+
+    def _normalize_result(self, item, dl_farm, dl_port):
+        # Skip password protected or virus-flagged files
+        if item.get('passwd') or item.get('virus'):
+            return None
+
+        file_hash = item.get('0', '')
+        extension = item.get('2', '')
+        rawsize = item.get('rawSize', item.get('4', 0))
+        date_str = item.get('5', '')
+        filename = item.get('10', '')
+
+        if not file_hash or not filename:
+            return None
+
+        # Build the download URL
+        download_url = 'https://members.easynews.com/%s/%s/%s%s/%s%s' % (
+            dl_farm, dl_port, file_hash, extension, filename, extension
+        )
+
+        # Format file size for display
+        try:
+            size_bytes = int(rawsize)
+            if size_bytes >= 1073741824:
+                size_display = '%.1f GB' % (size_bytes / 1073741824.0)
+            elif size_bytes >= 1048576:
+                size_display = '%.1f MB' % (size_bytes / 1048576.0)
+            elif size_bytes >= 1024:
+                size_display = '%.1f KB' % (size_bytes / 1024.0)
+            else:
+                size_display = '%s B' % size_bytes
+        except (ValueError, TypeError):
+            size_display = '0 MB'
+
+        # Format date
+        try:
+            pubdate = datetime.datetime.strptime(date_str[:10], '%Y-%m-%d').strftime('%a, %d %b %Y %H:%M:%S')
+        except Exception:
+            pubdate = datetime.datetime.now().strftime('%a, %d %b %Y %H:%M:%S')
+
+        # Strip extension from filename for title
+        title = os.path.splitext(filename)[0]
+
+        return {
+            "title": title,
+            "pubdate": pubdate,
+            "filename": filename,
+            "size": size_display,
+            "pack": False,
+            "series": None,
+            "link": download_url,
+            "year": None,
+            "id": file_hash,
+            "site": "DDL(Easynews)",
+        }
+
+    def downloadit(self, id, link, issueid, remote_filesize=0):
+        myDB = db.DBConnection()
+
+        if mylar.DDL_LOCK is True:
+            logger.fdebug('[DDL(Easynews)] Download is locked - another download is in progress...')
+            return {"success": False, "filename": None, "path": None}
+
+        mylar.DDL_LOCK = True
+        filename = None
+
+        try:
+            # Extract filename from URL path
+            url_filename = link.rsplit('/', 1)[-1] if '/' in link else None
+            if url_filename:
+                filename = requests.utils.unquote(url_filename)
+            else:
+                filename = 'easynews_%s' % id
+
+            # Add issueid tag to filename
+            file_base, file_ext = os.path.splitext(filename)
+            filename = '%s[__%s__]%s' % (file_base, issueid, file_ext)
+
+            # Write tracking info to db
+            myDB.upsert(
+                'ddl_info',
+                {'filename': filename, 'remote_filesize': remote_filesize},
+                {'id': id},
+            )
+
+            if mylar.CONFIG.DDL_LOCATION is not None and not os.path.isdir(
+                mylar.CONFIG.DDL_LOCATION
+            ):
+                checkdirectory = mylar.filechecker.validateAndCreateDirectory(
+                    mylar.CONFIG.DDL_LOCATION, True
+                )
+                if not checkdirectory:
+                    logger.warn(
+                        '[DDL(Easynews)] [ABORTING] Error trying to validate/create DDL download'
+                        ' directory: %s.' % mylar.CONFIG.DDL_LOCATION
+                    )
+                    mylar.DDL_LOCK = False
+                    return {"success": False, "filename": filename, "path": None}
+
+            dst_path = os.path.join(mylar.CONFIG.DDL_LOCATION, filename)
+
+            logger.info('[DDL(Easynews)] Downloading %s to %s' % (filename, dst_path))
+
+            t = self.session.get(link, stream=True, timeout=(30, 300))
+
+            if t.status_code == 401:
+                logger.warn('[DDL(Easynews)] Authentication failed during download. Check credentials.')
+                mylar.DDL_LOCK = False
+                return {"success": False, "filename": filename, "path": None}
+
+            if t.status_code != 200:
+                logger.warn('[DDL(Easynews)] Download returned status %s' % t.status_code)
+                mylar.DDL_LOCK = False
+                return {"success": False, "filename": filename, "path": None}
+
+            t.headers['Accept-encoding'] = 'gzip'
+
+            if os.path.exists(dst_path):
+                logger.fdebug('[DDL(Easynews)] %s already exists - removing' % dst_path)
+                try:
+                    os.remove(dst_path)
+                except Exception as e:
+                    file_base, file_ext = os.path.splitext(filename)
+                    filename = '%s.1%s' % (file_base, file_ext)
+                    dst_path = os.path.join(mylar.CONFIG.DDL_LOCATION, filename)
+                    logger.warn(
+                        '[DDL(Easynews)] [ERROR: %s] Unable to remove existing file.'
+                        ' Creating tmp file @%s' % (e, filename)
+                    )
+
+            with open(dst_path, 'wb') as f:
+                for chunk in t.iter_content(chunk_size=1024):
+                    if chunk:
+                        f.write(chunk)
+                        f.flush()
+
+        except requests.exceptions.Timeout as e:
+            logger.error('[DDL(Easynews)] Download timed out: %s' % e)
+            mylar.DDL_LOCK = False
+            return {"success": False, "filename": filename, "path": None}
+
+        except Exception as e:
+            logger.error('[DDL(Easynews)] Download error: %s' % e)
+            mylar.DDL_LOCK = False
+            return {"success": False, "filename": filename, "path": None}
+        else:
+            mylar.DDL_LOCK = False
+            return self._zip_check(id, dst_path, filename)
+
+    def _zip_check(self, id, dst_path, filename):
+        if os.path.isfile(dst_path):
+            if dst_path.endswith('.zip'):
+                new_path = os.path.join(
+                    mylar.CONFIG.DDL_LOCATION, re.sub('.zip', '', filename).strip()
+                )
+                logger.info(
+                    '[DDL(Easynews)] Zip file detected.'
+                    ' Unzipping into: %s' % new_path
+                )
+                try:
+                    zip_f = zipfile.ZipFile(dst_path, 'r')
+                    zip_f.extractall(new_path)
+                    zip_f.close()
+                except Exception as e:
+                    logger.warn(
+                        '[DDL(Easynews)] [ERROR: %s] Unable to extract zip file: %s' % (e, new_path)
+                    )
+                    return {"success": False, "filename": filename, "path": None}
+                else:
+                    try:
+                        os.remove(dst_path)
+                    except Exception as e:
+                        logger.warn(
+                            '[DDL(Easynews)] [ERROR: %s] Unable to remove zip file from %s after'
+                            ' extraction.' % (e, dst_path)
+                        )
+                    filename = None
+            else:
+                new_path = dst_path
+            return {"success": True, "filename": filename, "path": new_path}
+
+        mylar.DDL_LOCK = False
+        return {"success": False, "filename": filename, "path": None}

--- a/mylar/easynews.py
+++ b/mylar/easynews.py
@@ -105,6 +105,35 @@ class Easynews(object):
                 logger.fdebug('[DDL(Easynews)] sleep...%s%s' % (mylar.CONFIG.DDL_QUERY_DELAY, 's'))
                 time.sleep(mylar.CONFIG.DDL_QUERY_DELAY)
 
+            # Fallback: try normalized title (e.g. "Aliens Predator ..." for "Aliens vs. Predator ...")
+            # so we find files named without "vs." or with different punctuation
+            if not verified_matches and is_info is not None:
+                normalized_name = re.sub(r'\s*vs\.?\s*', ' ', self.query['comicname'], flags=re.I)
+                normalized_name = re.sub(r'\s*-\s*', ' ', normalized_name)
+                normalized_name = re.sub(r'\s+', ' ', normalized_name).strip()
+                if normalized_name != self.query['comicname']:
+                    for fmt in ['%s #%s', '%s %s']:
+                        sf_issue = self.query['issue']
+                        if any([self.query['issue'] == 'None', self.query['issue'] is None]):
+                            sf_issue = None
+                        if fmt == '%s %s' and sf_issue is not None:
+                            queryline = fmt % (normalized_name, sf_issue)
+                        elif fmt == '%s #%s' and sf_issue is not None:
+                            queryline = fmt % (normalized_name, sf_issue)
+                        else:
+                            continue
+                        logger.fdebug('[DDL(Easynews)-QUERY] Fallback query (normalized): %s' % queryline)
+                        result_generator = self.perform_search_queries(queryline)
+                        sfs = search_filer.search_check()
+                        match = sfs.check_for_first_result(
+                            result_generator, is_info, prefer_pack=False
+                        )
+                        if match is not None:
+                            verified_matches = [match]
+                            logger.fdebug('[DDL(Easynews)] verified_matches (normalized query): %s' % (verified_matches,))
+                            break
+                        time.sleep(mylar.CONFIG.DDL_QUERY_DELAY)
+
         except requests.exceptions.Timeout as e:
             logger.warn('[DDL(Easynews)] Timeout occured fetching data: %s' % e)
             return 'no results'

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -108,7 +108,7 @@ class FileChecker(object):
 
         self.failed_files = []
         self.dynamic_handlers = ['/','-',':',';','\'','"',',','&','?','!','+','*','(',')','\\u2014','\\u2013','\\u2019']
-        self.dynamic_replacements = ['and','the']
+        self.dynamic_replacements = ['and', 'the', 'vs.']
         self.rippers = ['-empire','-empire-hd','minutemen-','-dcp','Glorith-HD']
 
         #pre-generate the AS_Alternates now

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3348,6 +3348,20 @@ def ddl_downloader(queue):
                 meganz = mega.MegaNZ()
                 ddzstat = meganz.ddl_download(item['link'], item['filename'], item['id'], item['issueid'], item['link_type'])
 
+            elif item['site'] == 'DDL(Easynews)':
+                try:
+                    remote_filesize = item.get('remote_filesize', 0)
+                    if remote_filesize == 0:
+                        try:
+                            remote_filesize = helpers.human2bytes(re.sub('/s', '', item['size'][:-1]).strip())
+                        except Exception:
+                            remote_filesize = 0
+                except Exception:
+                    remote_filesize = 0
+                from mylar import easynews
+                en = easynews.Easynews()
+                ddzstat = en.downloadit(item['id'], item['link'], item['issueid'], remote_filesize)
+
             # Check for file validity post download and mark as failure if file is not a zip, rar, or pdf
             # Can only check single downloads.  Packs will have to be managed by post-processing if enabled
             if ddzstat['success'] and ddzstat['filename'] is not None:

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -31,6 +31,7 @@ from mylar import (
     search_filer,
     getcomics,
     downloaders,
+    easynews,
 )
 from mylar.downloaders import external_server as exs
 
@@ -278,6 +279,11 @@ def search_init(
                         searchprov['DDL(External)'] = ({'id': 201, 'type': 'DDL(External)', 'lastrun': 0, 'active': True, 'hits': 0})
                     else:
                         searchprov['DDL(External)']['active'] = True
+                elif prov_order[prov_count] == 'DDL(Easynews)' and not provider_blocked and 'DDL(Easynews)' not in checked_once:
+                    if 'DDL(Easynews)' not in searchprov.keys():
+                        searchprov['DDL(Easynews)'] = ({'id': 202, 'type': 'DDL', 'lastrun': 0, 'active': True, 'hits': 0})
+                    else:
+                        searchprov['DDL(Easynews)']['active'] = True
                 elif prov_order[prov_count] == '32p' and not provider_blocked:
                     searchprov['32P'] = ({'type': 'torrent', 'lastrun': 0, 'active': True, 'hits': 0})
                 elif prov_order[prov_count].lower() == 'experimental' and not provider_blocked and 'experimental' not in checked_once:
@@ -624,6 +630,15 @@ def provider_order(initial_run=False):
             ddlprovider.append('DDL(External)')
             ddls+=1
 
+        if all(
+            [
+                mylar.CONFIG.ENABLE_EASYNEWS is True,
+                not helpers.block_provider_check('DDL(Easynews)'),
+            ]
+        ):
+            ddlprovider.append('DDL(Easynews)')
+            ddls+=1
+
     if initial_run:
         logger.fdebug('nzbprovider(s): %s' % nzbprovider)
     # --------
@@ -959,6 +974,12 @@ def NZB_SEARCH(
             elif nzbprov == 'DDL(External)':
                 b = exs.MegaNZ(query='%s' % ComicName, provider_stat=provider_stat)
                 verified_matches = b.ddl_search(is_info=is_info)
+            elif nzbprov == 'DDL(Easynews)':
+                fline = {'comicname': findcomic,
+                         'issue':     isssearch,
+                         'year':      comyear}
+                b = easynews.Easynews(query=fline, provider_stat=provider_stat)
+                verified_matches = b.search(is_info=is_info)
             #logger.fdebug('bb returned from %s: %s' % (nzbprov, verified_matches))
 
         elif RSS == "yes" and 'DDL(External)' not in nzbprov:
@@ -3146,6 +3167,49 @@ def searcher(
             else:
                 logger.info('[%s] Failed to retrieve %s from the DDL site.' % (tnzbprov, nzbname))
                 return "ddl-fail"
+        elif nzbprov == 'DDL(Easynews)':
+            mod_id = nzbid
+            ctrlval = {'id': mod_id}
+            vals = {
+                'series': comicinfo[0]['ComicName'],
+                'year': comicinfo[0]['comyear'],
+                'size': comicinfo[0].get('size', '0'),
+                'issues': comicinfo[0]['IssueNumber'],
+                'issueid': tmp_issueid,
+                'comicid': ComicID,
+                'link': link,
+                'mainlink': link,
+                'site': 'DDL(Easynews)',
+                'pack': 0,
+                'link_type': 'EN-Direct',
+                'updated_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M'),
+                'status': 'Queued',
+            }
+            myDB = db.DBConnection()
+            myDB.upsert('ddl_info', vals, ctrlval)
+
+            mylar.DDL_QUEUE.put({
+                'link': link,
+                'mainlink': link,
+                'series': comicinfo[0]['ComicName'],
+                'year': comicinfo[0]['comyear'],
+                'size': comicinfo[0].get('size', '0'),
+                'comicid': ComicID,
+                'issueid': tmp_issueid,
+                'oneoff': oneoff,
+                'id': mod_id,
+                'link_type': 'EN-Direct',
+                'filename': nzbname,
+                'comicinfo': comicinfo,
+                'packinfo': pack_info,
+                'site': 'DDL(Easynews)',
+                'remote_filesize': 0,
+                'resume': None,
+            })
+            tnzbprov = 'DDL(Easynews)'
+            ddl_it = {'success': True, 'site': 'EN-Direct'}
+            logger.info('[%s] Successfully queued %s for download in position %s'
+                        % (tnzbprov, nzbname, mylar.DDL_QUEUE.qsize()))
         else:
             cinfo = {'id': nzbid,
                      'series': comicinfo[0]['ComicName'],

--- a/mylar/search.py
+++ b/mylar/search.py
@@ -1565,6 +1565,7 @@ def searchforissue(issueid=None, new=False, rsschecker=None, manual=False):
             [
                 mylar.CONFIG.ENABLE_GETCOMICS is True,
                 mylar.CONFIG.ENABLE_EXTERNAL_SERVER is True,
+                mylar.CONFIG.ENABLE_EASYNEWS is True,
             ]
        ))
        or any(
@@ -2033,6 +2034,7 @@ def searchforissue(issueid=None, new=False, rsschecker=None, manual=False):
                             mylar.CONFIG.EXPERIMENTAL is True,
                             mylar.CONFIG.ENABLE_GETCOMICS is True,
                             mylar.CONFIG.ENABLE_EXTERNAL_SERVER is True,
+                            mylar.CONFIG.ENABLE_EASYNEWS is True,
                         ]
                     )
                     or all([mylar.CONFIG.NEWZNAB is True, len(ens) > 0])
@@ -2525,7 +2527,8 @@ def searchIssueIDList(issuelist):
        and any(
             [
                 mylar.CONFIG.ENABLE_GETCOMICS is True,
-                mylar.CONFIG.ENABLE_EXTERNAL_SERVER is True
+                mylar.CONFIG.ENABLE_EXTERNAL_SERVER is True,
+                mylar.CONFIG.ENABLE_EASYNEWS is True,
             ]
         )
         ) or any(

--- a/mylar/search_filer.py
+++ b/mylar/search_filer.py
@@ -143,6 +143,14 @@ class search_check(object):
                                     comsize_b = None
                                 else:
                                     comsize_b = helpers.human2bytes(entry['size'])
+                        elif entry['site'] == 'DDL(Easynews)':
+                            comsize_b = entry['size']
+                            if comsize_b is not None:
+                                cb2 = re.sub(r'[^0-9]', '', str(comsize_b)).strip()
+                                if cb2 == '':
+                                    comsize_b = None
+                                else:
+                                    comsize_b = helpers.human2bytes(entry['size'])
                         elif entry['site'] == 'DDL(External)':
                             comsize_b = '0' #External links ! filesize
                     except Exception:

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6844,6 +6844,9 @@ class WebInterface(object):
                     "external_server": mylar.CONFIG.EXTERNAL_SERVER,
                     "external_username": mylar.CONFIG.EXTERNAL_USERNAME,
                     "external_apikey": mylar.CONFIG.EXTERNAL_APIKEY,
+                    "enable_easynews": helpers.checked(mylar.CONFIG.ENABLE_EASYNEWS),
+                    "easynews_username": mylar.CONFIG.EASYNEWS_USERNAME,
+                    "easynews_password": mylar.CONFIG.EASYNEWS_PASSWORD,
                     "enable_rss": helpers.checked(mylar.CONFIG.ENABLE_RSS),
                     "rss_checkinterval": mylar.CONFIG.RSS_CHECKINTERVAL,
                     "rss_last": rss_sclast,
@@ -7330,7 +7333,7 @@ class WebInterface(object):
                            'prowl_enabled', 'prowl_onsnatch', 'pushover_enabled', 'pushover_onsnatch', 'pushover_image', 'mattermost_enabled', 'mattermost_onsnatch', 'boxcar_enabled',
                            'boxcar_onsnatch', 'pushbullet_enabled', 'pushbullet_onsnatch', 'telegram_enabled', 'telegram_onsnatch', 'telegram_image', 'discord_enabled', 'discord_onsnatch', 'slack_enabled', 'slack_onsnatch',
                            'email_enabled', 'email_enc', 'email_ongrab', 'email_onpost', 'gotify_enabled', 'gotify_server_url', 'gotify_token', 'gotify_onsnatch', 'opds_enable', 'opds_authentication', 'opds_metainfo', 'opds_pagesize', 'enable_ddl',
-                           'enable_getcomics', 'enable_external_server', 'ddl_prefer_upscaled', 'deluge_pause'] #enable_public
+                           'enable_getcomics', 'enable_external_server', 'enable_easynews', 'ddl_prefer_upscaled', 'deluge_pause'] #enable_public
 
         for checked_config in checked_configs:
             if checked_config not in kwargs:
@@ -8409,6 +8412,25 @@ class WebInterface(object):
             logger.warn('Testing failed to %s [HOST:%s][SSL:%s]' % (name, host, bool(ssl)))
             return 'Error - failed running test for %s' % name
     testtorznab.exposed = True
+
+    def testeasynews(self, username, password):
+        import requests as test_requests
+        try:
+            response = test_requests.get(
+                'https://members.easynews.com/2.0/search/solr-search/advanced',
+                params={'gps': 'test', 'pby': 1, 'st': 'adv', 'sb': 1},
+                auth=(username, password),
+                timeout=15
+            )
+            if response.status_code == 200:
+                return json.dumps({"status": True, "message": "Successfully connected to Easynews."})
+            elif response.status_code == 401:
+                return json.dumps({"status": False, "message": "Authentication failed. Check username/password."})
+            else:
+                return json.dumps({"status": False, "message": "Connection failed (status %s)." % response.status_code})
+        except Exception as e:
+            return json.dumps({"status": False, "message": "Connection error: %s" % str(e)})
+    testeasynews.exposed = True
 
     def orderThis(self, **kwargs):
         return


### PR DESCRIPTION
## Summary
Adds [Easynews](https://www.easynews.com/) as a Direct Download (DDL) provider alongside GetComics and External Server. Easynews decodes binaries server-side and provides a JSON search API with direct HTTP file downloads using Basic Auth, so it fits into the existing DDL flow without extra client-side decoding.

## Changes
- **New module** `mylar/easynews.py`: search (Solr-style API), result normalization to the existing DDL format, and streaming download with Basic Auth. Supports CBR/CBZ/CB7/PDF; handles ZIP-wrapped results.
- **Config** (`mylar/config.py`): `enable_easynews`, `easynews_username`, `easynews_password`; DDL(Easynews) in provider order and `write_out_provider_searches` (provider id 202).
- **Search** (`mylar/search.py`): Easynews in DDL provider list and search path; results go through the same filer and DDL queue as other DDL providers.
- **Download path** (`mylar/helpers.py`, `mylar/search_filer.py`): DDL(Easynews) snatches use the existing DDL worker and post-processing.
- **Web UI** (`mylar/webserve.py`, `data/interfaces/default/config.html`): Easynews options on the config page and a “Test Easynews” connection button.

## Usage
1. Enable DDL and Easynews in Config → Search Providers.
2. Set Easynews username and password (member credentials).
3. Use “Test Easynews” to verify; optionally adjust DDL provider order.

No new dependencies; uses existing `requests` and proxy settings.