### PR TITLE
FIX: TypeError in weekly_info() - year-specific weeknumber branching causes str passed to timedelta

### DIFF
--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3102,10 +3102,7 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
 def weekly_info(week=None, year=None, current=None):
     #find the current week and save it as a reference point.
     todaydate = datetime.datetime.today()
-    if todaydate.year == 2025:
-        current_weeknumber = todaydate.isocalendar()[1]
-    else:
-        current_weeknumber = todaydate.strftime("%U")
+    current_weeknumber = int(todaydate.isocalendar()[1])
     if current is not None:
         c_weeknumber = int(current[:current.find('-')])
         c_weekyear = int(current[current.find('-')+1:])
@@ -3158,10 +3155,7 @@ def weekly_info(week=None, year=None, current=None):
     startofyear = date(year,1,1)
     week0 = startofyear - timedelta(days=startofyear.isoweekday())
     stweek = datetime.datetime.strptime(week0.strftime('%Y-%m-%d'), '%Y-%m-%d')
-    if year == 2025:
-        startweek = stweek + timedelta(weeks = weeknumber -1)
-    else:
-        startweek = stweek + timedelta(weeks = weeknumber)
+    startweek = stweek + timedelta(weeks = weeknumber - 1)
 
     midweek = startweek + timedelta(days = 3)
     endweek = startweek + timedelta(days = 6)


### PR DESCRIPTION
## Problem

Clicking the **Wanted** (`/upcoming`) or **This Week** (`/pullist`) tabs
produces a 500 Internal Server Error:
```
TypeError: unsupported type for timedelta weeks component: str
```

This affects all users in 2026+ on the master branch.

## Root Cause

In `helpers.py`, the `weekly_info()` function uses a year-specific
conditional (line ~3105) that only returns an integer weeknumber for
2025 via `isocalendar()[1]`. For all other years, it falls through to
`strftime("%U")` which returns a **string**. This string is then passed
to `timedelta(weeks=weeknumber)` which requires an integer.

A second year-gated block (line ~3161) pairs `isocalendar` with a
`weeknumber - 1` offset (since ISO weeks are 1-indexed) but only for
2025, using `weeknumber` (0-indexed) for other years.

## Fix

Remove both year-specific conditionals and use universal logic:
- `isocalendar()[1]` for all years (always returns int, no type error)
- `weeknumber - 1` offset for all years (correct for 1-indexed ISO weeks)

This matches the pattern the developer already established for 2025,
extended to work for every year.

Fixes #1753