### PR TITLE
Fix filesafe() regex: unterminated character set

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -1215,10 +1215,10 @@ def filesafe(comic):
     #logger.info('comic-type: %s' % type(u_comic))
 
     if type(u_comic) != bytes:
-        comicname_filesafe = re.sub(r'[\:\'\"\,\?\!\\\]', '', u_comic)
+        comicname_filesafe = re.sub(r'[\:\'\"\,\?\!\\\]]', '', u_comic)
         comicname_filesafe = re.sub(r'[\/\*]', '-', comicname_filesafe)
     else:
-        comicname_filesafe = re.sub(r'[\:\'\"\,\?\!\\\]', '', u_comic.decode('utf-8'))
+        comicname_filesafe = re.sub(r'[\:\'\"\,\?\!\\\]]', '', u_comic.decode('utf-8'))
         comicname_filesafe = re.sub(r'[\/\*]', '-', comicname_filesafe)
 
     return comicname_filesafe


### PR DESCRIPTION
The pattern ended with \] which adds a literal ] to the class but leaves the character class unclosed. Add a closing ] so the regex is valid. Fixes: re.error: unterminated character set at position 0 (e.g. on mass-add)