### PR TITLE
FIX: Reset issue status to Wanted when DDL download exhausts all links

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3033,14 +3033,34 @@ def ddl_downloader(queue):
                         nval = {'status':  'Failed',
                                 'updated_date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M')}
                         myDB.upsert('ddl_info', nval, ctrlval)
-                        #undo all snatched items, to previous status via item['id'] - this will be set to Skipped currently regardless of previous status
+                        # undo all snatched items, to previous status via item['id']
+                        # pack siblings are set to Skipped (opportunistic); individual issue
+                        # is set to Wanted below so it can be retried via usenet/torrent
                         reverse_the_pack_snatch(item['id'], item['comicid'])
+                        # also reset individual issue status so it can be retried via other providers
+                        if item['issueid'] is not None:
+                            myDB.upsert("issues", {"Status": "Wanted"}, {"IssueID": item['issueid']})
+                            logger.info('[DDL-FAILURE] Reset issue %s status to Wanted so it can be retried via usenet/torrent providers' % item['issueid'])
                         link_type_failure.pop(item['id'])
                         ddl_cleanup(item['id'])
+                        try:
+                            mylar.DDL_QUEUED.remove(item['id'])
+                        except ValueError:
+                            pass
                 else:
                     logger.info('[Status: %s] Failed to download item from %s : %s ' % (ddzstat['success'], item['site'], ddzstat))
                     myDB.action('DELETE FROM ddl_info where id=?', [item['id']])
                     mylar.search.FailedMark(item['issueid'], item['comicid'], item['id'], ddzstat['filename'], item['site'])
+                    # reset issue status so it can be retried via other providers
+                    # (FailedMark sets status to Failed; override back to Wanted for retry)
+                    if item['issueid'] is not None:
+                        myDB.upsert("issues", {"Status": "Wanted"}, {"IssueID": item['issueid']})
+                        logger.info('[DDL-FAILURE] Reset issue %s status to Wanted so it can be retried via usenet/torrent providers' % item['issueid'])
+                    ddl_cleanup(item['id'])
+                    try:
+                        mylar.DDL_QUEUED.remove(item['id'])
+                    except ValueError:
+                        pass
         else:
             time.sleep(5)
 


### PR DESCRIPTION
DDL downloads that exhaust all links get stuck in Snatched permanently, never retried via usenet/torrent.

Three problems in `ddl_downloader`:

1. GetComics exhausted-links path never reset the individual issue to Wanted (only called `reverse_the_pack_snatch`).
2. External DDL path called `FailedMark()` *after* setting Wanted, which clobbered it back to Failed. Reordered so the Wanted upsert wins.
3. External DDL path was missing `ddl_cleanup()` and `DDL_QUEUED.remove()`, so failed items stayed in the queue forever.

Also added `try/except ValueError` on `DDL_QUEUED.remove()` since the success path may have already cleared it.