### PR TITLE
FIX: weekly_info() TypeError for years after 2025

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -2704,7 +2704,7 @@ def weekly_info(week=None, year=None, current=None):
     if todaydate.year == 2025:
         current_weeknumber = todaydate.isocalendar()[1]
     else:
-        current_weeknumber = todaydate.strftime("%U")
+        current_weeknumber = int(todaydate.strftime("%U"))
     if current is not None:
         c_weeknumber = int(current[:current.find('-')])
         c_weekyear = int(current[current.find('-')+1:])

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -277,7 +277,7 @@ def test_weekly_info_format0(patch_datetime, monkeypatch, input, result):
     monkeypatch.setattr(mylar.CONFIG, "DESTINATION_DIR", os.getcwd(), raising=False)
     monkeypatch.setattr(mylar.CONFIG, "WEEKFOLDER_FORMAT", 0, raising=False)
 
-    assert helpers.weekly_info(*input) == {'current_weeknumber': '51',
+    assert helpers.weekly_info(*input) == {'current_weeknumber': 51,
                                            'endweek': result['endweek'],
                                            'last_update': result['last_update'],
                                            'midweek': result['midweek'],
@@ -299,7 +299,7 @@ def test_weekly_info_format1(patch_datetime, monkeypatch, input, result):
     monkeypatch.setattr(mylar.CONFIG, "DESTINATION_DIR", os.getcwd(), raising=False)
     monkeypatch.setattr(mylar.CONFIG, "WEEKFOLDER_FORMAT", 1, raising=False)
 
-    assert helpers.weekly_info(*input) == {'current_weeknumber': '51',
+    assert helpers.weekly_info(*input) == {'current_weeknumber': 51,
                                            'endweek': result['endweek'],
                                            'last_update': result['last_update'],
                                            'midweek': result['midweek'],


### PR DESCRIPTION
Fixes #1753.

`strftime("%U")` returns a string, but `timedelta(weeks=...)` needs an int. The 2025 branch already uses `isocalendar()[1]` which returns int, so this was only broken for other years. Wrapping in `int()` fixes the 500 on Wanted/This Week pages.

Test expectations updated to match.