### PR TITLE
Add optional paging parameters to the API

### DIFF
--- a/API_REFERENCE
+++ b/API_REFERENCE
@@ -63,7 +63,7 @@ restart (restart mylar)
 update (update mylar - you may want to check the install type in get version and not allow this if type==exe)
 
 downloadIssue&id=$issueid (download that issue to your browser)
-findComic&name=$comicname (Find comics)
+findComic&name=$comicname[&page=$page][&pageSize=$pageSize] (Find comics)
 
 getStoryArc (List all story arcs)
 getStoryArc&customOnly=1 (List custom story arcs)

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -1067,12 +1067,22 @@ class Api(object):
             else:
                 self.data = self._failureResponse('Failed to return a image')
 
-    def _findComic(self, name, issue=None, type_=None, mode=None, serinfo=None):
+    def _findComic(self, name, issue=None, type_=None, mode=None, serinfo=None, page=None, pageSize=None):
         # set defaults
         if type_ is None:
             type_ = 'comic'
         if mode is None:
             mode = 'series'
+        if page is not None:
+            try:
+                page = int(page)
+            except (ValueError, TypeError):
+                page = None
+        if pageSize is not None:
+            try:
+                pageSize = int(pageSize)
+            except (ValueError, TypeError):
+                pageSize = None
 
         # Dont do shit if name is missing
         if len(name) == 0:
@@ -1080,13 +1090,13 @@ class Api(object):
             return
 
         if type_ == 'comic' and mode == 'series':
-            searchresults = mb.findComic(name, mode, issue=issue)
+            searchresults = mb.findComic(name, mode, issue=issue, page=page, pageSize=pageSize)
         elif type_ == 'comic' and mode == 'pullseries':
-            searchresults = mb.findComic(name, mode, issue=issue)
+            searchresults = mb.findComic(name, mode, issue=issue, page=page, pageSize=pageSize)
         elif type_ == 'comic' and mode == 'want':
-            searchresults = mb.findComic(name, mode, issue=issue)
+            searchresults = mb.findComic(name, mode, issue=issue, page=page, pageSize=pageSize)
         elif type_ == 'story_arc':
-            searchresults = mb.findComic(name, mode, issue=None, search_type='story_arc')
+            searchresults = mb.findComic(name, mode, issue=None, search_type='story_arc', page=page, pageSize=pageSize)
 
         searchresults = sorted(searchresults, key=itemgetter('comicyear', 'issues'), reverse=True)
         self.data = searchresults

--- a/mylar/mb.py
+++ b/mylar/mb.py
@@ -98,7 +98,7 @@ def pullsearch(comicapi, comicquery, offset, search_type):
     else:
         return dom
 
-def findComic(name, mode, issue, limityear=None, search_type=None, annual_check=False):
+def findComic(name, mode, issue, limityear=None, search_type=None, annual_check=False, page=None, pageSize=None):
 
     #with mb_lock:
     comicResults = None
@@ -155,10 +155,19 @@ def findComic(name, mode, issue, limityear=None, search_type=None, annual_check=
     logger.fdebug("there are " + str(totalResults) + " search results...")
     if not totalResults:
         return False
-    if int(totalResults) > 1000:
+    if int(totalResults) > 1000 and page is None:
         logger.warn('Search returned more than 1000 hits [' + str(totalResults) + ']. Only displaying first 1000 results - use more specifics or the exact ComicID if required.')
         totalResults = 1000
     countResults = 0
+    if pageSize is not None:
+        # Allow pageSize to be up to 1000 if page is not supplied
+        pageSize = max(1, min(1000, pageSize))
+    if page is not None and page > 0:
+        # Limit results to a specific page
+        # Search results are limited to 100 per page by default
+        pageSize = max(1, min(100, pageSize or 100))
+        countResults = (page - 1) * pageSize
+        totalResults = min(countResults + pageSize, int(totalResults))
     while (countResults < int(totalResults)):
         #logger.fdebug("querying " + str(countResults))
         if countResults > 0:
@@ -166,6 +175,10 @@ def findComic(name, mode, issue, limityear=None, search_type=None, annual_check=
 
             searched = pullsearch(comicapi, comicquery, offsetcount, search_type)
         comicResults = searched.getElementsByTagName(search_type)
+        if page is not None and pageSize is not None:
+            # Trim here to prevent excess processing of unused results if a page is specified
+            # Trimming here if a page is not specified can cause pullsearch to be called significantly more often than necessary
+            comicResults = comicResults[:pageSize]
         body = ''
         n = 0
         if not comicResults:
@@ -508,6 +521,9 @@ def findComic(name, mode, issue, limityear=None, search_type=None, annual_check=
                 n+=1
         #search results are limited to 100 and by pagination now...let's account for this.
         countResults = countResults + 100
+
+    if pageSize is not None:
+        return comiclist[:pageSize]
 
     return comiclist
 


### PR DESCRIPTION
Adds new page and pageSize parameters to the findComic API call.

If pageSize is not supplied and page is specified, pageSize defaults to 100. This is to match the maximum number of results returned by the ComicVine API in a single call.

If page is not supplied, pageSize can be as large as 1000 in order to limit the returned values of a full search to a smaller number.