### PR TITLE
Feature/system health dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ __pycache__
 .devcontainer/config
 .devcontainer/comics
 .devcontainer/downloads
+#other
+*.bak-*
+docs/

--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -57,7 +57,7 @@
 				<li><a href="manage">Manage</a></li>
 				<li><a href="storyarc_main">StoryArcs</a></li>
 				<li><a href="history">History</a></li>
-				<li><a href="config" class="config"><img src="${icons['icon_gear']}" alt="settings"/></a></li>
+				<li><a href="config" class="config" style="position:relative;"><img src="${icons['icon_gear']}" alt="settings"/><span id="health_badge" style="display:none; position:absolute; top:2px; right:2px; background:#e04040; color:#fff; font-size:10px; font-weight:bold; border-radius:8px; min-width:16px; height:16px; line-height:16px; text-align:center; padding:0 4px;">0</span></a></li>
 			</ul>
 			<div id="searchbar">
                 <form action="searchit" method="get">
@@ -69,6 +69,17 @@
            
 			</div>
 		</header>
+
+		<!-- Health Status Banner (health-dashboard feature) -->
+		% if mylar.CONFIG.HEALTH_SHOW_BANNER:
+		<div id="health_banner" style="display:none; position:fixed; top:71px; left:50%; transform:translateX(-50%); width:960px; max-width:calc(100% - 32px); z-index:998;">
+		    <div id="health_error_bar" style="display:none; background:#ffd8d8; border:1px solid #e8b0b0; border-radius:6px; padding:6px 16px 5px; font-size:13px; font-family:'Trebuchet MS',Helvetica,Arial,sans-serif; color:#8b2020; align-items:center; box-shadow:0 2px 8px rgba(0,0,0,0.15);">
+		        <span style="margin-right:8px; line-height:1; font-size:12px;">&#x1F534;</span>
+		        <span id="health_error_text" style="flex:1;"></span>
+		        <a href="health" style="background:#d04040; color:#fff; padding:3px 12px; border-radius:3px; font-size:12px; font-weight:bold; text-decoration:none; margin-left:10px; white-space:nowrap;">View Health</a>
+		    </div>
+		</div>
+		% endif
 
 		<div id="main" class="main">
 			<div id="subhead">
@@ -801,6 +812,75 @@
         $(document).ready(function() {
             //$("#notifs_table").dataTable();
             check_the_update();
+        });
+
+        /* -- Health Banner Functions --
+         * Manages the persistent health status banner shown on all pages.
+         * Data loaded via AJAX from /getHealth endpoint.
+         */
+        function updateHealthBanner(data) {
+            var errorBar = document.getElementById('health_error_bar');
+            var banner = document.getElementById('health_banner');
+
+            if (!banner) return;
+
+            // Only errors get a banner — warnings/notices use the gear badge only
+            if (data.error_count > 0) {
+                var errorMsgs = data.errors ? data.errors.map(function(e) { return e.check_name.replace(/_/g, ' '); }).join(', ') : '';
+                document.getElementById('health_error_text').innerHTML =
+                    '<strong>' + data.error_count + ' error' + (data.error_count > 1 ? 's' : '') +
+                    '</strong> require' + (data.error_count === 1 ? 's' : '') + ' attention' + (errorMsgs ? ' \u2014 ' + errorMsgs : '');
+                errorBar.style.display = 'flex';
+                banner.style.display = 'block';
+            } else {
+                errorBar.style.display = 'none';
+                banner.style.display = 'none';
+            }
+            adjustMainPadding();
+        }
+
+        function updateNavBadge(errorCount, warningCount, noticeCount) {
+            var badge = document.getElementById('health_badge');
+            if (!badge) return;
+            var total = errorCount + warningCount + noticeCount;
+            if (total > 0) {
+                badge.textContent = total;
+                // Red for errors, amber for warnings/notices only
+                badge.style.background = errorCount > 0 ? '#e04040' : '#d09000';
+                badge.style.display = 'inline-block';
+            } else {
+                badge.style.display = 'none';
+            }
+        }
+
+        function adjustMainPadding() {
+            var banner = document.getElementById('health_banner');
+            var main = document.getElementById('main');
+            if (!banner || !main) return;
+            // banner height is 0 when hidden (display:none), so padding resets naturally
+            var bannerHeight = banner.offsetHeight || 0;
+            main.style.paddingTop = (88 + bannerHeight) + 'px';
+        }
+
+        // Load health status for the banner on every page
+        $(document).ready(function() {
+            $.ajax({
+                url: 'getHealth',
+                dataType: 'json',
+                success: function(resp) {
+                    if (resp && resp.success && resp.data) {
+                        var summary = resp.data.summary || {};
+                        var results = resp.data.results || [];
+                        updateHealthBanner({
+                            error_count: summary.errors || 0,
+                            warning_count: summary.warnings || 0,
+                            errors: results.filter(function(r) { return r.severity === 'error'; }),
+                            warnings: results.filter(function(r) { return r.severity === 'warning'; })
+                        });
+                        updateNavBadge(summary.errors || 0, summary.warnings || 0, summary.notices || 0);
+                    }
+                }
+            });
         });
         </script>
 	<!-- This template is made by Elmar Kouwenhoven -->

--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -354,6 +354,20 @@
             }
         }, false);
 
+        // Listen for real-time health status updates via SSE
+        evtSource.addEventListener("health_update", function(e){
+            if (e.data){
+                try {
+                    var data = JSON.parse(e.data);
+                    console.log('health_update SSE:', data);
+                    updateHealthBanner(data);
+                    updateNavBadge(data.error_count || 0, data.warning_count || 0, data.notice_count || 0);
+                } catch(err) {
+                    console.log('Health SSE parse error:', err);
+                }
+            }
+        }, false);
+
         evtSource.addEventListener('message', function(e){
             if ('END-OF-STREAM' == e.data) {
                 evtSource.close();

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -10,6 +10,7 @@
 			<a id="menu_link_carepackage" href="carepackage">Care Package</a>
 			<a id="menu_link_shutdown" href="shutdown">Shut Down</a>
 			<a id="menu_link_shutdown" href="restart">Restart</a>
+			<a id="menu_link_health" href="health">System Health</a>
                         <a id="menu_link_edit" title="Manage blocked Providers" href="javascript:void(0)" onclick="manageBlockedProviders()">Provider Blocklist</a>
                         <div id="manage_blocked_providers_dialog" title="Choose a specific provider to Unblock" style="display:none">
                             <table id="blocked_table" width="100%">
@@ -1490,6 +1491,41 @@
                                 </div>
 
     				</fieldset>
+
+                    <!-- Health Checks Settings Section -->
+                    <fieldset>
+                        <legend>Health Checks</legend>
+                        <div class="row checkbox">
+                            <input type="checkbox" name="health_check_enabled" id="health_check_enabled" value="1" ${config['health_check_enabled']} /><label>Enable Health Checks</label>
+                            <br/><small>Periodically check system components and report issues</small>
+                        </div>
+                        <div class="row">
+                            <label>Check Interval (minutes)</label>
+                            <input type="text" name="health_check_interval" id="health_check_interval" value="${config['health_check_interval']}" size="5">
+                        </div>
+                        <div class="row checkbox">
+                            <input type="checkbox" name="health_show_banner" id="health_show_banner" value="1" ${config['health_show_banner']} /><label>Show Persistent Banner</label>
+                            <br/><small>Display a warning banner on all pages when issues are detected</small>
+                        </div>
+                        <div class="row">
+                            <label>Disk Space Warning (GB)</label>
+                            <input type="text" name="health_disk_warn_gb" id="health_disk_warn_gb" value="${config['health_disk_warn_gb']}" size="5">
+                        </div>
+                        <div class="row">
+                            <label>Disk Space Error (GB)</label>
+                            <input type="text" name="health_disk_error_gb" id="health_disk_error_gb" value="${config['health_disk_error_gb']}" size="5">
+                        </div>
+                        <div class="row">
+                            <label>Stale Task Threshold (minutes)</label>
+                            <input type="text" name="health_stale_task_min" id="health_stale_task_min" value="${config['health_stale_task_min']}" size="5">
+                            <br/><small>Alert when a scheduler task has been running longer than this</small>
+                        </div>
+                        <div class="row">
+                            <label>History Retention (days)</label>
+                            <input type="text" name="health_history_days" id="health_history_days" value="${config['health_history_days']}" size="5">
+                            <br/><small>How long to keep resolved health check records</small>
+                        </div>
+                    </fieldset>
     				
 				</td>
 				<td>
@@ -1791,10 +1827,11 @@
                         </div>
                     </fieldset>
 
+
 	       </td>
              </tr>
         </table>
-    </div>	
+    </div>
         <input type="button" value="Save Changes" onclick="doAjaxCall('configUpdate',$(this),'tabs',true,'post');return false;" data-success="Changes saved successfully">
         <div class="message">
         	<p><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span>Web Interface changes require a restart to take effect</p>

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -1502,6 +1502,7 @@
                         <div class="row">
                             <label>Check Interval (minutes)</label>
                             <input type="text" name="health_check_interval" id="health_check_interval" value="${config['health_check_interval']}" size="5">
+                            <br/><small id="health_interval_hint" style="color:#999;">Minimum: 5 minutes</small>
                         </div>
                         <div class="row checkbox">
                             <input type="checkbox" name="health_show_banner" id="health_show_banner" value="1" ${config['health_show_banner']} /><label>Show Persistent Banner</label>
@@ -3656,6 +3657,17 @@ $("#enable_airdcpp").click(function(){
                 initConfigCheckbox("#enable_extra_scripts");
                 //initConfigCheckbox("#enable_file_conversions");
                 //initConfigCheckbox("#enable_image_conversions");
+
+                // Health check interval — enforce 5-minute minimum
+                $('#health_check_interval').on('change keyup paste', function() {
+                    var val = parseInt($(this).val(), 10);
+                    var hint = $('#health_interval_hint');
+                    if (!isNaN(val) && val < 5) {
+                        hint.text('Must be at least 5 minutes').css('color', 'red');
+                    } else {
+                        hint.text('Minimum: 5 minutes').css('color', '#999');
+                    }
+                });
 	}
 	$(document).ready(function() {
 		initThisPage();

--- a/data/interfaces/default/health.html
+++ b/data/interfaces/default/health.html
@@ -40,7 +40,7 @@
         </div>
     </div>
 
-    <!-- Active Issues Table -->
+    <!-- Active Issues Table — uses class="display" to inherit Mylar's dark theme styling -->
     <table class="display" id="health_table">
         <thead>
             <tr>
@@ -50,7 +50,6 @@
                 <th>First Seen</th>
                 <th>Last Seen</th>
                 <th>Count</th>
-                <th>Actions</th>
             </tr>
         </thead>
         <tbody id="health-tbody">
@@ -89,12 +88,11 @@
         }
         .health-card {
             flex: 1;
-            border: 1px solid #e0e0e0;
+            border: 1px solid #444;
             border-radius: 5px;
             padding: 14px 16px;
             text-align: center;
-            background: #fff;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+            background: transparent;
         }
         .health-card .card-count {
             font-size: 36px;
@@ -110,17 +108,17 @@
             font-weight: bold;
         }
         .health-card.errors { border-left: 4px solid #e04040; }
-        .health-card.errors .card-count { color: #d03030; }
-        .health-card.errors .card-label { color: #a02020; }
+        .health-card.errors .card-count { color: #e05050; }
+        .health-card.errors .card-label { color: #d04040; }
         .health-card.warnings { border-left: 4px solid #e0a000; }
-        .health-card.warnings .card-count { color: #c09000; }
-        .health-card.warnings .card-label { color: #906000; }
-        .health-card.notices { border-left: 4px solid #4183c4; }
-        .health-card.notices .card-count { color: #3070b0; }
-        .health-card.notices .card-label { color: #305080; }
+        .health-card.warnings .card-count { color: #e0a000; }
+        .health-card.warnings .card-label { color: #c09000; }
+        .health-card.notices { border-left: 4px solid #5090d0; }
+        .health-card.notices .card-count { color: #5090d0; }
+        .health-card.notices .card-label { color: #5090d0; }
         .health-card.lastcheck { border-left: 4px solid #60c060; }
-        .health-card.lastcheck .card-count { color: #40a040; font-size: 16px; line-height: 2.6; }
-        .health-card.lastcheck .card-label { color: #308030; }
+        .health-card.lastcheck .card-count { color: #60c060; font-size: 16px; line-height: 2.6; }
+        .health-card.lastcheck .card-label { color: #50b050; }
 
         /* ── Severity Badges ── */
         .severity-badge {
@@ -137,9 +135,6 @@
         .severity-badge.warning { background: #fef8e0; color: #a07000; border: 1px solid #ece0a0; }
         .severity-badge.notice { background: #e8f0ff; color: #3070b0; border: 1px solid #c0d8f0; }
 
-        /* ── Warning rows (not in default data_table.css) ── */
-        table.display tr.gradeW td { background-color: #fff8e0; }
-
         /* ── Wiki Link ── */
         .wiki-link {
             font-size: 10px;
@@ -153,29 +148,14 @@
         }
         .wiki-link:hover { background: #e0eeff; color: #306090; }
 
-        /* ── Action Buttons ── */
-        .action-btn {
-            display: inline-block;
-            font-size: 10px;
-            padding: 2px 8px;
-            border-radius: 3px;
-            cursor: pointer;
-            text-decoration: none;
-            border: 1px solid #ddd;
-            background: linear-gradient(#fafafa, #eaeaea);
-            color: #666;
-            white-space: nowrap;
-        }
-        .action-btn:hover { background: linear-gradient(#f0f0f0, #d8d8d8); color: #333; }
-
         /* ── Resolved Toggle ── */
         .resolved-toggle {
             cursor: pointer;
             font-size: 14px;
-            color: #666;
+            color: #999;
             padding: 10px 0;
             margin-top: 10px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid #444;
             user-select: none;
         }
         .resolved-toggle:hover { color: #4183c4; }
@@ -187,7 +167,9 @@
         }
         .resolved-toggle.open .arrow { transform: rotate(90deg); }
         .resolved-section { margin-top: 10px; }
-        table.display tr.resolved td { color: #999; }
+
+        /* ── Timestamp tooltip ── */
+        .health-ts { cursor: default; }
 
         /* ── Empty state ── */
         .health-empty {
@@ -206,16 +188,30 @@
 
     var healthRefreshTimer = null;
 
-    /* Format an ISO datetime string to a short display string */
+    /* Format an ISO datetime string to a relative time display.
+     * Server stores UTC times via datetime.utcnow().isoformat() WITHOUT
+     * the trailing 'Z', so we must append it before parsing to avoid
+     * JavaScript treating the string as local time.
+     */
     function formatHealthTime(isoStr) {
         if (!isoStr) return '--';
         try {
-            var d = new Date(isoStr);
+            var utcStr = isoStr;
+            // Normalize SQLite datetime format (space separator) to ISO (T separator)
+            if (utcStr.indexOf('T') === -1 && utcStr.indexOf(' ') > 0) {
+                utcStr = utcStr.replace(' ', 'T');
+            }
+            if (utcStr.indexOf('Z') === -1 && utcStr.indexOf('+') === -1 && utcStr.indexOf('T') !== -1) {
+                utcStr += 'Z';
+            }
+            var d = new Date(utcStr);
             if (isNaN(d.getTime())) return isoStr;
             var now = new Date();
             var diffMs = now - d;
-            var diffMin = Math.floor(diffMs / 60000);
-            if (diffMin < 1) return 'Just now';
+            if (diffMs < 0) return 'Just now';
+            var diffSec = Math.floor(diffMs / 1000);
+            if (diffSec < 60) return 'Just now';
+            var diffMin = Math.floor(diffSec / 60);
             if (diffMin < 60) return diffMin + ' min ago';
             var diffHrs = Math.floor(diffMin / 60);
             if (diffHrs < 24) return diffHrs + ' hr ago';
@@ -226,16 +222,44 @@
         }
     }
 
+    /* Format an ISO datetime string to a human-readable local time for tooltips */
+    function formatHealthTooltip(isoStr) {
+        if (!isoStr) return '';
+        try {
+            var utcStr = isoStr;
+            if (utcStr.indexOf('T') === -1 && utcStr.indexOf(' ') > 0) {
+                utcStr = utcStr.replace(' ', 'T');
+            }
+            if (utcStr.indexOf('Z') === -1 && utcStr.indexOf('+') === -1 && utcStr.indexOf('T') !== -1) {
+                utcStr += 'Z';
+            }
+            var d = new Date(utcStr);
+            if (isNaN(d.getTime())) return isoStr;
+            return d.toLocaleString();
+        } catch (e) {
+            return isoStr;
+        }
+    }
+
     /* Build severity badge HTML */
     function severityBadge(sev) {
         return '<span class="severity-badge ' + sev + '">' + sev.charAt(0).toUpperCase() + sev.slice(1) + '</span>';
     }
 
-    /* Determine DataTable row class based on severity */
+    /* Determine DataTable row class based on severity.
+     * Uses gradeX (red) for errors and gradeH (amber) for warnings —
+     * both are defined in data_table.css and inherit the dark theme.
+     */
     function severityRowClass(sev) {
         if (sev === 'error') return 'gradeX';
-        if (sev === 'warning') return 'gradeW';
+        if (sev === 'warning') return 'gradeH';
         return 'gradeZ';
+    }
+
+    /* Build a timestamp <td> with both relative text and a tooltip showing the full datetime */
+    function timestampCell(isoStr) {
+        if (!isoStr) return '<td class="health-ts">--</td>';
+        return '<td class="health-ts" data-iso="' + isoStr + '" title="' + formatHealthTooltip(isoStr) + '">' + formatHealthTime(isoStr) + '</td>';
     }
 
     /* Fetch health data from server and update the page */
@@ -257,27 +281,38 @@
                 $('#notice-count').text(summary.notices || 0);
                 $('#last-check-time').text(formatHealthTime(data.last_run));
 
+                // Update the persistent banner and nav badge (defined in base.html)
+                if (typeof updateHealthBanner === 'function') {
+                    updateHealthBanner({
+                        error_count: summary.errors || 0,
+                        warning_count: summary.warnings || 0,
+                        errors: results.filter(function(r) { return r.severity === 'error'; }),
+                        warnings: results.filter(function(r) { return r.severity === 'warning'; })
+                    });
+                }
+                if (typeof updateNavBadge === 'function') {
+                    updateNavBadge(summary.errors || 0, summary.warnings || 0, summary.notices || 0);
+                }
+
                 // Update active issues table
                 var tbody = $('#health-tbody');
                 tbody.empty();
 
                 if (results.length === 0) {
-                    tbody.append('<tr><td colspan="7" class="health-empty">All health checks passed &mdash; system is operating normally.</td></tr>');
+                    tbody.append('<tr class="gradeZ"><td colspan="6" class="health-empty">All health checks passed &mdash; system is operating normally.</td></tr>');
                 } else {
                     for (var i = 0; i < results.length; i++) {
                         var r = results[i];
-                        var rowClass = severityRowClass(r.severity);
+                        var parity = (i % 2 === 0) ? 'odd' : 'even';
+                        var rowClass = parity + ' ' + severityRowClass(r.severity);
                         var wikiHtml = r.wiki_url ? ' <a href="' + r.wiki_url + '" class="wiki-link" target="_blank">Wiki</a>' : '';
                         var row = '<tr class="' + rowClass + '">' +
                             '<td>' + severityBadge(r.severity) + '</td>' +
                             '<td><strong>' + (r.check_name || '').replace(/_/g, ' ') + '</strong></td>' +
-                            '<td>' + (r.message || '') + wikiHtml + '</td>' +
-                            '<td>' + formatHealthTime(r.first_seen) + '</td>' +
-                            '<td>' + formatHealthTime(r.last_seen) + '</td>' +
-                            '<td style="text-align:center;">' + (r.check_count || 1) + '</td>' +
-                            '<td>' +
-                                '<a href="#" class="action-btn" onclick="dismissCheck(' + r.id + '); return false;">Dismiss</a>' +
-                            '</td>' +
+                            '<td style="text-align:left;">' + (r.message || '') + wikiHtml + '</td>' +
+                            timestampCell(r.first_seen) +
+                            timestampCell(r.last_seen) +
+                            '<td>' + (r.check_count || 1) + '</td>' +
                             '</tr>';
                         tbody.append(row);
                     }
@@ -288,16 +323,19 @@
                 rtbody.empty();
                 if (history.length === 0) {
                     $('#resolved-label').text('No recently resolved issues');
-                    rtbody.append('<tr><td colspan="4" style="text-align:center; padding:15px; color:#999;">No resolved issues in history</td></tr>');
+                    rtbody.append('<tr class="gradeZ"><td colspan="4" style="text-align:center; padding:15px; color:#999;">No resolved issues in history</td></tr>');
                 } else {
                     $('#resolved-label').text('Recently Resolved (' + history.length + ')');
                     for (var j = 0; j < history.length; j++) {
                         var h = history[j];
-                        var hrow = '<tr class="resolved">' +
+                        var hparity = (j % 2 === 0) ? 'odd' : 'even';
+                        // Use resolved_at if available, fall back to last_seen
+                        var resolvedIso = h.resolved_at || h.last_seen || '';
+                        var hrow = '<tr class="' + hparity + ' gradeZ">' +
                             '<td>' + severityBadge(h.severity) + '</td>' +
                             '<td>' + (h.check_name || '').replace(/_/g, ' ') + '</td>' +
-                            '<td>' + (h.message || '') + '</td>' +
-                            '<td>' + formatHealthTime(h.last_seen) + '</td>' +
+                            '<td style="text-align:left;">' + (h.message || '') + '</td>' +
+                            timestampCell(resolvedIso) +
                             '</tr>';
                         rtbody.append(hrow);
                     }
@@ -321,7 +359,6 @@
                 if (resp && resp.status === 'ok') {
                     $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Health check triggered</div>");
                     $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
-                    // wait a moment for the check to complete, then refresh data
                     setTimeout(loadHealthData, 3000);
                 } else {
                     $('#ajaxMsg').html("<div class='msg'>Health check failed to trigger</div>");
@@ -339,27 +376,28 @@
         });
     }
 
-    /* Dismiss a specific health check issue */
-    function dismissCheck(checkId) {
+    /* Clear all resolved history records */
+    function clearResolved() {
         $.ajax({
-            url: 'dismissHealth',
-            data: { check_id: checkId },
+            url: 'clearResolvedHealth',
             dataType: 'json',
             success: function(resp) {
                 if (resp && resp.status === 'ok') {
-                    loadHealthData();
+                    $('#resolved-tbody').empty();
+                    $('#resolved-tbody').append('<tr class="gradeZ"><td colspan="4" style="text-align:center; padding:15px; color:#999;">No resolved issues in history</td></tr>');
+                    $('#resolved-label').text('No recently resolved issues');
+                    $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Resolved history cleared</div>");
+                    $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                } else {
+                    $('#ajaxMsg').html("<div class='msg'>Failed to clear resolved history</div>");
+                    $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
                 }
+            },
+            error: function() {
+                $('#ajaxMsg').html("<div class='msg'>Failed to clear resolved history</div>");
+                $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
             }
         });
-    }
-
-    /* Clear all resolved history records */
-    function clearResolved() {
-        // reload data without resolved (they get cleaned up by the engine's cleanup)
-        $('#resolved-tbody').empty();
-        $('#resolved-label').text('No recently resolved issues');
-        $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Resolved history cleared</div>");
-        $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
     }
 
     /* Toggle the resolved history section visibility */
@@ -374,15 +412,28 @@
         }
     }
 
+    /* Dynamically update all relative timestamps on the page.
+     * Runs every 15 seconds to keep "X min ago" labels current.
+     */
+    function refreshTimestamps() {
+        $('.health-ts').each(function() {
+            var iso = $(this).attr('data-iso');
+            if (iso) {
+                $(this).text(formatHealthTime(iso));
+            }
+        });
+    }
+
     /* Initialize page on document ready */
     $(document).ready(function() {
-        initActions();
-
         // load data immediately
         loadHealthData();
 
-        // auto-refresh every 30 seconds
+        // auto-refresh data every 30 seconds
         healthRefreshTimer = setInterval(loadHealthData, 30000);
+
+        // tick relative timestamps every 15 seconds
+        setInterval(refreshTimestamps, 15000);
     });
     </script>
 </%def>

--- a/data/interfaces/default/health.html
+++ b/data/interfaces/default/health.html
@@ -426,6 +426,8 @@
 
     /* Initialize page on document ready */
     $(document).ready(function() {
+        initActions();
+
         // load data immediately
         loadHealthData();
 

--- a/data/interfaces/default/health.html
+++ b/data/interfaces/default/health.html
@@ -9,6 +9,7 @@
         <div id="subhead_menu">
             <a id="menu_link_recheck" href="#" onclick="runHealthCheck(); return false;">Run Health Check</a>
             <a id="menu_link_clearresolved" href="#" onclick="clearResolved(); return false;">Clear Resolved</a>
+            <!--suppress HtmlUnknownTarget -- CherryPy route, not a file -->
             <a id="menu_link_viewlogs" href="logs">View Logs</a>
         </div>
     </div>
@@ -78,6 +79,7 @@
 </%def>
 
 <%def name="headIncludes()">
+    <!--suppress HtmlUnknownTarget -- Mako variable ${interface} resolves at runtime -->
     <link rel="stylesheet" href="interfaces/${interface}/css/data_table.css">
     <style>
         /* ── Health Summary Cards ── */
@@ -126,13 +128,17 @@
             font-size: 11px;
             font-weight: bold;
             text-transform: uppercase;
-            letter-spacing: 0.5px;
+            letter-spacing: 1px;
             padding: 2px 8px;
             border-radius: 3px;
             white-space: nowrap;
         }
+        /* applied dynamically by severityBadge() */
+        /*noinspection CssUnusedSymbol*/
         .severity-badge.error { background: #fce4e4; color: #c03030; border: 1px solid #f0c0c0; }
+        /*noinspection CssUnusedSymbol*/
         .severity-badge.warning { background: #fef8e0; color: #a07000; border: 1px solid #ece0a0; }
+        /*noinspection CssUnusedSymbol*/
         .severity-badge.notice { background: #e8f0ff; color: #3070b0; border: 1px solid #c0d8f0; }
 
         /* ── Wiki Link ── */
@@ -182,11 +188,15 @@
 </%def>
 
 <%def name="javascriptIncludes()">
+    <!--suppress HtmlUnknownTarget -- served by CherryPy static handler -->
     <script src="js/libs/jquery.dataTables.min.js"></script>
     <script>
+    /* global $ */
     /* ── Health Dashboard Data Loading ── */
 
-    var healthRefreshTimer = null;
+    let healthRefreshTimer = null;
+    let $ajaxMsg = null;
+    let $resolvedTbody = null;
 
     /* Format an ISO datetime string to a relative time display.
      * Server stores UTC times via datetime.utcnow().isoformat() WITHOUT
@@ -196,7 +206,7 @@
     function formatHealthTime(isoStr) {
         if (!isoStr) return '--';
         try {
-            var utcStr = isoStr;
+            let utcStr = isoStr;
             // Normalize SQLite datetime format (space separator) to ISO (T separator)
             if (utcStr.indexOf('T') === -1 && utcStr.indexOf(' ') > 0) {
                 utcStr = utcStr.replace(' ', 'T');
@@ -204,18 +214,18 @@
             if (utcStr.indexOf('Z') === -1 && utcStr.indexOf('+') === -1 && utcStr.indexOf('T') !== -1) {
                 utcStr += 'Z';
             }
-            var d = new Date(utcStr);
+            const d = new Date(utcStr);
             if (isNaN(d.getTime())) return isoStr;
-            var now = new Date();
-            var diffMs = now - d;
+            const now = new Date();
+            const diffMs = now - d;
             if (diffMs < 0) return 'Just now';
-            var diffSec = Math.floor(diffMs / 1000);
+            const diffSec = Math.floor(diffMs / 1000);
             if (diffSec < 60) return 'Just now';
-            var diffMin = Math.floor(diffSec / 60);
+            const diffMin = Math.floor(diffSec / 60);
             if (diffMin < 60) return diffMin + ' min ago';
-            var diffHrs = Math.floor(diffMin / 60);
+            const diffHrs = Math.floor(diffMin / 60);
             if (diffHrs < 24) return diffHrs + ' hr ago';
-            var diffDays = Math.floor(diffHrs / 24);
+            const diffDays = Math.floor(diffHrs / 24);
             return diffDays + ' day' + (diffDays > 1 ? 's' : '') + ' ago';
         } catch (e) {
             return isoStr;
@@ -226,14 +236,14 @@
     function formatHealthTooltip(isoStr) {
         if (!isoStr) return '';
         try {
-            var utcStr = isoStr;
+            let utcStr = isoStr;
             if (utcStr.indexOf('T') === -1 && utcStr.indexOf(' ') > 0) {
                 utcStr = utcStr.replace(' ', 'T');
             }
             if (utcStr.indexOf('Z') === -1 && utcStr.indexOf('+') === -1 && utcStr.indexOf('T') !== -1) {
                 utcStr += 'Z';
             }
-            var d = new Date(utcStr);
+            const d = new Date(utcStr);
             if (isNaN(d.getTime())) return isoStr;
             return d.toLocaleString();
         } catch (e) {
@@ -270,43 +280,45 @@
             dataType: 'json',
             success: function(resp) {
                 if (!resp || !resp.success) return;
-                var data = resp.data;
-                var results = data.results || [];
-                var summary = data.summary || {};
-                var history = data.history || [];
+                /** @type {{results: Array, summary: {errors: number, warnings: number, notices: number}, history: Array, last_run: string}} */
+                const data = resp.data;
+                const results = data.results || [];
+                const summaryData = data.summary || {};
+                const history = data.history || [];
 
                 // Update summary cards
-                $('#error-count').text(summary.errors || 0);
-                $('#warning-count').text(summary.warnings || 0);
-                $('#notice-count').text(summary.notices || 0);
+                $('#error-count').text(summaryData.errors || 0);
+                $('#warning-count').text(summaryData.warnings || 0);
+                $('#notice-count').text(summaryData.notices || 0);
                 $('#last-check-time').text(formatHealthTime(data.last_run));
 
                 // Update the persistent banner and nav badge (defined in base.html)
                 if (typeof updateHealthBanner === 'function') {
                     updateHealthBanner({
-                        error_count: summary.errors || 0,
-                        warning_count: summary.warnings || 0,
-                        errors: results.filter(function(r) { return r.severity === 'error'; }),
-                        warnings: results.filter(function(r) { return r.severity === 'warning'; })
+                        error_count: summaryData.errors || 0,
+                        warning_count: summaryData.warnings || 0,
+                        errors: results.filter(({severity}) => severity === 'error'),
+                        warnings: results.filter(({severity}) => severity === 'warning')
                     });
                 }
                 if (typeof updateNavBadge === 'function') {
-                    updateNavBadge(summary.errors || 0, summary.warnings || 0, summary.notices || 0);
+                    updateNavBadge(summaryData.errors || 0, summaryData.warnings || 0, summaryData.notices || 0);
                 }
 
                 // Update active issues table
-                var tbody = $('#health-tbody');
+                const tbody = $('#health-tbody');
                 tbody.empty();
 
                 if (results.length === 0) {
                     tbody.append('<tr class="gradeZ"><td colspan="6" class="health-empty">All health checks passed &mdash; system is operating normally.</td></tr>');
                 } else {
-                    for (var i = 0; i < results.length; i++) {
-                        var r = results[i];
-                        var parity = (i % 2 === 0) ? 'odd' : 'even';
-                        var rowClass = parity + ' ' + severityRowClass(r.severity);
-                        var wikiHtml = r.wiki_url ? ' <a href="' + r.wiki_url + '" class="wiki-link" target="_blank">Wiki</a>' : '';
-                        var row = '<tr class="' + rowClass + '">' +
+                    for (let i = 0; i < results.length; i++) {
+                        /** @type {{severity: string, wiki_url: string, check_name: string, message: string, first_seen: string, last_seen: string, check_count: number}} */
+                        const r = results[i];
+                        const parity = (i % 2 === 0) ? 'odd' : 'even';
+                        const rowClass = parity + ' ' + severityRowClass(r.severity);
+                        const wikiHtml = r.wiki_url ? ' <a href="' + r.wiki_url + '" class="wiki-link" target="_blank">Wiki</a>' : '';
+                        const row = '<tr class="' + rowClass + '">' +
                             '<td>' + severityBadge(r.severity) + '</td>' +
                             '<td><strong>' + (r.check_name || '').replace(/_/g, ' ') + '</strong></td>' +
                             '<td style="text-align:left;">' + (r.message || '') + wikiHtml + '</td>' +
@@ -319,25 +331,25 @@
                 }
 
                 // Update resolved history
-                var rtbody = $('#resolved-tbody');
-                rtbody.empty();
+                $resolvedTbody.empty();
                 if (history.length === 0) {
                     $('#resolved-label').text('No recently resolved issues');
-                    rtbody.append('<tr class="gradeZ"><td colspan="4" style="text-align:center; padding:15px; color:#999;">No resolved issues in history</td></tr>');
+                    $resolvedTbody.append('<tr class="gradeZ"><td colspan="4" style="text-align:center; padding:15px; color:#999;">No resolved issues in history</td></tr>');
                 } else {
                     $('#resolved-label').text('Recently Resolved (' + history.length + ')');
-                    for (var j = 0; j < history.length; j++) {
-                        var h = history[j];
-                        var hparity = (j % 2 === 0) ? 'odd' : 'even';
+                    for (let j = 0; j < history.length; j++) {
+                        /** @type {{severity: string, check_name: string, message: string, resolved_at: string, last_seen: string}} */
+                        const h = history[j];
+                        const hparity = (j % 2 === 0) ? 'odd' : 'even';
                         // Use resolved_at if available, fall back to last_seen
-                        var resolvedIso = h.resolved_at || h.last_seen || '';
-                        var hrow = '<tr class="' + hparity + ' gradeZ">' +
+                        const resolvedIso = h.resolved_at || h.last_seen || '';
+                        const hrow = '<tr class="' + hparity + ' gradeZ">' +
                             '<td>' + severityBadge(h.severity) + '</td>' +
                             '<td>' + (h.check_name || '').replace(/_/g, ' ') + '</td>' +
                             '<td style="text-align:left;">' + (h.message || '') + '</td>' +
                             timestampCell(resolvedIso) +
                             '</tr>';
-                        rtbody.append(hrow);
+                        $resolvedTbody.append(hrow);
                     }
                 }
             },
@@ -349,7 +361,7 @@
 
     /* Trigger an immediate health check run */
     function runHealthCheck() {
-        var btn = $('#menu_link_recheck');
+        const btn = $('#menu_link_recheck');
         btn.button("option", "label", "Running...");
         btn.button("disable");
         $.ajax({
@@ -357,17 +369,20 @@
             dataType: 'json',
             success: function(resp) {
                 if (resp && resp.status === 'ok') {
-                    $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Health check triggered</div>");
-                    $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                    $ajaxMsg.html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Health check triggered</div>");
+                    //noinspection JSUnresolvedReference
+                    $ajaxMsg.addClass('success').fadeIn().delay(3000).fadeOut();
                     setTimeout(loadHealthData, 3000);
                 } else {
-                    $('#ajaxMsg').html("<div class='msg'>Health check failed to trigger</div>");
-                    $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                    $ajaxMsg.html("<div class='msg'>Health check failed to trigger</div>");
+                    //noinspection JSUnresolvedReference
+                    $ajaxMsg.addClass('error').fadeIn().delay(3000).fadeOut();
                 }
             },
             error: function() {
-                $('#ajaxMsg').html("<div class='msg'>Health check request failed</div>");
-                $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                $ajaxMsg.html("<div class='msg'>Health check request failed</div>");
+                //noinspection JSUnresolvedReference
+                $ajaxMsg.addClass('error').fadeIn().delay(3000).fadeOut();
             },
             complete: function() {
                 btn.button("option", "label", "Run Health Check");
@@ -383,31 +398,38 @@
             dataType: 'json',
             success: function(resp) {
                 if (resp && resp.status === 'ok') {
-                    $('#resolved-tbody').empty();
-                    $('#resolved-tbody').append('<tr class="gradeZ"><td colspan="4" style="text-align:center; padding:15px; color:#999;">No resolved issues in history</td></tr>');
+                    $resolvedTbody.empty();
+                    $resolvedTbody.append('<tr class="gradeZ"><td colspan="4" style="text-align:center; padding:15px; color:#999;">No resolved issues in history</td></tr>');
                     $('#resolved-label').text('No recently resolved issues');
-                    $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Resolved history cleared</div>");
-                    $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                    $ajaxMsg.html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Resolved history cleared</div>");
+                    //noinspection JSUnresolvedReference
+                    $ajaxMsg.addClass('success').fadeIn().delay(3000).fadeOut();
                 } else {
-                    $('#ajaxMsg').html("<div class='msg'>Failed to clear resolved history</div>");
-                    $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                    $ajaxMsg.html("<div class='msg'>Failed to clear resolved history</div>");
+                    //noinspection JSUnresolvedReference
+                    $ajaxMsg.addClass('error').fadeIn().delay(3000).fadeOut();
                 }
             },
             error: function() {
-                $('#ajaxMsg').html("<div class='msg'>Failed to clear resolved history</div>");
-                $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                $ajaxMsg.html("<div class='msg'>Failed to clear resolved history</div>");
+                //noinspection JSUnresolvedReference
+                $ajaxMsg.addClass('error').fadeIn().delay(3000).fadeOut();
             }
         });
     }
 
     /* Toggle the resolved history section visibility */
     function toggleResolved() {
-        var toggle = $('#resolved-toggle');
-        var section = $('#resolved-section');
+        const toggle = $('#resolved-toggle');
+        const section = $('#resolved-section');
+        //noinspection JSUnresolvedReference
         toggle.toggleClass('open');
+        //noinspection JSUnresolvedReference
         if (toggle.hasClass('open')) {
+            //noinspection JSUnresolvedReference
             section.slideDown(200);
         } else {
+            //noinspection JSUnresolvedReference
             section.slideUp(200);
         }
     }
@@ -416,10 +438,13 @@
      * Runs every 15 seconds to keep "X min ago" labels current.
      */
     function refreshTimestamps() {
+        //noinspection JSUnresolvedReference
         $('.health-ts').each(function() {
-            var iso = $(this).attr('data-iso');
+            const el = $(this);
+            //noinspection JSUnresolvedReference
+            const iso = el.attr('data-iso');
             if (iso) {
-                $(this).text(formatHealthTime(iso));
+                el.text(formatHealthTime(iso));
             }
         });
     }
@@ -427,6 +452,8 @@
     /* Initialize page on document ready */
     $(document).ready(function() {
         initActions();
+        $ajaxMsg = $('#ajaxMsg');
+        $resolvedTbody = $('#resolved-tbody');
 
         // load data immediately
         loadHealthData();

--- a/data/interfaces/default/health.html
+++ b/data/interfaces/default/health.html
@@ -1,0 +1,388 @@
+<%doc>
+    Health Dashboard page — displays system health check results.
+    Part of the Health Dashboard feature (see docs/health-dashboard/).
+</%doc>
+<%inherit file="base.html"/>
+
+<%def name="headerIncludes()">
+    <div id="subhead_container">
+        <div id="subhead_menu">
+            <a id="menu_link_recheck" href="#" onclick="runHealthCheck(); return false;">Run Health Check</a>
+            <a id="menu_link_clearresolved" href="#" onclick="clearResolved(); return false;">Clear Resolved</a>
+            <a id="menu_link_viewlogs" href="logs">View Logs</a>
+        </div>
+    </div>
+</%def>
+
+<%def name="body()">
+    <input type="hidden" id="page_name" value="health" />
+    <div class="title">
+        <h1 class="clearfix">System Health</h1>
+    </div>
+
+    <!-- Summary Cards -->
+    <div class="health-summary" id="summary-cards">
+        <div class="health-card errors">
+            <div class="card-count" id="error-count">-</div>
+            <div class="card-label">Errors</div>
+        </div>
+        <div class="health-card warnings">
+            <div class="card-count" id="warning-count">-</div>
+            <div class="card-label">Warnings</div>
+        </div>
+        <div class="health-card notices">
+            <div class="card-count" id="notice-count">-</div>
+            <div class="card-label">Notices</div>
+        </div>
+        <div class="health-card lastcheck">
+            <div class="card-count" id="last-check-time">--</div>
+            <div class="card-label">Last Check</div>
+        </div>
+    </div>
+
+    <!-- Active Issues Table -->
+    <table class="display" id="health_table">
+        <thead>
+            <tr>
+                <th>Severity</th>
+                <th>Check</th>
+                <th>Message</th>
+                <th>First Seen</th>
+                <th>Last Seen</th>
+                <th>Count</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody id="health-tbody">
+        </tbody>
+    </table>
+    <br>
+
+    <!-- Resolved History -->
+    <div class="resolved-toggle" id="resolved-toggle" onclick="toggleResolved()">
+        <span class="arrow">&#9654;</span> <span id="resolved-label">Recently Resolved</span>
+    </div>
+    <div class="resolved-section" id="resolved-section" style="display:none;">
+        <table class="display" id="resolved_table">
+            <thead>
+                <tr>
+                    <th>Severity</th>
+                    <th>Check</th>
+                    <th>Message</th>
+                    <th>Resolved</th>
+                </tr>
+            </thead>
+            <tbody id="resolved-tbody">
+            </tbody>
+        </table>
+    </div>
+</%def>
+
+<%def name="headIncludes()">
+    <link rel="stylesheet" href="interfaces/${interface}/css/data_table.css">
+    <style>
+        /* ── Health Summary Cards ── */
+        .health-summary {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 20px;
+        }
+        .health-card {
+            flex: 1;
+            border: 1px solid #e0e0e0;
+            border-radius: 5px;
+            padding: 14px 16px;
+            text-align: center;
+            background: #fff;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+        }
+        .health-card .card-count {
+            font-size: 36px;
+            font-weight: bold;
+            line-height: 1.2;
+            font-family: "Trebuchet MS", Helvetica, Arial, sans-serif;
+        }
+        .health-card .card-label {
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            margin-top: 2px;
+            font-weight: bold;
+        }
+        .health-card.errors { border-left: 4px solid #e04040; }
+        .health-card.errors .card-count { color: #d03030; }
+        .health-card.errors .card-label { color: #a02020; }
+        .health-card.warnings { border-left: 4px solid #e0a000; }
+        .health-card.warnings .card-count { color: #c09000; }
+        .health-card.warnings .card-label { color: #906000; }
+        .health-card.notices { border-left: 4px solid #4183c4; }
+        .health-card.notices .card-count { color: #3070b0; }
+        .health-card.notices .card-label { color: #305080; }
+        .health-card.lastcheck { border-left: 4px solid #60c060; }
+        .health-card.lastcheck .card-count { color: #40a040; font-size: 16px; line-height: 2.6; }
+        .health-card.lastcheck .card-label { color: #308030; }
+
+        /* ── Severity Badges ── */
+        .severity-badge {
+            display: inline-block;
+            font-size: 11px;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            padding: 2px 8px;
+            border-radius: 3px;
+            white-space: nowrap;
+        }
+        .severity-badge.error { background: #fce4e4; color: #c03030; border: 1px solid #f0c0c0; }
+        .severity-badge.warning { background: #fef8e0; color: #a07000; border: 1px solid #ece0a0; }
+        .severity-badge.notice { background: #e8f0ff; color: #3070b0; border: 1px solid #c0d8f0; }
+
+        /* ── Warning rows (not in default data_table.css) ── */
+        table.display tr.gradeW td { background-color: #fff8e0; }
+
+        /* ── Wiki Link ── */
+        .wiki-link {
+            font-size: 10px;
+            color: #4183c4;
+            background: #f0f6ff;
+            border: 1px solid #d0e0f0;
+            padding: 1px 6px;
+            border-radius: 3px;
+            white-space: nowrap;
+            text-decoration: none;
+        }
+        .wiki-link:hover { background: #e0eeff; color: #306090; }
+
+        /* ── Action Buttons ── */
+        .action-btn {
+            display: inline-block;
+            font-size: 10px;
+            padding: 2px 8px;
+            border-radius: 3px;
+            cursor: pointer;
+            text-decoration: none;
+            border: 1px solid #ddd;
+            background: linear-gradient(#fafafa, #eaeaea);
+            color: #666;
+            white-space: nowrap;
+        }
+        .action-btn:hover { background: linear-gradient(#f0f0f0, #d8d8d8); color: #333; }
+
+        /* ── Resolved Toggle ── */
+        .resolved-toggle {
+            cursor: pointer;
+            font-size: 14px;
+            color: #666;
+            padding: 10px 0;
+            margin-top: 10px;
+            border-top: 1px solid #eee;
+            user-select: none;
+        }
+        .resolved-toggle:hover { color: #4183c4; }
+        .resolved-toggle .arrow {
+            display: inline-block;
+            transition: transform 0.2s;
+            font-size: 10px;
+            margin-right: 6px;
+        }
+        .resolved-toggle.open .arrow { transform: rotate(90deg); }
+        .resolved-section { margin-top: 10px; }
+        table.display tr.resolved td { color: #999; }
+
+        /* ── Empty state ── */
+        .health-empty {
+            text-align: center;
+            padding: 30px;
+            color: #60a060;
+            font-size: 14px;
+        }
+    </style>
+</%def>
+
+<%def name="javascriptIncludes()">
+    <script src="js/libs/jquery.dataTables.min.js"></script>
+    <script>
+    /* ── Health Dashboard Data Loading ── */
+
+    var healthRefreshTimer = null;
+
+    /* Format an ISO datetime string to a short display string */
+    function formatHealthTime(isoStr) {
+        if (!isoStr) return '--';
+        try {
+            var d = new Date(isoStr);
+            if (isNaN(d.getTime())) return isoStr;
+            var now = new Date();
+            var diffMs = now - d;
+            var diffMin = Math.floor(diffMs / 60000);
+            if (diffMin < 1) return 'Just now';
+            if (diffMin < 60) return diffMin + ' min ago';
+            var diffHrs = Math.floor(diffMin / 60);
+            if (diffHrs < 24) return diffHrs + ' hr ago';
+            var diffDays = Math.floor(diffHrs / 24);
+            return diffDays + ' day' + (diffDays > 1 ? 's' : '') + ' ago';
+        } catch (e) {
+            return isoStr;
+        }
+    }
+
+    /* Build severity badge HTML */
+    function severityBadge(sev) {
+        return '<span class="severity-badge ' + sev + '">' + sev.charAt(0).toUpperCase() + sev.slice(1) + '</span>';
+    }
+
+    /* Determine DataTable row class based on severity */
+    function severityRowClass(sev) {
+        if (sev === 'error') return 'gradeX';
+        if (sev === 'warning') return 'gradeW';
+        return 'gradeZ';
+    }
+
+    /* Fetch health data from server and update the page */
+    function loadHealthData() {
+        $.ajax({
+            url: 'getHealth',
+            data: { include_history: 'true' },
+            dataType: 'json',
+            success: function(resp) {
+                if (!resp || !resp.success) return;
+                var data = resp.data;
+                var results = data.results || [];
+                var summary = data.summary || {};
+                var history = data.history || [];
+
+                // Update summary cards
+                $('#error-count').text(summary.errors || 0);
+                $('#warning-count').text(summary.warnings || 0);
+                $('#notice-count').text(summary.notices || 0);
+                $('#last-check-time').text(formatHealthTime(data.last_run));
+
+                // Update active issues table
+                var tbody = $('#health-tbody');
+                tbody.empty();
+
+                if (results.length === 0) {
+                    tbody.append('<tr><td colspan="7" class="health-empty">All health checks passed &mdash; system is operating normally.</td></tr>');
+                } else {
+                    for (var i = 0; i < results.length; i++) {
+                        var r = results[i];
+                        var rowClass = severityRowClass(r.severity);
+                        var wikiHtml = r.wiki_url ? ' <a href="' + r.wiki_url + '" class="wiki-link" target="_blank">Wiki</a>' : '';
+                        var row = '<tr class="' + rowClass + '">' +
+                            '<td>' + severityBadge(r.severity) + '</td>' +
+                            '<td><strong>' + (r.check_name || '').replace(/_/g, ' ') + '</strong></td>' +
+                            '<td>' + (r.message || '') + wikiHtml + '</td>' +
+                            '<td>' + formatHealthTime(r.first_seen) + '</td>' +
+                            '<td>' + formatHealthTime(r.last_seen) + '</td>' +
+                            '<td style="text-align:center;">' + (r.check_count || 1) + '</td>' +
+                            '<td>' +
+                                '<a href="#" class="action-btn" onclick="dismissCheck(' + r.id + '); return false;">Dismiss</a>' +
+                            '</td>' +
+                            '</tr>';
+                        tbody.append(row);
+                    }
+                }
+
+                // Update resolved history
+                var rtbody = $('#resolved-tbody');
+                rtbody.empty();
+                if (history.length === 0) {
+                    $('#resolved-label').text('No recently resolved issues');
+                    rtbody.append('<tr><td colspan="4" style="text-align:center; padding:15px; color:#999;">No resolved issues in history</td></tr>');
+                } else {
+                    $('#resolved-label').text('Recently Resolved (' + history.length + ')');
+                    for (var j = 0; j < history.length; j++) {
+                        var h = history[j];
+                        var hrow = '<tr class="resolved">' +
+                            '<td>' + severityBadge(h.severity) + '</td>' +
+                            '<td>' + (h.check_name || '').replace(/_/g, ' ') + '</td>' +
+                            '<td>' + (h.message || '') + '</td>' +
+                            '<td>' + formatHealthTime(h.last_seen) + '</td>' +
+                            '</tr>';
+                        rtbody.append(hrow);
+                    }
+                }
+            },
+            error: function() {
+                $('#last-check-time').text('Error');
+            }
+        });
+    }
+
+    /* Trigger an immediate health check run */
+    function runHealthCheck() {
+        var btn = $('#menu_link_recheck');
+        btn.button("option", "label", "Running...");
+        btn.button("disable");
+        $.ajax({
+            url: 'recheckHealth',
+            dataType: 'json',
+            success: function(resp) {
+                if (resp && resp.status === 'ok') {
+                    $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Health check triggered</div>");
+                    $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+                    // wait a moment for the check to complete, then refresh data
+                    setTimeout(loadHealthData, 3000);
+                } else {
+                    $('#ajaxMsg').html("<div class='msg'>Health check failed to trigger</div>");
+                    $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+                }
+            },
+            error: function() {
+                $('#ajaxMsg').html("<div class='msg'>Health check request failed</div>");
+                $('#ajaxMsg').addClass('error').fadeIn().delay(3000).fadeOut();
+            },
+            complete: function() {
+                btn.button("option", "label", "Run Health Check");
+                btn.button("enable");
+            }
+        });
+    }
+
+    /* Dismiss a specific health check issue */
+    function dismissCheck(checkId) {
+        $.ajax({
+            url: 'dismissHealth',
+            data: { check_id: checkId },
+            dataType: 'json',
+            success: function(resp) {
+                if (resp && resp.status === 'ok') {
+                    loadHealthData();
+                }
+            }
+        });
+    }
+
+    /* Clear all resolved history records */
+    function clearResolved() {
+        // reload data without resolved (they get cleaned up by the engine's cleanup)
+        $('#resolved-tbody').empty();
+        $('#resolved-label').text('No recently resolved issues');
+        $('#ajaxMsg').html("<div class='msg'><span class='ui-icon ui-icon-check'></span>Resolved history cleared</div>");
+        $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
+    }
+
+    /* Toggle the resolved history section visibility */
+    function toggleResolved() {
+        var toggle = $('#resolved-toggle');
+        var section = $('#resolved-section');
+        toggle.toggleClass('open');
+        if (toggle.hasClass('open')) {
+            section.slideDown(200);
+        } else {
+            section.slideUp(200);
+        }
+    }
+
+    /* Initialize page on document ready */
+    $(document).ready(function() {
+        initActions();
+
+        // load data immediately
+        loadHealthData();
+
+        // auto-refresh every 30 seconds
+        healthRefreshTimer = setInterval(loadHealthData, 30000);
+    });
+    </script>
+</%def>

--- a/data/js/script.js
+++ b/data/js/script.js
@@ -68,6 +68,8 @@ function initActions() {
     $("#subhead_menu #menu_link_carepackage").button({ icons: { primary: "ui-icon-heart"} });
     $("#subhead_menu #menu_link_scan").button({ icons: { primary: "ui-icon-search"} });
     $("#subhead_menu #menu_link_addalltoRL").button({ icons: { primary: "ui-icon-plus"} });
+    $("#subhead_menu #menu_link_clearresolved").button({ icons: { primary: "ui-icon-trash"} });
+    $("#subhead_menu #menu_link_viewlogs").button({ icons: { primary: "ui-icon-note"} });
 }
 
 function refreshSubmenu() {

--- a/data/js/script.js
+++ b/data/js/script.js
@@ -66,6 +66,7 @@ function initActions() {
     $("#subhead_menu #menu_link_new").button({ icons: { primary: "ui-icon-arrowreturnthick-1-s" } });
     $("#subhead_menu #menu_link_shutdown").button({ icons: { primary: "ui-icon-power"} });
     $("#subhead_menu #menu_link_carepackage").button({ icons: { primary: "ui-icon-heart"} });
+    $("#subhead_menu #menu_link_health").button({ icons: { primary: "ui-icon-signal"} });
     $("#subhead_menu #menu_link_scan").button({ icons: { primary: "ui-icon-search"} });
     $("#subhead_menu #menu_link_addalltoRL").button({ icons: { primary: "ui-icon-plus"} });
     $("#subhead_menu #menu_link_clearresolved").button({ icons: { primary: "ui-icon-trash"} });

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -443,6 +443,34 @@ def initialize(config_file):
         UMASK = os.umask(0)
         os.umask(UMASK)
 
+        # Health Check scheduler
+        if CONFIG.HEALTH_CHECK_ENABLED:
+            try:
+                from mylar.healthcheck import HealthCheckRunner
+                HEALTH_CHECK = HealthCheckRunner()
+                HEALTH_CHECK.load_from_db()
+                HEALTH_SCHEDULER = SCHED.add_job(
+                    HEALTH_CHECK.run_all_checks,
+                    IntervalTrigger(minutes=int(CONFIG.HEALTH_CHECK_INTERVAL)),
+                    id='health_check',
+                    name='Health Check',
+                    replace_existing=True,
+                    max_instances=1,
+                    coalesce=True,
+                    next_run_time=datetime.datetime.utcnow() + datetime.timedelta(seconds=30)
+                )
+                logger.info('[HealthCheck] Scheduler registered — running every %s minutes' % CONFIG.HEALTH_CHECK_INTERVAL)
+            except Exception as e:
+                logger.error('[HealthCheck] Failed to initialize: %s' % e)
+                HEALTH_CHECK = None
+        else:
+            try:
+                from mylar.healthcheck import HealthCheckRunner
+                HEALTH_CHECK = HealthCheckRunner()
+            except Exception as e:
+                logger.error('[HealthCheck] Failed to import: %s' % e)
+                HEALTH_CHECK = None
+
         _INITIALIZED = True
         return True
 

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -244,6 +244,11 @@ BACKENDSTATUS_WS = 'up'
 BACKENDSTATUS_CV = 'up'
 PROVIDER_STATUS = {}
 
+## -- Health Check globals (set during initialize) --
+HEALTH_CHECK = None
+HEALTH_RESULTS = []
+HEALTH_SCHEDULER = None
+
 
 def initialize(config_file):
     with INIT_LOCK:
@@ -258,7 +263,8 @@ def initialize(config_file):
                MONITOR_SCHEDULER, SEARCH_SCHEDULER, RSS_SCHEDULER, WEEKLY_SCHEDULER, VERSION_SCHEDULER, UPDATER_SCHEDULER, START_UP, \
                SCHED_RSS_LAST, SCHED_WEEKLY_LAST, SCHED_MONITOR_LAST, SCHED_SEARCH_LAST, SCHED_VERSION_LAST, SCHED_DBUPDATE_LAST, COMICINFO, SEARCH_TIER_DATE, \
                BACKENDSTATUS_CV, BACKENDSTATUS_WS, PROVIDER_STATUS, EXT_IP, INBUILT_ISSUE_EXCEPTIONS, PROVIDER_START_ID, GLOBAL_MESSAGES, CHECK_FOLDER_CACHE, FOLDER_CACHE, SESSION_ID, \
-               MAINTENANCE_UPDATE, MAINTENANCE_DB_COUNT, MAINTENANCE_DB_TOTAL, UPDATE_VALUE, REQS, IMPRINT_MAPPING, GC_URL, PACK_ISSUEIDS_DONT_QUEUE, DDL_QUEUED, EXT_SERVER
+               MAINTENANCE_UPDATE, MAINTENANCE_DB_COUNT, MAINTENANCE_DB_TOTAL, UPDATE_VALUE, REQS, IMPRINT_MAPPING, GC_URL, PACK_ISSUEIDS_DONT_QUEUE, DDL_QUEUED, EXT_SERVER, \
+               HEALTH_CHECK, HEALTH_RESULTS, HEALTH_SCHEDULER
 
         cc = mylar.config.Config(config_file)
         CONFIG = cc.read(startup=True)
@@ -862,6 +868,30 @@ def dbcheck():
     c.execute('CREATE TABLE IF NOT EXISTS notifs(session_id INT, date TEXT, event TEXT, comicid TEXT, comicname TEXT, issuenumber TEXT, seriesyear TEXT, status TEXT, message TEXT, PRIMARY KEY (session_id, date))')
     c.execute('CREATE TABLE IF NOT EXISTS provider_searches(id INTEGER UNIQUE, provider TEXT UNIQUE, type TEXT, lastrun INTEGER, active TEXT, hits INTEGER DEFAULT 0)')
     c.execute('CREATE TABLE IF NOT EXISTS mylar_info(DatabaseVersion INTEGER PRIMARY KEY)')
+
+    ## -- Health Checks Table --
+    c.execute('CREATE TABLE IF NOT EXISTS health_checks ('
+              'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+              'check_type TEXT NOT NULL, '
+              'check_name TEXT NOT NULL, '
+              'severity TEXT NOT NULL, '
+              'message TEXT NOT NULL, '
+              'wiki_url TEXT, '
+              'source TEXT DEFAULT "health_check", '
+              'first_seen TEXT NOT NULL, '
+              'last_seen TEXT NOT NULL, '
+              'is_resolved INTEGER DEFAULT 0, '
+              'resolved_at TEXT, '
+              'check_count INTEGER DEFAULT 1, '
+              'metadata TEXT'
+              ')')
+
+    try:
+        c.execute('CREATE INDEX IF NOT EXISTS idx_health_active ON health_checks (is_resolved, severity)')
+        c.execute('CREATE INDEX IF NOT EXISTS idx_health_type ON health_checks (check_type, is_resolved)')
+    except Exception:
+        pass
+
     conn.commit()
 
     #create some indexes

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -457,7 +457,7 @@ def initialize(config_file):
                     replace_existing=True,
                     max_instances=1,
                     coalesce=True,
-                    next_run_time=datetime.datetime.utcnow() + datetime.timedelta(seconds=30)
+                    next_run_time=datetime.datetime.utcnow() + datetime.timedelta(seconds=5)
                 )
                 logger.info('[HealthCheck] Scheduler registered — running every %s minutes' % CONFIG.HEALTH_CHECK_INTERVAL)
             except Exception as e:

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -40,7 +40,8 @@ cmd_list = ['getIndex', 'getComic', 'getUpcoming', 'getWanted', 'getHistory',
             'getComicInfo', 'getIssueInfo', 'getArt', 'downloadIssue', 'regenerateCovers',
             'refreshSeriesjson', 'seriesjsonListing', 'checkGlobalMessages',
             'listProviders', 'changeProvider', 'addProvider', 'delProvider',
-            'downloadNZB', 'getReadList', 'getStoryArc', 'addStoryArc', 'listAnnualSeries']
+            'downloadNZB', 'getReadList', 'getStoryArc', 'addStoryArc', 'listAnnualSeries',
+            'getHealth', 'getHealthSummary']
 
 class Api(object):
 
@@ -1815,6 +1816,43 @@ class Api(object):
             else:
                 self.data = self._successResponse('Successfully changed %s for %s provider %s [prov_id:%s]' % (change_match, providertype, providername, prov_id))
                 logger.fdebug('[API][changeProvider] %s' % self.data)
+        return
+
+    def _getHealth(self, **kwargs):
+        """Return active health check results."""
+        try:
+            if mylar.HEALTH_CHECK:
+                results = [r.to_dict() for r in mylar.HEALTH_CHECK.get_results()]
+                summary = mylar.HEALTH_CHECK.get_summary()
+                last_run = mylar.HEALTH_CHECK.last_run_iso()
+            else:
+                results = []
+                summary = {'errors': 0, 'warnings': 0, 'notices': 0, 'total': 0}
+                last_run = None
+            self.data = self._successResponse({
+                'results': results,
+                'summary': summary,
+                'last_run': last_run,
+            })
+        except Exception as e:
+            self.data = self._failureResponse('Health check query failed: %s' % str(e)[:200])
+        return
+
+    def _getHealthSummary(self, **kwargs):
+        """Return health check summary counts only."""
+        try:
+            if mylar.HEALTH_CHECK:
+                summary = mylar.HEALTH_CHECK.get_summary()
+                last_run = mylar.HEALTH_CHECK.last_run_iso()
+            else:
+                summary = {'errors': 0, 'warnings': 0, 'notices': 0, 'total': 0}
+                last_run = None
+            self.data = self._successResponse({
+                'summary': summary,
+                'last_run': last_run,
+            })
+        except Exception as e:
+            self.data = self._failureResponse('Health summary query failed: %s' % str(e)[:200])
         return
 
 class REST(object):

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -105,6 +105,11 @@ class Api(object):
                     data = '\nevent: shutdown\ndata: {\ndata: "status": "' + results['status'] + '",\ndata: "message": "' + results['message'] + '"\ndata: }\n\n'
                 except Exception:
                     data = '\nevent: shutdown\ndata: {\ndata: "status": "' + results['status'] + '",\ndata: "message": "' + results['message'] + '"\ndata: }\n\n'
+            elif results['event'] == 'health_update':
+                try:
+                    data = '\nevent: health_update\ndata: ' + results['data'] + '\n\n'
+                except Exception:
+                    data = '\ndata: \n\n'
             elif results['event'] == 'check_update':
                 try:
                     data = '\nevent: check_update\ndata: {\ndata: "status": "' + results['status'] + '",\ndata: "current_version": "' + results['current_version'] + '",\ndata: "latest_version": "' + results['latest_version'] + '",\ndata: "commits_behind": "' + results['commits_behind'] + '",\ndata: "docker": "' + results['docker'] + '",\ndata: "message": "' + results['message'] + '"\ndata: }\n\n'
@@ -1290,6 +1295,8 @@ class Api(object):
 
             if event is not None and any([event == 'shutdown', event == 'config_check']):
                 the_message = {'status': mylar.GLOBAL_MESSAGES['status'], 'event': event, 'message': mylar.GLOBAL_MESSAGES['message']}
+            elif event is not None and event == 'health_update':
+                the_message = {'status': mylar.GLOBAL_MESSAGES['status'], 'event': event, 'data': mylar.GLOBAL_MESSAGES['data']}
             elif event is not None and event == 'check_update':
                 the_message = {'status': mylar.GLOBAL_MESSAGES['status'], 'event': event, 'current_version': mylar.GLOBAL_MESSAGES['current_version'], 'latest_version': mylar.GLOBAL_MESSAGES['latest_version'], 'commits_behind': str(mylar.GLOBAL_MESSAGES['commits_behind']), 'docker': mylar.GLOBAL_MESSAGES['docker'], 'message': mylar.GLOBAL_MESSAGES['message']}
             else:
@@ -1300,7 +1307,7 @@ class Api(object):
                 except Exception as e:
                     logger.warn('error: %s' % e)
             #logger.fdebug('the_message added: %s' % (the_message,))
-            if mylar.GLOBAL_MESSAGES['status'] != 'mid-message-event':
+            if mylar.GLOBAL_MESSAGES['status'] != 'mid-message-event' and event != 'health_update':
                 myDB = db.DBConnection()
                 tmp_message = dict(the_message, **{'session_id': mylar.SESSION_ID})
                 if event != 'check_update':

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -1397,6 +1397,10 @@ class Config(object):
             logger.fdebug("Minimum RSS Interval Check delay set for 20 minutes to avoid hammering.")
             self.RSS_CHECKINTERVAL = 20
 
+        if self.HEALTH_CHECK_INTERVAL < 5:
+            logger.fdebug("Minimum Health Check interval set to 5 minutes to avoid excessive checking.")
+            self.HEALTH_CHECK_INTERVAL = 5
+
         if self.ENABLE_RSS is True and mylar.RSS_STATUS == 'Paused':
             mylar.RSS_STATUS = 'Waiting'
         elif self.ENABLE_RSS is False and mylar.RSS_STATUS == 'Waiting':

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -467,6 +467,15 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'CBL_IMPORT_ISSUESONLY' : (bool, 'CBLImport', True),
     'CBL_IMPORT_IGNOREARCHIVED' : (bool, 'CBLImport', False),
 
+    # Health Check settings
+    'HEALTH_CHECK_ENABLED':    (bool, 'Health', True),
+    'HEALTH_CHECK_INTERVAL':   (int,  'Health', 5),
+    'HEALTH_DISK_WARN_GB':     (str,  'Health', '5.0'),
+    'HEALTH_DISK_ERROR_GB':    (str,  'Health', '1.0'),
+    'HEALTH_STALE_TASK_MIN':   (int,  'Health', 60),
+    'HEALTH_SHOW_BANNER':      (bool, 'Health', True),
+    'HEALTH_HISTORY_DAYS':     (int,  'Health', 30),
+
 })
 
 _BAD_DEFINITIONS = OrderedDict({

--- a/mylar/healthcheck.py
+++ b/mylar/healthcheck.py
@@ -27,7 +27,7 @@ import socket
 import requests
 
 import mylar
-from mylar import logger, db, helpers
+from mylar import logger, db
 
 
 # ── Health Check System ──
@@ -297,7 +297,8 @@ class HealthCheckRunner:
         except Exception as e:
             logger.error('[HealthCheck] Failed to load from database: %s' % e)
 
-    def clear_resolved_history(self):
+    @staticmethod
+    def clear_resolved_history():
         """Delete all resolved health check records from the database."""
         try:
             myconn = db.DBConnection()
@@ -306,7 +307,8 @@ class HealthCheckRunner:
         except Exception as e:
             logger.error('[HealthCheck] Failed to clear resolved history: %s' % e)
 
-    def get_resolved_history(self, days=None):
+    @staticmethod
+    def get_resolved_history(days=None):
         """Query resolved health check records for the UI."""
         if days is None:
             days = int(mylar.CONFIG.HEALTH_HISTORY_DAYS or 30)
@@ -320,7 +322,8 @@ class HealthCheckRunner:
 
     # ── Check Methods ──
 
-    def check_root_folders(self):
+    @staticmethod
+    def check_root_folders():
         """Check that configured comic root folders exist and are accessible."""
         results = []
         paths_to_check = []
@@ -352,7 +355,8 @@ class HealthCheckRunner:
                 ))
         return results
 
-    def check_comicvine_api(self):
+    @staticmethod
+    def check_comicvine_api():
         """Check ComicVine API connectivity and key validity."""
         results = []
         api_key = mylar.CONFIG.COMICVINE_API
@@ -415,7 +419,8 @@ class HealthCheckRunner:
             ))
         return results
 
-    def check_stuck_tasks(self):
+    @staticmethod
+    def check_stuck_tasks():
         """Check for scheduler tasks that have been running too long."""
         results = []
         stale_minutes = int(mylar.CONFIG.HEALTH_STALE_TASK_MIN or 60)
@@ -453,12 +458,13 @@ class HealthCheckRunner:
                                 ))
                         except (ValueError, TypeError):
                             pass
-                except Exception:
+                except (OSError, KeyError):
                     pass
 
         return results
 
-    def check_disk_space(self):
+    @staticmethod
+    def check_disk_space():
         """Check free disk space on configured storage paths."""
         results = []
 
@@ -509,7 +515,8 @@ class HealthCheckRunner:
 
         return results
 
-    def check_indexers(self):
+    @staticmethod
+    def check_indexers():
         """Check configured indexers for connectivity issues."""
         results = []
 
@@ -538,7 +545,8 @@ class HealthCheckRunner:
 
         return results
 
-    def check_no_indexers(self):
+    @staticmethod
+    def check_no_indexers():
         """Warn if no search indexers or providers are enabled."""
         results = []
 
@@ -553,7 +561,7 @@ class HealthCheckRunner:
                 if len(nz) > 5 and str(nz[5]) == '1':
                     has_any = True
                     break
-        except Exception:
+        except (TypeError, IndexError, AttributeError):
             pass
 
         # check torznab providers — same tuple format as newznabs
@@ -564,7 +572,7 @@ class HealthCheckRunner:
                     if len(tz) > 5 and str(tz[5]) == '1':
                         has_any = True
                         break
-            except Exception:
+            except (TypeError, IndexError, AttributeError):
                 pass
 
         # check other search toggles
@@ -584,7 +592,8 @@ class HealthCheckRunner:
 
         return results
 
-    def check_download_client(self):
+    @staticmethod
+    def check_download_client():
         """Test download client connectivity."""
         # NZB clients (SABnzbd, NZBGet): HTTP API version endpoint
         # Torrent clients (qBittorrent, Transmission, uTorrent): HTTP API probe
@@ -780,7 +789,7 @@ class HealthCheckRunner:
                     rpc_url = getattr(mylar.CONFIG, 'RTORRENT_RPC_URL', '') or ''
                     test_url = rt_host.rstrip('/') + '/' + rpc_url.lstrip('/')
                     rt_verify = getattr(mylar.CONFIG, 'RTORRENT_VERIFY', False)
-                    resp = requests.get(test_url.rstrip('/'), timeout=5, verify=rt_verify)
+                    _resp = requests.get(test_url.rstrip('/'), timeout=5, verify=rt_verify)
                     # Any HTTP response means the server is reachable; only
                     # connection-level failures indicate a problem.
                 except requests.exceptions.ConnectionError:
@@ -881,7 +890,8 @@ class HealthCheckRunner:
 
         return results
 
-    def check_download_category(self):
+    @staticmethod
+    def check_download_category():
         """Verify the configured download category exists in the client."""
         # Deferred — requires querying SABnzbd/NZBGet categories API which
         # involves client-specific XML-RPC or REST calls and authentication.
@@ -889,14 +899,16 @@ class HealthCheckRunner:
         # expose a list_categories() interface.
         return []
 
-    def check_stalled_downloads(self):
+    @staticmethod
+    def check_stalled_downloads():
         """Check for downloads that appear stuck in the client queue."""
         # Deferred — requires querying each download client's active queue
         # and comparing item ages against a threshold.  Each client (SABnzbd,
         # NZBGet, qBittorrent, etc.) has a different API for queue inspection.
         return []
 
-    def check_failed_postprocessing(self):
+    @staticmethod
+    def check_failed_postprocessing():
         """Check for repeated post-processing failures in the last 24 hours."""
         results = []
         try:
@@ -919,7 +931,8 @@ class HealthCheckRunner:
             logger.debug('[HealthCheck] Could not query Failed table: %s' % str(e)[:200])
         return results
 
-    def check_update_available(self):
+    @staticmethod
+    def check_update_available():
         """Check if a newer version of Mylar3 is available."""
         results = []
         commits_behind = getattr(mylar, 'COMMITS_BEHIND', None)
@@ -935,7 +948,8 @@ class HealthCheckRunner:
             ))
         return results
 
-    def check_permissions(self):
+    @staticmethod
+    def check_permissions():
         """Verify write access to key Mylar directories."""
         results = []
         dirs_to_check = {
@@ -954,7 +968,8 @@ class HealthCheckRunner:
                 ))
         return results
 
-    def check_no_download_client(self):
+    @staticmethod
+    def check_no_download_client():
         """Warn if no download client is configured."""
         results = []
 
@@ -990,7 +1005,8 @@ class HealthCheckRunner:
             ))
         return results
 
-    def check_api_key_missing(self):
+    @staticmethod
+    def check_api_key_missing():
         """Warn if ComicVine API key is not configured."""
         results = []
         api_key = getattr(mylar.CONFIG, 'COMICVINE_API', None)
@@ -1003,7 +1019,8 @@ class HealthCheckRunner:
             ))
         return results
 
-    def check_database_integrity(self):
+    @staticmethod
+    def check_database_integrity():
         """Run SQLite PRAGMA integrity_check (runs every 6 hours)."""
         results = []
         try:
@@ -1041,7 +1058,8 @@ class HealthCheckRunner:
         elapsed_min = (datetime.datetime.now(datetime.timezone.utc) - last).total_seconds() / 60
         return elapsed_min >= interval
 
-    def _save_to_db(self, results):
+    @staticmethod
+    def _save_to_db(results):
         # persist current results to SQLite — upserts active, skips unchanged
         myconn = db.DBConnection()
         now = datetime.datetime.now(datetime.timezone.utc).isoformat()
@@ -1084,7 +1102,8 @@ class HealthCheckRunner:
         # persist one result (used by log handler for immediate findings)
         self._save_to_db([result])
 
-    def _resolve_cleared(self, current_results, checks_that_ran):
+    @staticmethod
+    def _resolve_cleared(current_results, checks_that_ran):
         # Only resolve DB records for checks that ACTUALLY RAN this cycle
         # and returned clean (no results).  If a check was skipped by
         # _should_run(), its DB records must be left untouched.
@@ -1107,7 +1126,8 @@ class HealthCheckRunner:
         except Exception as e:
             logger.error('[HealthCheck] Failed to resolve cleared checks: %s' % str(e)[:200])
 
-    def _cleanup_old(self):
+    @staticmethod
+    def _cleanup_old():
         # purge resolved records older than HEALTH_HISTORY_DAYS
         days = int(mylar.CONFIG.HEALTH_HISTORY_DAYS or 30)
         cutoff = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days)).isoformat()
@@ -1201,7 +1221,7 @@ class HealthLogHandler(logging.Handler):
                         return
 
                     # Only set throttle AFTER successfully ingesting
-                    # the finding.  If HEALTH_CHECK is not yet initialised
+                    # the finding.  If HEALTH_CHECK is not yet initialized
                     # (e.g. during startup, before initialize() creates the
                     # runner) we must NOT set the throttle — otherwise the
                     # first real opportunity (config-save) would be blocked
@@ -1219,5 +1239,5 @@ class HealthLogHandler(logging.Handler):
                         self._last_emit[check_name] = now  # throttle only on success
                     break  # only match first pattern
 
-        except Exception:
-            pass  # NEVER let a logging handler crash the application
+        except (AttributeError, TypeError, ValueError, RuntimeError):
+            pass  # logging handlers must NEVER crash the application

--- a/mylar/healthcheck.py
+++ b/mylar/healthcheck.py
@@ -21,6 +21,8 @@ import threading
 import json
 import logging
 import re
+import shutil
+import socket
 
 import requests
 
@@ -31,7 +33,8 @@ from mylar import logger, db, helpers
 # ── Health Check System ──
 # Provides periodic health monitoring for Mylar3 components.
 # Checks infrastructure (folders, disk, DB), providers (ComicVine, indexers),
-# download clients (SABnzbd, NZBGet), and scheduler tasks.
+# download clients (SABnzbd, NZBGet, qBittorrent, Transmission, rTorrent,
+# Deluge, uTorrent), and scheduler tasks.
 #
 # Results are stored in the health_checks SQLite table and pushed to
 # the browser via SSE for real-time banner and badge updates.
@@ -177,6 +180,8 @@ class HealthCheckRunner:
             checks_that_ran.add(check_name)
             try:
                 check_results = check_method()
+                if not check_results:
+                    logger.fdebug('[HealthCheck] %s: passed' % check_name)
                 for cr in check_results:
                     if cr.severity == 'error':
                         logger.error('[HealthCheck] %s: %s' % (cr.check_name, cr.message))
@@ -218,8 +223,9 @@ class HealthCheckRunner:
         error_count = sum(1 for r in results if r.severity == 'error')
         warning_count = sum(1 for r in results if r.severity == 'warning')
         notice_count = sum(1 for r in results if r.severity == 'notice')
-        summary_msg = '[HealthCheck] Completed in %.2fs — %d errors, %d warnings, %d notices' % (
-            elapsed, error_count, warning_count, notice_count)
+        summary_msg = '[HealthCheck] Completed in %.2fs — %d errors, %d warnings, %d notices (%d/%d checks ran)' % (
+            elapsed, error_count, warning_count, notice_count,
+            len(checks_that_ran), len(check_methods))
 
         if error_count > 0:
             logger.error(summary_msg)
@@ -454,11 +460,56 @@ class HealthCheckRunner:
 
         return results
 
-    # ── Stubbed Checks (Phase 3) ──
-
     def check_disk_space(self):
-        """[Phase 3] Check free disk space on storage paths."""
-        return []
+        """Check free disk space on configured storage paths."""
+        results = []
+
+        # Cast thresholds from config — stored as str in config.ini
+        warn_gb = float(mylar.CONFIG.HEALTH_DISK_WARN_GB or 5.0)
+        error_gb = float(mylar.CONFIG.HEALTH_DISK_ERROR_GB or 1.0)
+
+        paths_to_check = set()
+        if mylar.CONFIG.DESTINATION_DIR and os.path.exists(mylar.CONFIG.DESTINATION_DIR):
+            paths_to_check.add(mylar.CONFIG.DESTINATION_DIR)
+        if mylar.CONFIG.CACHE_DIR and os.path.exists(mylar.CONFIG.CACHE_DIR):
+            paths_to_check.add(mylar.CONFIG.CACHE_DIR)
+
+        # Dedup by mount point — use (total, used) as a proxy for the same
+        # filesystem since two paths on the same disk will report identical
+        # total capacity.  This avoids duplicate alerts for /comics and /cache
+        # when both live on the same volume.
+        checked_mounts = set()
+
+        for path in paths_to_check:
+            try:
+                usage = shutil.disk_usage(path)
+                mount_key = usage.total  # same total == same filesystem
+                if mount_key in checked_mounts:
+                    continue
+                checked_mounts.add(mount_key)
+
+                free_gb = usage.free / (1024 ** 3)
+
+                if free_gb < error_gb:
+                    results.append(HealthCheckResult(
+                        check_type='infrastructure',
+                        check_name='disk_space',
+                        severity='error',
+                        message='Critically low disk space on %s — only %.1f GB free (threshold: %.1f GB). Downloads will fail.' % (path, free_gb, error_gb),
+                        metadata={'path': path, 'free_gb': round(free_gb, 2), 'total_gb': round(usage.total / (1024 ** 3), 2)}
+                    ))
+                elif free_gb < warn_gb:
+                    results.append(HealthCheckResult(
+                        check_type='infrastructure',
+                        check_name='disk_space',
+                        severity='warning',
+                        message='Low disk space on %s — %.1f GB free (warning threshold: %.1f GB).' % (path, free_gb, warn_gb),
+                        metadata={'path': path, 'free_gb': round(free_gb, 2), 'total_gb': round(usage.total / (1024 ** 3), 2)}
+                    ))
+            except OSError as e:
+                logger.debug('[HealthCheck] Could not check disk space for %s: %s' % (path, e))
+
+        return results
 
     def check_indexers(self):
         """Check configured indexers for connectivity issues."""
@@ -536,32 +587,412 @@ class HealthCheckRunner:
         return results
 
     def check_download_client(self):
-        """[Phase 3] Test download client connectivity."""
-        return []
+        """Test download client connectivity.
+
+        NZB clients (SABnzbd, NZBGet): HTTP API version endpoint.
+        Torrent clients (qBittorrent, Transmission, uTorrent): HTTP API probe.
+        rTorrent: HTTP GET to SCGI pass-through URL (skipped for non-HTTP hosts).
+        Deluge: TCP socket connect to daemon RPC port.
+        """
+        results = []
+
+        if getattr(mylar, 'USE_SABNZBD', False):
+            try:
+                sab_host = mylar.CONFIG.SAB_HOST or ''
+                sab_apikey = mylar.CONFIG.SAB_APIKEY or ''
+                # SABnzbd API URL: host/api?mode=version&apikey=KEY&output=json
+                if sab_host and not sab_host.endswith('/'):
+                    sab_host = sab_host + '/'
+                sab_url = '%sapi?mode=version&apikey=%s&output=json' % (sab_host, sab_apikey)
+                verify = sab_host.startswith('https')
+                resp = requests.get(sab_url, timeout=5, verify=verify)
+                if resp.status_code != 200:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='SABnzbd returned HTTP %d — check host and API key.' % resp.status_code,
+                        metadata={'client': 'sabnzbd', 'status_code': resp.status_code}
+                    ))
+            except requests.exceptions.ConnectionError:
+                results.append(HealthCheckResult(
+                    check_type='download',
+                    check_name='download_client',
+                    severity='error',
+                    message='SABnzbd unreachable at %s — connection refused.' % mylar.CONFIG.SAB_HOST,
+                    metadata={'client': 'sabnzbd', 'error': 'connection_refused'}
+                ))
+            except requests.exceptions.Timeout:
+                results.append(HealthCheckResult(
+                    check_type='download',
+                    check_name='download_client',
+                    severity='error',
+                    message='SABnzbd connection timed out at %s.' % mylar.CONFIG.SAB_HOST,
+                    metadata={'client': 'sabnzbd', 'error': 'timeout'}
+                ))
+            except Exception as e:
+                results.append(HealthCheckResult(
+                    check_type='download',
+                    check_name='download_client',
+                    severity='error',
+                    message='SABnzbd check failed: %s' % str(e)[:200],
+                    metadata={'client': 'sabnzbd', 'error': str(type(e).__name__)}
+                ))
+
+        if getattr(mylar, 'USE_NZBGET', False):
+            try:
+                nzbget_host = mylar.CONFIG.NZBGET_HOST or ''
+                nzbget_port = mylar.CONFIG.NZBGET_PORT or ''
+                # NZBGet uses XML-RPC; test with a simple HTTP GET to the base URL
+                # Build URL: protocol://host:port[/subpath]/xmlrpc
+                if nzbget_host.startswith('https'):
+                    protocol = 'https'
+                    host_part = nzbget_host[8:]
+                elif nzbget_host.startswith('http'):
+                    protocol = 'http'
+                    host_part = nzbget_host[7:]
+                else:
+                    protocol = 'http'
+                    host_part = nzbget_host
+
+                nzbget_url = '%s://%s:%s/jsonrpc/version' % (protocol, host_part, nzbget_port)
+                resp = requests.get(nzbget_url, timeout=5, verify=False)
+                if resp.status_code != 200:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='NZBGet returned HTTP %d — check host and port.' % resp.status_code,
+                        metadata={'client': 'nzbget', 'status_code': resp.status_code}
+                    ))
+            except requests.exceptions.ConnectionError:
+                results.append(HealthCheckResult(
+                    check_type='download',
+                    check_name='download_client',
+                    severity='error',
+                    message='NZBGet unreachable at %s:%s — connection refused.' % (mylar.CONFIG.NZBGET_HOST, mylar.CONFIG.NZBGET_PORT),
+                    metadata={'client': 'nzbget', 'error': 'connection_refused'}
+                ))
+            except requests.exceptions.Timeout:
+                results.append(HealthCheckResult(
+                    check_type='download',
+                    check_name='download_client',
+                    severity='error',
+                    message='NZBGet connection timed out at %s:%s.' % (mylar.CONFIG.NZBGET_HOST, mylar.CONFIG.NZBGET_PORT),
+                    metadata={'client': 'nzbget', 'error': 'timeout'}
+                ))
+            except Exception as e:
+                results.append(HealthCheckResult(
+                    check_type='download',
+                    check_name='download_client',
+                    severity='error',
+                    message='NZBGet check failed: %s' % str(e)[:200],
+                    metadata={'client': 'nzbget', 'error': str(type(e).__name__)}
+                ))
+
+        # ── Torrent client connectivity checks ──
+
+        if getattr(mylar, 'USE_QBITTORRENT', False):
+            qbt_host = getattr(mylar.CONFIG, 'QBITTORRENT_HOST', None) or ''
+            if qbt_host:
+                try:
+                    # qBittorrent WebUI: /api/v2/app/version is unauthenticated
+                    test_url = qbt_host.rstrip('/') + '/api/v2/app/version'
+                    resp = requests.get(test_url, timeout=5, verify=False)
+                    if resp.status_code == 403:
+                        pass  # 403 = reachable, auth required — healthy
+                    elif resp.status_code not in (200, 403):
+                        results.append(HealthCheckResult(
+                            check_type='download',
+                            check_name='download_client',
+                            severity='error',
+                            message='qBittorrent returned HTTP %d — check host and port.' % resp.status_code,
+                            metadata={'client': 'qbittorrent', 'status_code': resp.status_code}
+                        ))
+                except requests.exceptions.ConnectionError:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='qBittorrent unreachable at %s — connection refused.' % qbt_host,
+                        metadata={'client': 'qbittorrent', 'error': 'connection_refused'}
+                    ))
+                except requests.exceptions.Timeout:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='qBittorrent connection timed out at %s.' % qbt_host,
+                        metadata={'client': 'qbittorrent', 'error': 'timeout'}
+                    ))
+                except Exception as e:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='qBittorrent check failed: %s' % str(e)[:200],
+                        metadata={'client': 'qbittorrent', 'error': str(type(e).__name__)}
+                    ))
+
+        if getattr(mylar, 'USE_TRANSMISSION', False):
+            trans_host = getattr(mylar.CONFIG, 'TRANSMISSION_HOST', None) or ''
+            if trans_host:
+                try:
+                    # Transmission RPC responds with 409 + X-Transmission-Session-Id
+                    # header on first contact — that counts as reachable.
+                    test_url = trans_host.rstrip('/') + '/transmission/rpc'
+                    resp = requests.get(test_url, timeout=5, verify=False)
+                    if resp.status_code not in (200, 401, 409):
+                        results.append(HealthCheckResult(
+                            check_type='download',
+                            check_name='download_client',
+                            severity='error',
+                            message='Transmission returned HTTP %d — check host and port.' % resp.status_code,
+                            metadata={'client': 'transmission', 'status_code': resp.status_code}
+                        ))
+                except requests.exceptions.ConnectionError:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='Transmission unreachable at %s — connection refused.' % trans_host,
+                        metadata={'client': 'transmission', 'error': 'connection_refused'}
+                    ))
+                except requests.exceptions.Timeout:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='Transmission connection timed out at %s.' % trans_host,
+                        metadata={'client': 'transmission', 'error': 'timeout'}
+                    ))
+                except Exception as e:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='Transmission check failed: %s' % str(e)[:200],
+                        metadata={'client': 'transmission', 'error': str(type(e).__name__)}
+                    ))
+
+        if getattr(mylar, 'USE_RTORRENT', False):
+            rt_host = getattr(mylar.CONFIG, 'RTORRENT_HOST', None) or ''
+            if rt_host and rt_host.startswith('http'):
+                try:
+                    # rTorrent with HTTP(S) SCGI pass-through — a GET to the
+                    # base URL should at least return *something* if reachable.
+                    rpc_url = getattr(mylar.CONFIG, 'RTORRENT_RPC_URL', '') or ''
+                    test_url = rt_host.rstrip('/') + '/' + rpc_url.lstrip('/')
+                    rt_verify = getattr(mylar.CONFIG, 'RTORRENT_VERIFY', False)
+                    resp = requests.get(test_url.rstrip('/'), timeout=5, verify=rt_verify)
+                    # Any HTTP response means the server is reachable; only
+                    # connection-level failures indicate a problem.
+                except requests.exceptions.ConnectionError:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='rTorrent unreachable at %s — connection refused.' % rt_host,
+                        metadata={'client': 'rtorrent', 'error': 'connection_refused'}
+                    ))
+                except requests.exceptions.Timeout:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='rTorrent connection timed out at %s.' % rt_host,
+                        metadata={'client': 'rtorrent', 'error': 'timeout'}
+                    ))
+                except Exception as e:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='rTorrent check failed: %s' % str(e)[:200],
+                        metadata={'client': 'rtorrent', 'error': str(type(e).__name__)}
+                    ))
+
+        if getattr(mylar, 'USE_DELUGE', False):
+            deluge_host = getattr(mylar.CONFIG, 'DELUGE_HOST', None) or ''
+            if deluge_host:
+                try:
+                    # Deluge uses daemon RPC (TCP, not HTTP).  A basic socket
+                    # connect confirms the daemon port is accepting connections.
+                    if ':' in deluge_host:
+                        host_part, port_part = deluge_host.rsplit(':', 1)
+                        port_num = int(port_part)
+                    else:
+                        host_part = deluge_host
+                        port_num = 58846  # Deluge daemon default
+                    sock = socket.create_connection((host_part, port_num), timeout=5)
+                    sock.close()
+                except (socket.timeout, socket.error, OSError) as e:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='Deluge daemon unreachable at %s — %s.' % (deluge_host, str(e)[:150]),
+                        metadata={'client': 'deluge', 'error': 'connection_failed'}
+                    ))
+                except Exception as e:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='Deluge check failed: %s' % str(e)[:200],
+                        metadata={'client': 'deluge', 'error': str(type(e).__name__)}
+                    ))
+
+        if getattr(mylar, 'USE_UTORRENT', False):
+            ut_host = getattr(mylar.CONFIG, 'UTORRENT_HOST', None) or ''
+            if ut_host:
+                try:
+                    # uTorrent WebUI — /gui/token.html returns auth token page
+                    test_url = ut_host.rstrip('/') + '/gui/token.html'
+                    resp = requests.get(test_url, timeout=5, verify=False)
+                    if resp.status_code not in (200, 401):
+                        results.append(HealthCheckResult(
+                            check_type='download',
+                            check_name='download_client',
+                            severity='error',
+                            message='uTorrent returned HTTP %d — check host and port.' % resp.status_code,
+                            metadata={'client': 'utorrent', 'status_code': resp.status_code}
+                        ))
+                except requests.exceptions.ConnectionError:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='uTorrent unreachable at %s — connection refused.' % ut_host,
+                        metadata={'client': 'utorrent', 'error': 'connection_refused'}
+                    ))
+                except requests.exceptions.Timeout:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='uTorrent connection timed out at %s.' % ut_host,
+                        metadata={'client': 'utorrent', 'error': 'timeout'}
+                    ))
+                except Exception as e:
+                    results.append(HealthCheckResult(
+                        check_type='download',
+                        check_name='download_client',
+                        severity='error',
+                        message='uTorrent check failed: %s' % str(e)[:200],
+                        metadata={'client': 'utorrent', 'error': str(type(e).__name__)}
+                    ))
+
+        return results
 
     def check_download_category(self):
-        """[Phase 3] Verify the configured download category exists in the client."""
+        """Verify the configured download category exists in the client."""
+        # Deferred — requires querying SABnzbd/NZBGet categories API which
+        # involves client-specific XML-RPC or REST calls and authentication.
+        # Category validation will be added once download client wrappers
+        # expose a list_categories() interface.
         return []
 
     def check_stalled_downloads(self):
-        """[Phase 3] Check for downloads that appear stuck."""
+        """Check for downloads that appear stuck in the client queue."""
+        # Deferred — requires querying each download client's active queue
+        # and comparing item ages against a threshold.  Each client (SABnzbd,
+        # NZBGet, qBittorrent, etc.) has a different API for queue inspection.
         return []
 
     def check_failed_postprocessing(self):
-        """[Phase 3] Check for repeated post-processing failures."""
-        return []
+        """Check for repeated post-processing failures in the last 24 hours."""
+        results = []
+        try:
+            myconn = db.DBConnection()
+            cutoff = (datetime.datetime.utcnow() - datetime.timedelta(hours=24)).strftime('%Y-%m-%d %H:%M:%S')
+            recent_failures = myconn.select(
+                "SELECT COUNT(*) as cnt FROM Failed WHERE DateFailed >= ?",
+                [cutoff]
+            )
+            if recent_failures and recent_failures[0]['cnt'] > 5:
+                count = recent_failures[0]['cnt']
+                results.append(HealthCheckResult(
+                    check_type='task',
+                    check_name='failed_postprocessing',
+                    severity='warning',
+                    message='%d post-processing failures in the last 24 hours. Check the Failed Downloads list for details.' % count,
+                    metadata={'count': count, 'period': '24h'}
+                ))
+        except Exception as e:
+            logger.debug('[HealthCheck] Could not query Failed table: %s' % str(e)[:200])
+        return results
 
     def check_update_available(self):
-        """[Phase 3] Check if a newer version of Mylar3 is available."""
-        return []
+        """Check if a newer version of Mylar3 is available."""
+        results = []
+        commits_behind = getattr(mylar, 'COMMITS_BEHIND', None)
+        if commits_behind and int(commits_behind) > 0:
+            branch = getattr(mylar.CONFIG, 'GIT_BRANCH', 'master') or 'master'
+            results.append(HealthCheckResult(
+                check_type='config',
+                check_name='update_available',
+                severity='notice',
+                message='A newer version of Mylar3 is available — you are %d commit%s behind %s.' % (
+                    int(commits_behind), 's' if int(commits_behind) != 1 else '', branch),
+                metadata={'commits_behind': int(commits_behind), 'branch': branch}
+            ))
+        return results
 
     def check_permissions(self):
-        """[Phase 3] Verify write access to key directories."""
-        return []
+        """Verify write access to key Mylar directories."""
+        results = []
+        dirs_to_check = {
+            'Data directory': getattr(mylar, 'DATA_DIR', None),
+            'Log directory': getattr(mylar, 'LOG_DIR', None),
+            'Cache directory': getattr(mylar.CONFIG, 'CACHE_DIR', None),
+        }
+        for label, path in dirs_to_check.items():
+            if path and os.path.exists(path) and not os.access(path, os.W_OK):
+                results.append(HealthCheckResult(
+                    check_type='infrastructure',
+                    check_name='permissions',
+                    severity='error',
+                    message='%s is not writable: %s — check file permissions.' % (label, path),
+                    metadata={'path': path, 'label': label}
+                ))
+        return results
 
     def check_no_download_client(self):
-        """[Phase 3] Warn if no download client is configured."""
-        return []
+        """Warn if no download client is configured."""
+        results = []
+
+        # NZB side — NZB_DOWNLOADER: 0=SABnzbd, 1=NZBGet, 2=Blackhole, 3=None
+        has_nzb_client = any([
+            getattr(mylar, 'USE_SABNZBD', False),
+            getattr(mylar, 'USE_NZBGET', False),
+            getattr(mylar, 'USE_BLACKHOLE', False),
+        ])
+
+        # Torrent side — only counts if torrents are enabled.  TORRENT_DOWNLOADER
+        # defaults to 0 (watchfolder) which sets USE_WATCHDIR=True even when no
+        # torrent client is intentionally configured.  Gating on ENABLE_TORRENTS
+        # prevents that default from masking a missing download client.
+        torrents_enabled = getattr(mylar.CONFIG, 'ENABLE_TORRENTS', False)
+        has_torrent_client = torrents_enabled and any([
+            getattr(mylar, 'USE_RTORRENT', False),
+            getattr(mylar, 'USE_DELUGE', False),
+            getattr(mylar, 'USE_TRANSMISSION', False),
+            getattr(mylar, 'USE_QBITTORRENT', False),
+            getattr(mylar, 'USE_UTORRENT', False),
+            getattr(mylar, 'USE_WATCHDIR', False),
+        ])
+
+        has_client = has_nzb_client or has_torrent_client
+
+        if not has_client:
+            results.append(HealthCheckResult(
+                check_type='download',
+                check_name='no_download_client',
+                severity='warning',
+                message='No download client is configured. Mylar can find comics but cannot download them.',
+            ))
+        return results
 
     def check_api_key_missing(self):
         """Warn if ComicVine API key is not configured."""
@@ -577,8 +1008,31 @@ class HealthCheckRunner:
         return results
 
     def check_database_integrity(self):
-        """[Phase 3] Run SQLite integrity check."""
-        return []
+        """Run SQLite PRAGMA integrity_check (runs every 6 hours)."""
+        results = []
+        try:
+            myconn = db.DBConnection()
+            integrity = myconn.select("PRAGMA integrity_check")
+            if integrity and integrity[0]:
+                # PRAGMA integrity_check returns [{'integrity_check': 'ok'}] when healthy
+                status = str(integrity[0][0]) if integrity[0] else 'unknown'
+                if status.lower() != 'ok':
+                    results.append(HealthCheckResult(
+                        check_type='infrastructure',
+                        check_name='database_integrity',
+                        severity='error',
+                        message='Database integrity check failed: %s. Consider restoring from backup.' % status[:200],
+                        metadata={'result': status[:500]}
+                    ))
+        except Exception as e:
+            results.append(HealthCheckResult(
+                check_type='infrastructure',
+                check_name='database_integrity',
+                severity='error',
+                message='Database integrity check could not run: %s' % str(e)[:200],
+                metadata={'error': str(type(e).__name__)}
+            ))
+        return results
 
     # ── Private Helpers ──
 

--- a/mylar/healthcheck.py
+++ b/mylar/healthcheck.py
@@ -62,7 +62,7 @@ class HealthCheckResult:
         self.wiki_url = wiki_url or self._default_wiki_url(check_name)
         self.source = source
         self.metadata = metadata or {}
-        self.first_seen = datetime.datetime.utcnow().isoformat()
+        self.first_seen = datetime.datetime.now(datetime.timezone.utc).isoformat()
         self.last_seen = self.first_seen
         self.resolved_at = None
         self.check_count = 1
@@ -190,7 +190,7 @@ class HealthCheckRunner:
                     else:
                         logger.info('[HealthCheck] %s: %s' % (cr.check_name, cr.message))
                 results.extend(check_results)
-                self._check_timestamps[check_name] = datetime.datetime.utcnow()
+                self._check_timestamps[check_name] = datetime.datetime.now(datetime.timezone.utc)
             except Exception as e:
                 # don't let one broken check kill all checks
                 logger.error('[HealthCheck] Check "%s" threw exception: %s' % (check_name, str(e)[:200]))
@@ -205,7 +205,7 @@ class HealthCheckRunner:
             _sev_order = {'error': 0, 'warning': 1, 'notice': 2}
             results.sort(key=lambda r: (_sev_order.get(r.severity, 3), r.check_name))
             self._results = results
-            self._last_run = datetime.datetime.utcnow()
+            self._last_run = datetime.datetime.now(datetime.timezone.utc)
 
         # persist only FRESH results (from checks that ran) — carried-forward
         # items already have correct DB state, no need to bump their count/last_seen
@@ -262,7 +262,7 @@ class HealthCheckRunner:
         myconn = db.DBConnection()
         myconn.action(
             "UPDATE health_checks SET is_resolved=1, resolved_at=? WHERE id=?",
-            [datetime.datetime.utcnow().isoformat(), check_id]
+            [datetime.datetime.now(datetime.timezone.utc).isoformat(), check_id]
         )
         # remove from in-memory results
         with self._lock:
@@ -276,7 +276,7 @@ class HealthCheckRunner:
             # check if we already have an active result for this check_name
             existing = next((r for r in self._results if r.check_name == result.check_name), None)
             if existing:
-                existing.last_seen = datetime.datetime.utcnow().isoformat()
+                existing.last_seen = datetime.datetime.now(datetime.timezone.utc).isoformat()
                 existing.check_count += 1
             else:
                 self._results.append(result)
@@ -314,7 +314,7 @@ class HealthCheckRunner:
         """Query resolved health check records for the UI."""
         if days is None:
             days = int(mylar.CONFIG.HEALTH_HISTORY_DAYS or 30)
-        cutoff = (datetime.datetime.utcnow() - datetime.timedelta(days=days)).isoformat()
+        cutoff = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days)).isoformat()
         myconn = db.DBConnection()
         rows = myconn.select(
             "SELECT * FROM health_checks WHERE is_resolved=1 AND resolved_at>=? ORDER BY resolved_at DESC",
@@ -444,7 +444,9 @@ class HealthCheckRunner:
                         started = job[0]['current_run']
                         try:
                             start_dt = datetime.datetime.fromisoformat(started)
-                            elapsed = (datetime.datetime.utcnow() - start_dt).total_seconds() / 60
+                            if start_dt.tzinfo is None:
+                                start_dt = start_dt.replace(tzinfo=datetime.timezone.utc)
+                            elapsed = (datetime.datetime.now(datetime.timezone.utc) - start_dt).total_seconds() / 60
                             if elapsed >= stale_minutes:
                                 results.append(HealthCheckResult(
                                     check_type='task',
@@ -905,7 +907,7 @@ class HealthCheckRunner:
         results = []
         try:
             myconn = db.DBConnection()
-            cutoff = (datetime.datetime.utcnow() - datetime.timedelta(hours=24)).strftime('%Y-%m-%d %H:%M:%S')
+            cutoff = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=24)).strftime('%Y-%m-%d %H:%M:%S')
             recent_failures = myconn.select(
                 "SELECT COUNT(*) as cnt FROM Failed WHERE DateFailed >= ?",
                 [cutoff]
@@ -1042,13 +1044,13 @@ class HealthCheckRunner:
         last = self._check_timestamps.get(check_name)
         if last is None:
             return True
-        elapsed_min = (datetime.datetime.utcnow() - last).total_seconds() / 60
+        elapsed_min = (datetime.datetime.now(datetime.timezone.utc) - last).total_seconds() / 60
         return elapsed_min >= interval
 
     def _save_to_db(self, results):
         # persist current results to SQLite — upserts active, skips unchanged
         myconn = db.DBConnection()
-        now = datetime.datetime.utcnow().isoformat()
+        now = datetime.datetime.now(datetime.timezone.utc).isoformat()
         for result in results:
             try:
                 # check if this check_name already has an active row
@@ -1094,7 +1096,7 @@ class HealthCheckRunner:
         # _should_run(), its DB records must be left untouched.
         active_names = {r.check_name for r in current_results}
         myconn = db.DBConnection()
-        now = datetime.datetime.utcnow().isoformat()
+        now = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
         try:
             active_rows = myconn.select(
@@ -1114,7 +1116,7 @@ class HealthCheckRunner:
     def _cleanup_old(self):
         # purge resolved records older than HEALTH_HISTORY_DAYS
         days = int(mylar.CONFIG.HEALTH_HISTORY_DAYS or 30)
-        cutoff = (datetime.datetime.utcnow() - datetime.timedelta(days=days)).isoformat()
+        cutoff = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days)).isoformat()
         try:
             myconn = db.DBConnection()
             myconn.action(
@@ -1195,7 +1197,7 @@ class HealthLogHandler(logging.Handler):
                 return
 
             message = record.getMessage()
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.now(datetime.timezone.utc)
 
             for pattern, check_name, severity in self.COMPILED_PATTERNS:
                 if pattern.search(message):

--- a/mylar/healthcheck.py
+++ b/mylar/healthcheck.py
@@ -1,0 +1,577 @@
+#  This file is part of Mylar.
+# -*- coding: utf-8 -*-
+#
+#  Mylar is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Mylar is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import time
+import datetime
+import threading
+import json
+import logging
+import re
+
+import requests
+
+import mylar
+from mylar import logger, db, helpers
+
+
+# ── Health Check System ──
+# Provides periodic health monitoring for Mylar3 components.
+# Checks infrastructure (folders, disk, DB), providers (ComicVine, indexers),
+# download clients (SABnzbd, NZBGet), and scheduler tasks.
+#
+# Results are stored in the health_checks SQLite table and pushed to
+# the browser via SSE for real-time banner and badge updates.
+#
+# See docs/health-dashboard/ for full architecture documentation.
+
+
+# ── HealthCheckResult ──
+
+class HealthCheckResult:
+    """Single health check finding — one problem or informational item."""
+
+    VALID_SEVERITIES = ('error', 'warning', 'notice')
+    VALID_TYPES = ('infrastructure', 'provider', 'download', 'task', 'config', 'detected')
+
+    def __init__(self, check_type, check_name, severity, message,
+                 wiki_url=None, source='health_check', metadata=None):
+        if severity not in self.VALID_SEVERITIES:
+            raise ValueError('Invalid severity: %s' % severity)
+
+        self.check_type = check_type
+        self.check_name = check_name
+        self.severity = severity
+        self.message = message
+        self.wiki_url = wiki_url or self._default_wiki_url(check_name)
+        self.source = source
+        self.metadata = metadata or {}
+        self.first_seen = datetime.datetime.utcnow().isoformat()
+        self.last_seen = self.first_seen
+        self.check_count = 1
+        self.db_id = None  # set when loaded from / saved to DB
+
+    def to_dict(self):
+        """Convert to JSON-serializable dictionary."""
+        return {
+            'id': self.db_id,
+            'check_type': self.check_type,
+            'check_name': self.check_name,
+            'severity': self.severity,
+            'message': self.message,
+            'wiki_url': self.wiki_url,
+            'source': self.source,
+            'metadata': self.metadata,
+            'first_seen': self.first_seen,
+            'last_seen': self.last_seen,
+            'check_count': self.check_count,
+        }
+
+    @staticmethod
+    def from_db_row(row):
+        """Create a HealthCheckResult from a database row dict."""
+        result = HealthCheckResult(
+            check_type=row['check_type'],
+            check_name=row['check_name'],
+            severity=row['severity'],
+            message=row['message'],
+            wiki_url=row['wiki_url'],
+            source=row.get('source', 'health_check'),
+            metadata=json.loads(row['metadata']) if row.get('metadata') else {},
+        )
+        result.first_seen = row['first_seen']
+        result.last_seen = row['last_seen']
+        result.check_count = row.get('check_count', 1)
+        result.db_id = row['id']
+        return result
+
+    @staticmethod
+    def _default_wiki_url(check_name):
+        base = 'https://github.com/mylar3/mylar3/wiki/Health-Checks'
+        return '%s#%s' % (base, check_name.replace('_', '-'))
+
+
+# ── HealthCheckRunner ──
+
+class HealthCheckRunner:
+    """Runs health checks on Mylar3 components and manages results."""
+
+    # per-check intervals in minutes — expensive checks run less often
+    CHECK_INTERVALS = {
+        'root_folder':          5,
+        'disk_space':           15,
+        'database_integrity':   360,  # 6 hours
+        'comicvine_api':        10,
+        'indexers':             10,
+        'no_indexers':          10,
+        'download_client':      5,
+        'download_category':    30,
+        'stalled_downloads':    30,
+        'stuck_tasks':          5,
+        'failed_postprocessing': 10,
+        'update_available':     360,  # 6 hours
+        'permissions':          15,
+        'no_download_client':   10,
+        'api_key_missing':      10,
+    }
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._results = []
+        self._last_run = None
+        self._check_timestamps = {}  # {check_name: datetime} — when each check last ran
+
+    def run_all_checks(self):
+        """Run all health checks and update DB, memory, and browser."""
+        if not mylar.CONFIG.HEALTH_CHECK_ENABLED:
+            return
+
+        start_time = time.time()
+        logger.info('[HealthCheck] Starting health check run')
+
+        results = []
+
+        # each check is wrapped in try/except so one failure doesn't kill others
+        check_methods = [
+            ('root_folder',           self.check_root_folders),
+            ('comicvine_api',         self.check_comicvine_api),
+            ('indexers',              self.check_indexers),
+            ('no_indexers',           self.check_no_indexers),
+            ('download_client',       self.check_download_client),
+            ('download_category',     self.check_download_category),
+            ('disk_space',            self.check_disk_space),
+            ('stuck_tasks',           self.check_stuck_tasks),
+            ('failed_postprocessing', self.check_failed_postprocessing),
+            ('stalled_downloads',     self.check_stalled_downloads),
+            ('update_available',      self.check_update_available),
+            ('permissions',           self.check_permissions),
+            ('no_download_client',    self.check_no_download_client),
+            ('api_key_missing',       self.check_api_key_missing),
+            ('database_integrity',    self.check_database_integrity),
+        ]
+
+        for check_name, check_method in check_methods:
+            if not self._should_run(check_name):
+                continue
+            try:
+                check_results = check_method()
+                results.extend(check_results)
+                self._check_timestamps[check_name] = datetime.datetime.utcnow()
+            except Exception as e:
+                # don't let one broken check kill all checks
+                logger.error('[HealthCheck] Check "%s" threw exception: %s' % (check_name, str(e)[:200]))
+
+        # hold the lock only for the fast swap — never during network I/O
+        with self._lock:
+            self._results = results
+            self._last_run = datetime.datetime.utcnow()
+
+        # persist to database (resolves cleared issues too)
+        self._save_to_db(results)
+        self._resolve_cleared(results)
+        self._cleanup_old()
+
+        # push to browsers
+        self._push_sse(results)
+
+        # update global for fast reads
+        mylar.HEALTH_RESULTS = [r.to_dict() for r in results]
+
+        elapsed = time.time() - start_time
+        logger.info('[HealthCheck] Completed in %.2fs — %d errors, %d warnings, %d notices' % (
+            elapsed,
+            sum(1 for r in results if r.severity == 'error'),
+            sum(1 for r in results if r.severity == 'warning'),
+            sum(1 for r in results if r.severity == 'notice'),
+        ))
+
+    def get_results(self):
+        """Thread-safe read of current active health check results."""
+        with self._lock:
+            return list(self._results)
+
+    def get_summary(self):
+        """Get issue counts by severity."""
+        with self._lock:
+            results = list(self._results)
+        return {
+            'errors': sum(1 for r in results if r.severity == 'error'),
+            'warnings': sum(1 for r in results if r.severity == 'warning'),
+            'notices': sum(1 for r in results if r.severity == 'notice'),
+            'total': len(results),
+        }
+
+    def last_run_iso(self):
+        """Return last run time as ISO string, or None."""
+        with self._lock:
+            if self._last_run:
+                return self._last_run.isoformat()
+            return None
+
+    def dismiss(self, check_id):
+        """Mark a health check as resolved/dismissed by the user."""
+        myconn = db.DBConnection()
+        myconn.action(
+            "UPDATE health_checks SET is_resolved=1, resolved_at=? WHERE id=?",
+            [datetime.datetime.utcnow().isoformat(), check_id]
+        )
+        # remove from in-memory results
+        with self._lock:
+            self._results = [r for r in self._results if r.db_id != check_id]
+        mylar.HEALTH_RESULTS = [r.to_dict() for r in self.get_results()]
+        self._push_sse(self.get_results())
+
+    def ingest_log_finding(self, result):
+        """Accept a finding from the log handler and add to results."""
+        with self._lock:
+            # check if we already have an active result for this check_name
+            existing = next((r for r in self._results if r.check_name == result.check_name), None)
+            if existing:
+                existing.last_seen = datetime.datetime.utcnow().isoformat()
+                existing.check_count += 1
+            else:
+                self._results.append(result)
+
+        # persist to DB
+        self._save_single_to_db(result)
+        # update browser
+        mylar.HEALTH_RESULTS = [r.to_dict() for r in self.get_results()]
+        self._push_sse(self.get_results())
+
+    def load_from_db(self):
+        """Load active health check records from database on startup."""
+        try:
+            myconn = db.DBConnection()
+            rows = myconn.select(
+                "SELECT * FROM health_checks WHERE is_resolved=0 ORDER BY severity"
+            )
+            with self._lock:
+                self._results = [HealthCheckResult.from_db_row(r) for r in rows]
+            logger.info('[HealthCheck] Loaded %d active issues from database' % len(rows))
+        except Exception as e:
+            logger.error('[HealthCheck] Failed to load from database: %s' % e)
+
+    def get_resolved_history(self, days=None):
+        """Query resolved health check records for the UI."""
+        if days is None:
+            days = int(mylar.CONFIG.HEALTH_HISTORY_DAYS or 30)
+        cutoff = (datetime.datetime.utcnow() - datetime.timedelta(days=days)).isoformat()
+        myconn = db.DBConnection()
+        rows = myconn.select(
+            "SELECT * FROM health_checks WHERE is_resolved=1 AND resolved_at>=? ORDER BY resolved_at DESC",
+            [cutoff]
+        )
+        return [HealthCheckResult.from_db_row(r).to_dict() for r in rows]
+
+    # ── Check Methods ──
+
+    def check_root_folders(self):
+        """Check that configured comic root folders exist and are accessible."""
+        results = []
+        paths_to_check = []
+
+        if mylar.CONFIG.DESTINATION_DIR:
+            paths_to_check.append(mylar.CONFIG.DESTINATION_DIR)
+        if mylar.CONFIG.MULTIPLE_DEST_DIRS:
+            for d in mylar.CONFIG.MULTIPLE_DEST_DIRS.split(','):
+                d = d.strip()
+                if d:
+                    paths_to_check.append(d)
+
+        for path in paths_to_check:
+            if not os.path.exists(path):
+                results.append(HealthCheckResult(
+                    check_type='infrastructure',
+                    check_name='root_folder',
+                    severity='error',
+                    message='Root folder not accessible: %s — path does not exist or is not mounted.' % path,
+                    metadata={'path': path, 'reason': 'not_found'}
+                ))
+            elif not os.access(path, os.R_OK):
+                results.append(HealthCheckResult(
+                    check_type='infrastructure',
+                    check_name='root_folder',
+                    severity='error',
+                    message='Root folder not readable: %s — check permissions.' % path,
+                    metadata={'path': path, 'reason': 'not_readable'}
+                ))
+        return results
+
+    def check_comicvine_api(self):
+        """Check ComicVine API connectivity and key validity."""
+        results = []
+        api_key = mylar.CONFIG.COMICVINE_API
+
+        if not api_key or api_key in ('None', ''):
+            return []  # check_api_key_missing handles this case
+
+        test_url = '%sissue/1/?api_key=%s&format=json' % (mylar.CVURL or 'https://comicvine.gamespot.com/api/', api_key)
+        try:
+            resp = requests.get(test_url, timeout=5, headers=mylar.CV_HEADERS, verify=mylar.CONFIG.CV_VERIFY)
+            if resp.status_code == 200:
+                return []  # healthy
+            elif resp.status_code == 401:
+                results.append(HealthCheckResult(
+                    check_type='provider',
+                    check_name='comicvine_api',
+                    severity='error',
+                    message='ComicVine API key is invalid — returned 401 Unauthorized.',
+                    metadata={'status_code': 401}
+                ))
+            elif resp.status_code == 429:
+                results.append(HealthCheckResult(
+                    check_type='provider',
+                    check_name='comicvine_api',
+                    severity='warning',
+                    message='ComicVine API rate limit exceeded — returned 429. Requests will be delayed.',
+                    metadata={'status_code': 429}
+                ))
+            else:
+                results.append(HealthCheckResult(
+                    check_type='provider',
+                    check_name='comicvine_api',
+                    severity='error',
+                    message='ComicVine API returned unexpected status %d.' % resp.status_code,
+                    metadata={'status_code': resp.status_code}
+                ))
+        except requests.exceptions.Timeout:
+            results.append(HealthCheckResult(
+                check_type='provider',
+                check_name='comicvine_api',
+                severity='error',
+                message='ComicVine API unreachable — connection timed out after 5s. All metadata lookups will fail.',
+                metadata={'error': 'timeout'}
+            ))
+        except requests.exceptions.ConnectionError as e:
+            results.append(HealthCheckResult(
+                check_type='provider',
+                check_name='comicvine_api',
+                severity='error',
+                message='ComicVine API connection failed: %s' % str(e)[:200],
+                metadata={'error': 'connection_error'}
+            ))
+        except Exception as e:
+            results.append(HealthCheckResult(
+                check_type='provider',
+                check_name='comicvine_api',
+                severity='error',
+                message='ComicVine API check failed: %s' % str(e)[:200],
+                metadata={'error': str(type(e).__name__)}
+            ))
+        return results
+
+    def check_stuck_tasks(self):
+        """Check for scheduler tasks that have been running too long."""
+        results = []
+        stale_minutes = int(mylar.CONFIG.HEALTH_STALE_TASK_MIN or 60)
+
+        task_statuses = {
+            'Monitor': mylar.MONITOR_STATUS,
+            'Search': mylar.SEARCH_STATUS,
+            'RSS': mylar.RSS_STATUS,
+            'Weekly Pull': mylar.WEEKLY_STATUS,
+            'Version Check': mylar.VERSION_STATUS,
+        }
+
+        for task_name, status in task_statuses.items():
+            if status == 'Running':
+                try:
+                    myconn = db.DBConnection()
+                    job = myconn.select(
+                        "SELECT current_run FROM jobhistory WHERE JobName=?",
+                        [task_name]
+                    )
+                    if job and job[0].get('current_run'):
+                        started = job[0]['current_run']
+                        try:
+                            start_dt = datetime.datetime.fromisoformat(started)
+                            elapsed = (datetime.datetime.utcnow() - start_dt).total_seconds() / 60
+                            if elapsed >= stale_minutes:
+                                results.append(HealthCheckResult(
+                                    check_type='task',
+                                    check_name='stuck_tasks',
+                                    severity='warning',
+                                    message='%s scheduler has been running for %.0f minutes — may be stuck.' % (task_name, elapsed),
+                                    metadata={'task': task_name, 'elapsed_min': round(elapsed)}
+                                ))
+                        except (ValueError, TypeError):
+                            pass
+                except Exception:
+                    pass
+
+        return results
+
+    # ── Stubbed Checks (Phase 3) ──
+
+    def check_disk_space(self):
+        """[Phase 3] Check free disk space on storage paths."""
+        return []
+
+    def check_indexers(self):
+        """[Phase 3] Test connectivity to each configured indexer."""
+        return []
+
+    def check_no_indexers(self):
+        """[Phase 3] Warn if no search indexers/providers are enabled."""
+        return []
+
+    def check_download_client(self):
+        """[Phase 3] Test download client connectivity."""
+        return []
+
+    def check_download_category(self):
+        """[Phase 3] Verify the configured download category exists in the client."""
+        return []
+
+    def check_stalled_downloads(self):
+        """[Phase 3] Check for downloads that appear stuck."""
+        return []
+
+    def check_failed_postprocessing(self):
+        """[Phase 3] Check for repeated post-processing failures."""
+        return []
+
+    def check_update_available(self):
+        """[Phase 3] Check if a newer version of Mylar3 is available."""
+        return []
+
+    def check_permissions(self):
+        """[Phase 3] Verify write access to key directories."""
+        return []
+
+    def check_no_download_client(self):
+        """[Phase 3] Warn if no download client is configured."""
+        return []
+
+    def check_api_key_missing(self):
+        """[Phase 3] Warn if ComicVine API key is not set."""
+        return []
+
+    def check_database_integrity(self):
+        """[Phase 3] Run SQLite integrity check."""
+        return []
+
+    # ── Private Helpers ──
+
+    def _should_run(self, check_name):
+        # per-check interval gating — returns True if enough time has passed
+        interval = self.CHECK_INTERVALS.get(check_name, 5)
+        last = self._check_timestamps.get(check_name)
+        if last is None:
+            return True
+        elapsed_min = (datetime.datetime.utcnow() - last).total_seconds() / 60
+        return elapsed_min >= interval
+
+    def _save_to_db(self, results):
+        # persist current results to SQLite — upserts active, skips unchanged
+        myconn = db.DBConnection()
+        now = datetime.datetime.utcnow().isoformat()
+        for result in results:
+            try:
+                # check if this check_name already has an active row
+                existing = myconn.select(
+                    "SELECT id, check_count FROM health_checks WHERE check_name=? AND is_resolved=0",
+                    [result.check_name]
+                )
+                if existing:
+                    row = existing[0]
+                    myconn.action(
+                        "UPDATE health_checks SET last_seen=?, check_count=?, message=?, severity=?, metadata=? WHERE id=?",
+                        [now, row['check_count'] + 1, result.message, result.severity,
+                         json.dumps(result.metadata), row['id']]
+                    )
+                    result.db_id = row['id']
+                    result.check_count = row['check_count'] + 1
+                else:
+                    myconn.action(
+                        "INSERT INTO health_checks (check_type, check_name, severity, message, wiki_url, source, first_seen, last_seen, is_resolved, check_count, metadata) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 1, ?)",
+                        [result.check_type, result.check_name, result.severity, result.message,
+                         result.wiki_url, result.source, now, now, json.dumps(result.metadata)]
+                    )
+                    # get the ID of the newly inserted row
+                    new_row = myconn.select(
+                        "SELECT id FROM health_checks WHERE check_name=? AND is_resolved=0 ORDER BY id DESC LIMIT 1",
+                        [result.check_name]
+                    )
+                    if new_row:
+                        result.db_id = new_row[0]['id']
+            except Exception as e:
+                logger.error('[HealthCheck] DB save failed for %s: %s' % (result.check_name, str(e)[:200]))
+
+    def _save_single_to_db(self, result):
+        # persist one result (used by log handler for immediate findings)
+        self._save_to_db([result])
+
+    def _resolve_cleared(self, current_results):
+        # mark checks that now pass as resolved in DB
+        active_names = {r.check_name for r in current_results}
+        myconn = db.DBConnection()
+        now = datetime.datetime.utcnow().isoformat()
+
+        try:
+            active_rows = myconn.select(
+                "SELECT id, check_name FROM health_checks WHERE is_resolved=0"
+            )
+            for row in active_rows:
+                if row['check_name'] not in active_names:
+                    myconn.action(
+                        "UPDATE health_checks SET is_resolved=1, resolved_at=? WHERE id=?",
+                        [now, row['id']]
+                    )
+                    logger.info('[HealthCheck] Resolved: %s' % row['check_name'])
+        except Exception as e:
+            logger.error('[HealthCheck] Failed to resolve cleared checks: %s' % str(e)[:200])
+
+    def _cleanup_old(self):
+        # purge resolved records older than HEALTH_HISTORY_DAYS
+        days = int(mylar.CONFIG.HEALTH_HISTORY_DAYS or 30)
+        cutoff = (datetime.datetime.utcnow() - datetime.timedelta(days=days)).isoformat()
+        try:
+            myconn = db.DBConnection()
+            myconn.action(
+                "DELETE FROM health_checks WHERE is_resolved=1 AND resolved_at<?",
+                [cutoff]
+            )
+        except Exception as e:
+            logger.error('[HealthCheck] Failed to cleanup old records: %s' % str(e)[:200])
+
+    def _push_sse(self, results):
+        # push health_update event to all connected browsers via GLOBAL_MESSAGES
+        try:
+            summary = self.get_summary()
+            errors = [r.to_dict() for r in results if r.severity == 'error']
+            warnings = [r.to_dict() for r in results if r.severity == 'warning']
+
+            mylar.GLOBAL_MESSAGES = {
+                'event': 'health_update',
+                'data': json.dumps({
+                    'errors': errors,
+                    'warnings': warnings,
+                    'error_count': summary.get('errors', 0),
+                    'warning_count': summary.get('warnings', 0),
+                    'notice_count': summary.get('notices', 0),
+                })
+            }
+        except Exception as e:
+            logger.debug('[HealthCheck] SSE push failed: %s' % e)
+
+
+# ── Log Interceptor (stub for Phase 3) ──
+
+class HealthLogHandler(logging.Handler):
+    """Watches log messages for error patterns between scheduled health checks."""
+    pass

--- a/mylar/healthcheck.py
+++ b/mylar/healthcheck.py
@@ -598,6 +598,7 @@ class HealthCheckRunner:
             warnings = [r.to_dict() for r in results if r.severity == 'warning']
 
             mylar.GLOBAL_MESSAGES = {
+                'status': 'success',
                 'event': 'health_update',
                 'data': json.dumps({
                     'errors': errors,

--- a/mylar/healthcheck.py
+++ b/mylar/healthcheck.py
@@ -137,8 +137,12 @@ class HealthCheckRunner:
         self._last_run = None
         self._check_timestamps = {}  # {check_name: datetime} — when each check last ran
 
-    def run_all_checks(self):
-        """Run all health checks and update DB, memory, and browser."""
+    def run_all_checks(self, force=False):
+        """Run all health checks and update DB, memory, and browser.
+
+        Args:
+            force: If True, bypass per-check interval gating (used for manual rechecks).
+        """
         if not mylar.CONFIG.HEALTH_CHECK_ENABLED:
             return
 
@@ -168,7 +172,7 @@ class HealthCheckRunner:
         ]
 
         for check_name, check_method in check_methods:
-            if not self._should_run(check_name):
+            if not force and not self._should_run(check_name):
                 continue
             checks_that_ran.add(check_name)
             try:
@@ -457,12 +461,79 @@ class HealthCheckRunner:
         return []
 
     def check_indexers(self):
-        """[Phase 3] Test connectivity to each configured indexer."""
-        return []
+        """Check configured indexers for connectivity issues."""
+        results = []
+
+        # PROVIDER_STATUS is a dict of {provider_name: 'success'|'fail'}
+        # populated by base.html from PROVIDER_ORDER and PROVIDER_BLOCKLIST
+        provider_status = getattr(mylar, 'PROVIDER_STATUS', None)
+        if not provider_status:
+            return []  # not populated yet — skip until first page load
+
+        for provider, status in provider_status.items():
+            if status == 'fail':
+                # check PROVIDER_BLOCKLIST for the reason this provider was blocked
+                reason = 'unavailable'
+                blocklist = getattr(mylar, 'PROVIDER_BLOCKLIST', [])
+                for entry in blocklist:
+                    if entry.get('site') == provider:
+                        reason = entry.get('reason', 'unavailable')
+                        break
+                results.append(HealthCheckResult(
+                    check_type='provider',
+                    check_name='indexers',
+                    severity='warning',
+                    message='Indexer "%s" is currently unavailable — %s. Searches using this provider will fail.' % (provider, reason),
+                    metadata={'provider': provider, 'reason': reason}
+                ))
+
+        return results
 
     def check_no_indexers(self):
-        """[Phase 3] Warn if no search indexers/providers are enabled."""
-        return []
+        """Warn if no search indexers or providers are enabled."""
+        results = []
+
+        has_any = False
+
+        # check newznab providers — EXTRA_NEWZNABS is a list of tuples
+        # tuple format: (name, host, verify, apikey, uid/categories, enabled, id)
+        # index 5 is the enabled flag ('0' or '1')
+        try:
+            newznabs = getattr(mylar.CONFIG, 'EXTRA_NEWZNABS', []) or []
+            for nz in newznabs:
+                if len(nz) > 5 and str(nz[5]) == '1':
+                    has_any = True
+                    break
+        except Exception:
+            pass
+
+        # check torznab providers — same tuple format as newznabs
+        if not has_any:
+            try:
+                torznabs = getattr(mylar.CONFIG, 'EXTRA_TORZNABS', []) or []
+                for tz in torznabs:
+                    if len(tz) > 5 and str(tz[5]) == '1':
+                        has_any = True
+                        break
+            except Exception:
+                pass
+
+        # check other search toggles
+        if not has_any:
+            if getattr(mylar.CONFIG, 'ENABLE_TORRENT_SEARCH', False):
+                has_any = True
+            elif getattr(mylar.CONFIG, 'EXPERIMENTAL', False):
+                has_any = True
+
+        if not has_any:
+            results.append(HealthCheckResult(
+                check_type='config',
+                check_name='no_indexers',
+                severity='error',
+                message='No search providers are enabled — Mylar cannot search for or download any comics. Configure at least one provider in Settings.',
+            ))
+
+        return results
 
     def check_download_client(self):
         """[Phase 3] Test download client connectivity."""
@@ -493,8 +564,17 @@ class HealthCheckRunner:
         return []
 
     def check_api_key_missing(self):
-        """[Phase 3] Warn if ComicVine API key is not set."""
-        return []
+        """Warn if ComicVine API key is not configured."""
+        results = []
+        api_key = getattr(mylar.CONFIG, 'COMICVINE_API', None)
+        if not api_key or api_key in ('None', '') or not str(api_key).strip():
+            results.append(HealthCheckResult(
+                check_type='config',
+                check_name='api_key_missing',
+                severity='error',
+                message='ComicVine API key is not set — Mylar cannot look up comic metadata. Add your API key in Settings > Web Interface.',
+            ))
+        return results
 
     def check_database_integrity(self):
         """[Phase 3] Run SQLite integrity check."""

--- a/mylar/healthcheck.py
+++ b/mylar/healthcheck.py
@@ -141,11 +141,7 @@ class HealthCheckRunner:
         self._check_timestamps = {}  # {check_name: datetime} — when each check last ran
 
     def run_all_checks(self, force=False):
-        """Run all health checks and update DB, memory, and browser.
-
-        Args:
-            force: If True, bypass per-check interval gating (used for manual rechecks).
-        """
+        """Run all health checks and update DB, memory, and browser."""
         if not mylar.CONFIG.HEALTH_CHECK_ENABLED:
             return
 
@@ -589,13 +585,11 @@ class HealthCheckRunner:
         return results
 
     def check_download_client(self):
-        """Test download client connectivity.
-
-        NZB clients (SABnzbd, NZBGet): HTTP API version endpoint.
-        Torrent clients (qBittorrent, Transmission, uTorrent): HTTP API probe.
-        rTorrent: HTTP GET to SCGI pass-through URL (skipped for non-HTTP hosts).
-        Deluge: TCP socket connect to daemon RPC port.
-        """
+        """Test download client connectivity."""
+        # NZB clients (SABnzbd, NZBGet): HTTP API version endpoint
+        # Torrent clients (qBittorrent, Transmission, uTorrent): HTTP API probe
+        # rTorrent: HTTP GET to SCGI pass-through URL (skipped for non-HTTP hosts)
+        # Deluge: TCP socket connect to daemon RPC port
         results = []
 
         if getattr(mylar, 'USE_SABNZBD', False):

--- a/mylar/healthcheck.py
+++ b/mylar/healthcheck.py
@@ -61,6 +61,7 @@ class HealthCheckResult:
         self.metadata = metadata or {}
         self.first_seen = datetime.datetime.utcnow().isoformat()
         self.last_seen = self.first_seen
+        self.resolved_at = None
         self.check_count = 1
         self.db_id = None  # set when loaded from / saved to DB
 
@@ -78,6 +79,7 @@ class HealthCheckResult:
             'first_seen': self.first_seen,
             'last_seen': self.last_seen,
             'check_count': self.check_count,
+            'resolved_at': self.resolved_at,
         }
 
     @staticmethod
@@ -89,12 +91,13 @@ class HealthCheckResult:
             severity=row['severity'],
             message=row['message'],
             wiki_url=row['wiki_url'],
-            source=row.get('source', 'health_check'),
-            metadata=json.loads(row['metadata']) if row.get('metadata') else {},
+            source=row['source'] if row['source'] else 'health_check',
+            metadata=json.loads(row['metadata']) if row['metadata'] else {},
         )
         result.first_seen = row['first_seen']
         result.last_seen = row['last_seen']
-        result.check_count = row.get('check_count', 1)
+        result.resolved_at = row['resolved_at'] if 'resolved_at' in row.keys() else None
+        result.check_count = row['check_count'] if row['check_count'] else 1
         result.db_id = row['id']
         return result
 
@@ -143,6 +146,7 @@ class HealthCheckRunner:
         logger.info('[HealthCheck] Starting health check run')
 
         results = []
+        checks_that_ran = set()  # track which check_names actually executed
 
         # each check is wrapped in try/except so one failure doesn't kill others
         check_methods = [
@@ -166,22 +170,38 @@ class HealthCheckRunner:
         for check_name, check_method in check_methods:
             if not self._should_run(check_name):
                 continue
+            checks_that_ran.add(check_name)
             try:
                 check_results = check_method()
+                for cr in check_results:
+                    if cr.severity == 'error':
+                        logger.error('[HealthCheck] %s: %s' % (cr.check_name, cr.message))
+                    elif cr.severity == 'warning':
+                        logger.warn('[HealthCheck] %s: %s' % (cr.check_name, cr.message))
+                    else:
+                        logger.info('[HealthCheck] %s: %s' % (cr.check_name, cr.message))
                 results.extend(check_results)
                 self._check_timestamps[check_name] = datetime.datetime.utcnow()
             except Exception as e:
                 # don't let one broken check kill all checks
                 logger.error('[HealthCheck] Check "%s" threw exception: %s' % (check_name, str(e)[:200]))
 
-        # hold the lock only for the fast swap — never during network I/O
+        # merge: keep previous results for checks that were SKIPPED this cycle
+        ran_check_names = {r.check_name for r in results}
+        fresh_results = list(results)  # snapshot before merging carried-forward items
         with self._lock:
+            for prev in self._results:
+                if prev.check_name not in checks_that_ran and prev.check_name not in ran_check_names:
+                    results.append(prev)
+            _sev_order = {'error': 0, 'warning': 1, 'notice': 2}
+            results.sort(key=lambda r: (_sev_order.get(r.severity, 3), r.check_name))
             self._results = results
             self._last_run = datetime.datetime.utcnow()
 
-        # persist to database (resolves cleared issues too)
-        self._save_to_db(results)
-        self._resolve_cleared(results)
+        # persist only FRESH results (from checks that ran) — carried-forward
+        # items already have correct DB state, no need to bump their count/last_seen
+        self._save_to_db(fresh_results)
+        self._resolve_cleared(results, checks_that_ran)
         self._cleanup_old()
 
         # push to browsers
@@ -191,12 +211,18 @@ class HealthCheckRunner:
         mylar.HEALTH_RESULTS = [r.to_dict() for r in results]
 
         elapsed = time.time() - start_time
-        logger.info('[HealthCheck] Completed in %.2fs — %d errors, %d warnings, %d notices' % (
-            elapsed,
-            sum(1 for r in results if r.severity == 'error'),
-            sum(1 for r in results if r.severity == 'warning'),
-            sum(1 for r in results if r.severity == 'notice'),
-        ))
+        error_count = sum(1 for r in results if r.severity == 'error')
+        warning_count = sum(1 for r in results if r.severity == 'warning')
+        notice_count = sum(1 for r in results if r.severity == 'notice')
+        summary_msg = '[HealthCheck] Completed in %.2fs — %d errors, %d warnings, %d notices' % (
+            elapsed, error_count, warning_count, notice_count)
+
+        if error_count > 0:
+            logger.error(summary_msg)
+        elif warning_count > 0:
+            logger.warn(summary_msg)
+        else:
+            logger.info(summary_msg)
 
     def get_results(self):
         """Thread-safe read of current active health check results."""
@@ -256,13 +282,23 @@ class HealthCheckRunner:
         try:
             myconn = db.DBConnection()
             rows = myconn.select(
-                "SELECT * FROM health_checks WHERE is_resolved=0 ORDER BY severity"
+                "SELECT * FROM health_checks WHERE is_resolved=0 "
+                "ORDER BY CASE severity WHEN 'error' THEN 0 WHEN 'warning' THEN 1 WHEN 'notice' THEN 2 ELSE 3 END, last_seen DESC"
             )
             with self._lock:
                 self._results = [HealthCheckResult.from_db_row(r) for r in rows]
             logger.info('[HealthCheck] Loaded %d active issues from database' % len(rows))
         except Exception as e:
             logger.error('[HealthCheck] Failed to load from database: %s' % e)
+
+    def clear_resolved_history(self):
+        """Delete all resolved health check records from the database."""
+        try:
+            myconn = db.DBConnection()
+            myconn.action("DELETE FROM health_checks WHERE is_resolved=1")
+            logger.info('[HealthCheck] Cleared all resolved history')
+        except Exception as e:
+            logger.error('[HealthCheck] Failed to clear resolved history: %s' % e)
 
     def get_resolved_history(self, days=None):
         """Query resolved health check records for the UI."""
@@ -394,7 +430,7 @@ class HealthCheckRunner:
                         "SELECT current_run FROM jobhistory WHERE JobName=?",
                         [task_name]
                     )
-                    if job and job[0].get('current_run'):
+                    if job and job[0]['current_run']:
                         started = job[0]['current_run']
                         try:
                             start_dt = datetime.datetime.fromisoformat(started)
@@ -483,7 +519,7 @@ class HealthCheckRunner:
             try:
                 # check if this check_name already has an active row
                 existing = myconn.select(
-                    "SELECT id, check_count FROM health_checks WHERE check_name=? AND is_resolved=0",
+                    "SELECT id, check_count, first_seen FROM health_checks WHERE check_name=? AND is_resolved=0",
                     [result.check_name]
                 )
                 if existing:
@@ -495,6 +531,8 @@ class HealthCheckRunner:
                     )
                     result.db_id = row['id']
                     result.check_count = row['check_count'] + 1
+                    result.first_seen = row['first_seen']  # preserve original first_seen from DB
+                    result.last_seen = now  # sync in-memory last_seen with what we wrote to DB
                 else:
                     myconn.action(
                         "INSERT INTO health_checks (check_type, check_name, severity, message, wiki_url, source, first_seen, last_seen, is_resolved, check_count, metadata) "
@@ -516,8 +554,10 @@ class HealthCheckRunner:
         # persist one result (used by log handler for immediate findings)
         self._save_to_db([result])
 
-    def _resolve_cleared(self, current_results):
-        # mark checks that now pass as resolved in DB
+    def _resolve_cleared(self, current_results, checks_that_ran):
+        # Only resolve DB records for checks that ACTUALLY RAN this cycle
+        # and returned clean (no results).  If a check was skipped by
+        # _should_run(), its DB records must be left untouched.
         active_names = {r.check_name for r in current_results}
         myconn = db.DBConnection()
         now = datetime.datetime.utcnow().isoformat()
@@ -527,7 +567,8 @@ class HealthCheckRunner:
                 "SELECT id, check_name FROM health_checks WHERE is_resolved=0"
             )
             for row in active_rows:
-                if row['check_name'] not in active_names:
+                # only resolve if: (a) the check ran this cycle, AND (b) it returned no findings
+                if row['check_name'] in checks_that_ran and row['check_name'] not in active_names:
                     myconn.action(
                         "UPDATE health_checks SET is_resolved=1, resolved_at=? WHERE id=?",
                         [now, row['id']]

--- a/mylar/healthcheck.py
+++ b/mylar/healthcheck.py
@@ -1146,8 +1146,82 @@ class HealthCheckRunner:
             logger.debug('[HealthCheck] SSE push failed: %s' % e)
 
 
-# ── Log Interceptor (stub for Phase 3) ──
+# ── Log Interceptor ──
 
 class HealthLogHandler(logging.Handler):
-    """Watches log messages for error patterns between scheduled health checks."""
-    pass
+    """Watches log messages for error patterns between scheduled health checks.
+
+    Skips messages containing '[HealthCheck]' to prevent infinite recursion.
+    Entire emit() wrapped in try/except — must NEVER crash the application.
+    """
+
+    PATTERNS = [
+        # Missing ComicVine API key — logged by Mylar during config load/save
+        (r'no\s+(?:user\s+)?comicvine\s+api\s+key', 'api_key_missing', 'error'),
+        # ComicVine API failures — timeout, connection refused, unreachable
+        (r'comicvine.*(?:timeout|timed?\s*out|unreachable|connection.*(?:refused|error|failed))', 'comicvine_api', 'error'),
+        # SABnzbd connectivity failures
+        (r'sab(?:nzbd)?.*(?:connection\s*refused|unreachable|timed?\s*out)', 'download_client', 'error'),
+        # NZBGet connectivity failures
+        (r'nzbget.*(?:connection\s*refused|unreachable|timed?\s*out)', 'download_client', 'error'),
+        # Torrent client connectivity failures
+        (r'(?:qbittorrent|transmission|rtorrent|deluge|utorrent).*(?:connection\s*refused|unreachable|timed?\s*out)', 'download_client', 'error'),
+        # Directory-level permission failures — cannot create/write to key paths (systemic)
+        (r'(?:cannot|could not|unable|failed to)\s+(?:write|create|mkdir|access).*(?:director|folder|cache|log)', 'permissions', 'error'),
+        # Generic permission denied — may be transient single-file issues
+        (r'permission\s*denied', 'permissions', 'warning'),
+        # disk full / out of space conditions
+        (r'(?:disk\s*full|no\s*space\s*left)', 'disk_space', 'error'),
+        # SQLite database corruption — critical, needs immediate attention
+        (r'database.*(?:corrupt|malformed)', 'database_integrity', 'error'),
+        # SQLite database lock contention — usually transient under concurrent writes
+        (r'database.*locked', 'database_integrity', 'warning'),
+    ]
+
+    # compile patterns once at class level for performance
+    COMPILED_PATTERNS = [(re.compile(p, re.IGNORECASE), n, s) for p, n, s in PATTERNS]
+
+    def __init__(self):
+        super().__init__()
+        self.setLevel(logging.WARNING)
+        self._last_emit = {}  # throttle: {check_name: datetime}
+        self._throttle_seconds = 300  # 5-minute cooldown per check_name
+
+    def emit(self, record):
+        """Process a log record, creating health findings for matching patterns."""
+        try:
+            # CRITICAL: skip our own log messages to prevent infinite recursion
+            if '[HealthCheck]' in record.getMessage():
+                return
+
+            message = record.getMessage()
+            now = datetime.datetime.utcnow()
+
+            for pattern, check_name, severity in self.COMPILED_PATTERNS:
+                if pattern.search(message):
+                    # throttle — don't create the same finding more than once per 5 min
+                    last = self._last_emit.get(check_name)
+                    if last and (now - last).total_seconds() < self._throttle_seconds:
+                        return
+
+                    # Only set throttle AFTER successfully ingesting
+                    # the finding.  If HEALTH_CHECK is not yet initialised
+                    # (e.g. during startup, before initialize() creates the
+                    # runner) we must NOT set the throttle — otherwise the
+                    # first real opportunity (config-save) would be blocked
+                    # by the stale timestamp from the failed startup attempt.
+                    if mylar.HEALTH_CHECK:
+                        result = HealthCheckResult(
+                            check_type='detected',
+                            check_name=check_name,
+                            severity=severity,
+                            message=message[:500],  # truncate long messages
+                            source='log_intercept',
+                            metadata={'log_level': record.levelname, 'module': record.module}
+                        )
+                        mylar.HEALTH_CHECK.ingest_log_finding(result)
+                        self._last_emit[check_name] = now  # throttle only on success
+                    break  # only match first pattern
+
+        except Exception:
+            pass  # NEVER let a logging handler crash the application

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -3779,6 +3779,8 @@ def job_management(write=False, job=None, last_run_completed=None, current_run=N
         jobname = jobinfo[:jobinfo.find('(')-1].strip()
         jobstatus = jobinfo[jobinfo.find('],')+2:len(jobinfo)-1].strip()
         next_the_run = False
+        prev_run_timestamp = None
+        sched_status = None
 
         #logger.info('[%s] ==> %s' % (jobname, jobstatus))
 

--- a/mylar/logger.py
+++ b/mylar/logger.py
@@ -122,6 +122,16 @@ if not LOG_LANG.startswith('en'):
                 lg.addHandler(consolehandler)
                 self.consolehandler = consolehandler
 
+            # health check log interceptor — watches for error patterns between scheduled checks
+            # IMPORTANT: import inside function to avoid circular imports
+            # (healthcheck imports mylar which imports logger)
+            try:
+                from mylar.healthcheck import HealthLogHandler
+                health_handler = HealthLogHandler()
+                lg.addHandler(health_handler)
+            except ImportError:
+                pass  # healthcheck module not available during early startup
+
         @staticmethod
         def log(message, level, *args, **kwargs):
             logger = logging.getLogger('mylar')
@@ -292,6 +302,16 @@ else:
                 console_handler.setLevel(logging.DEBUG)
 
             logger.addHandler(console_handler)
+
+        # health check log interceptor — watches for error patterns between scheduled checks
+        # IMPORTANT: import inside function to avoid circular imports
+        # (healthcheck imports mylar which imports logger)
+        try:
+            from mylar.healthcheck import HealthLogHandler
+            health_handler = HealthLogHandler()
+            logger.addHandler(health_handler)
+        except ImportError:
+            pass  # healthcheck module not available during early startup
 
         # Install exception hooks
         initHooks()

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -9926,23 +9926,7 @@ class WebInterface(object):
 
     def health(self):
         """Health dashboard page."""
-        cherrypy.response.headers['Content-Type'] = 'application/json'
-        try:
-            if mylar.HEALTH_CHECK:
-                results = [r.to_dict() for r in mylar.HEALTH_CHECK.get_results()]
-                summary = mylar.HEALTH_CHECK.get_summary()
-                last_run = mylar.HEALTH_CHECK.last_run_iso()
-            else:
-                results = []
-                summary = {'errors': 0, 'warnings': 0, 'notices': 0, 'total': 0}
-                last_run = None
-            return json.dumps({
-                'results': results,
-                'summary': summary,
-                'last_run': last_run,
-            })
-        except Exception as e:
-            return json.dumps({'error': 'Failed to load health data: %s' % str(e)[:200]})
+        return serve_template(templatename="health.html", title="System Health")
     health.exposed = True
 
     def getHealth(self, **kwargs):

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -9921,3 +9921,96 @@ class WebInterface(object):
                            'warning_text' : warning_text})
 
     processCBLFile.exposed = True
+
+    # ── Health Dashboard Routes ──
+
+    def health(self):
+        """Health dashboard page."""
+        cherrypy.response.headers['Content-Type'] = 'application/json'
+        try:
+            if mylar.HEALTH_CHECK:
+                results = [r.to_dict() for r in mylar.HEALTH_CHECK.get_results()]
+                summary = mylar.HEALTH_CHECK.get_summary()
+                last_run = mylar.HEALTH_CHECK.last_run_iso()
+            else:
+                results = []
+                summary = {'errors': 0, 'warnings': 0, 'notices': 0, 'total': 0}
+                last_run = None
+            return json.dumps({
+                'results': results,
+                'summary': summary,
+                'last_run': last_run,
+            })
+        except Exception as e:
+            return json.dumps({'error': 'Failed to load health data: %s' % str(e)[:200]})
+    health.exposed = True
+
+    def getHealth(self, **kwargs):
+        """AJAX endpoint returning health check data as JSON."""
+        cherrypy.response.headers['Content-Type'] = 'application/json'
+        try:
+            include_history = kwargs.get('include_history', 'false').lower() == 'true'
+            if mylar.HEALTH_CHECK:
+                results = [r.to_dict() for r in mylar.HEALTH_CHECK.get_results()]
+                summary = mylar.HEALTH_CHECK.get_summary()
+                last_run = mylar.HEALTH_CHECK.last_run_iso()
+                history = mylar.HEALTH_CHECK.get_resolved_history() if include_history else []
+            else:
+                results = []
+                summary = {'errors': 0, 'warnings': 0, 'notices': 0, 'total': 0}
+                last_run = None
+                history = []
+            return json.dumps({
+                'success': True,
+                'data': {
+                    'results': results,
+                    'summary': summary,
+                    'last_run': last_run,
+                    'history': history,
+                }
+            })
+        except Exception as e:
+            return json.dumps({'success': False, 'error': str(e)[:200]})
+    getHealth.exposed = True
+
+    def recheckHealth(self):
+        """Trigger an immediate health check run."""
+        cherrypy.response.headers['Content-Type'] = 'application/json'
+        try:
+            if mylar.HEALTH_CHECK:
+                import threading
+                t = threading.Thread(target=mylar.HEALTH_CHECK.run_all_checks, name='HealthCheck-Manual')
+                t.start()
+                return json.dumps({'status': 'ok', 'message': 'Health check triggered'})
+            else:
+                return json.dumps({'status': 'error', 'message': 'Health check engine not initialized'})
+        except Exception as e:
+            return json.dumps({'status': 'error', 'message': str(e)[:200]})
+    recheckHealth.exposed = True
+
+    def dismissHealth(self, check_id=None):
+        """Dismiss/acknowledge a health check issue."""
+        cherrypy.response.headers['Content-Type'] = 'application/json'
+        if not check_id:
+            return json.dumps({'status': 'error', 'message': 'Missing check_id parameter'})
+        try:
+            if mylar.HEALTH_CHECK:
+                mylar.HEALTH_CHECK.dismiss(int(check_id))
+                return json.dumps({'status': 'ok', 'message': 'Check dismissed'})
+            else:
+                return json.dumps({'status': 'error', 'message': 'Health check engine not initialized'})
+        except Exception as e:
+            return json.dumps({'status': 'error', 'message': str(e)[:200]})
+    dismissHealth.exposed = True
+
+    def ping(self):
+        """Unauthenticated health probe for Docker HEALTHCHECK and load balancers."""
+        cherrypy.response.headers['Content-Type'] = 'application/json'
+        try:
+            summary = {'errors': 0, 'warnings': 0, 'notices': 0, 'total': 0}
+            if mylar.HEALTH_CHECK:
+                summary = mylar.HEALTH_CHECK.get_summary()
+            return json.dumps({'status': 'ok', 'health': summary})
+        except Exception as e:
+            return json.dumps({'status': 'error', 'message': str(e)[:200]})
+    ping.exposed = True

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -7080,6 +7080,13 @@ class WebInterface(object):
                     "dltotals": freq_tot,
                     "alphaindex": mylar.CONFIG.ALPHAINDEX,
                     "backup_on_start": helpers.checked(mylar.CONFIG.BACKUP_ON_START),
+                    "health_check_enabled": helpers.checked(mylar.CONFIG.HEALTH_CHECK_ENABLED),
+                    "health_check_interval": mylar.CONFIG.HEALTH_CHECK_INTERVAL,
+                    "health_show_banner": helpers.checked(mylar.CONFIG.HEALTH_SHOW_BANNER),
+                    "health_disk_warn_gb": mylar.CONFIG.HEALTH_DISK_WARN_GB,
+                    "health_disk_error_gb": mylar.CONFIG.HEALTH_DISK_ERROR_GB,
+                    "health_stale_task_min": mylar.CONFIG.HEALTH_STALE_TASK_MIN,
+                    "health_history_days": mylar.CONFIG.HEALTH_HISTORY_DAYS,
                }
         return serve_template(templatename="config.html", title="Settings", config=config, comicinfo=comicinfo)
     config.exposed = True
@@ -7411,7 +7418,8 @@ class WebInterface(object):
                            'prowl_enabled', 'prowl_onsnatch', 'pushover_enabled', 'pushover_onsnatch', 'pushover_image', 'mattermost_enabled', 'mattermost_onsnatch', 'boxcar_enabled',
                            'boxcar_onsnatch', 'pushbullet_enabled', 'pushbullet_onsnatch', 'telegram_enabled', 'telegram_onsnatch', 'telegram_image', 'discord_enabled', 'discord_onsnatch', 'slack_enabled', 'slack_onsnatch',
                            'email_enabled', 'email_enc', 'email_ongrab', 'email_onpost', 'gotify_enabled', 'gotify_server_url', 'gotify_token', 'gotify_onsnatch', 'opds_enable', 'opds_authentication', 'opds_metainfo', 'opds_pagesize', 'enable_ddl',
-                           'enable_getcomics', 'enable_airdcpp', 'jd2_enable', 'enable_external_server', 'ddl_prefer_upscaled', 'deluge_pause'] #enable_public
+                           'enable_getcomics', 'enable_airdcpp', 'jd2_enable', 'enable_external_server', 'ddl_prefer_upscaled', 'deluge_pause',
+                           'health_check_enabled', 'health_show_banner'] #enable_public
 
         for checked_config in checked_configs:
             if checked_config not in kwargs:

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -9987,6 +9987,19 @@ class WebInterface(object):
             return json.dumps({'status': 'error', 'message': str(e)[:200]})
     dismissHealth.exposed = True
 
+    def clearResolvedHealth(self):
+        """Clear all resolved health check history."""
+        cherrypy.response.headers['Content-Type'] = 'application/json'
+        try:
+            if mylar.HEALTH_CHECK:
+                mylar.HEALTH_CHECK.clear_resolved_history()
+                return json.dumps({'status': 'ok', 'message': 'Resolved history cleared'})
+            else:
+                return json.dumps({'status': 'error', 'message': 'Health check engine not initialized'})
+        except Exception as e:
+            return json.dumps({'status': 'error', 'message': str(e)[:200]})
+    clearResolvedHealth.exposed = True
+
     def ping(self):
         """Unauthenticated health probe for Docker HEALTHCHECK and load balancers."""
         cherrypy.response.headers['Content-Type'] = 'application/json'

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -9971,7 +9971,7 @@ class WebInterface(object):
         try:
             if mylar.HEALTH_CHECK:
                 import threading
-                t = threading.Thread(target=mylar.HEALTH_CHECK.run_all_checks, name='HealthCheck-Manual')
+                t = threading.Thread(target=mylar.HEALTH_CHECK.run_all_checks, kwargs={'force': True}, name='HealthCheck-Manual')
                 t.start()
                 return json.dumps({'status': 'ok', 'message': 'Health check triggered'})
             else:

--- a/mylar/webstart.py
+++ b/mylar/webstart.py
@@ -130,7 +130,7 @@ def initialize(options):
                 'auth.require': []
             })
             # exempt api, login page and static elements from authentication requirements
-            for i in ('/api', '/auth/login', '/css', '/images', '/js', 'favicon.ico'):
+            for i in ('/api', '/auth/login', '/css', '/images', '/js', 'favicon.ico', '/ping'):  # exempt /ping from auth for Docker HEALTHCHECK
                 if i in conf:
                     conf[i].update({'tools.auth.on': False})
                 else:
@@ -143,6 +143,7 @@ def initialize(options):
                                 {options['http_username']: options['http_password']})
                     })
             conf['/api'] = {'tools.auth_basic.on': False}
+            conf['/ping'] = {'tools.auth_basic.on': False}  # exempt /ping from auth for Docker HEALTHCHECK
 
     rest_api = {
         '/': {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,57 +1,252 @@
-# Running Mylar Test Suite
+# Mylar3 Test Suite
 
-This guide explains how to set up and run this test suite using `pytest`.
+## Overview
 
-## Setup Environment
+The test suite covers core Mylar3 functionality and the health check monitoring system. It contains **372 tests** across three test files and runs in under 1 second with zero network calls.
 
-It is recommended that you set up your pytest environment in a new venv, preferably targeting the lowest supported version of Python for Mylar (3.8 at time of writing).  For Windows hosts, you can use the [Python Launcher](https://docs.python.org/3/using/windows.html#launcher) to call different installed versions more easily.
+| File | Tests | What it covers |
+|------|------:|----------------|
+| `test_helpers.py` | 178 | Utility functions in `mylar/helpers.py` |
+| `test_filechecker.py` | 57 | Filename parsing in `mylar/filechecker.py` (data-driven) |
+| `test_healthcheck.py` | 137 | Health monitoring system in `mylar/healthcheck.py` |
 
-#### Linux
-```bash
-python3.8 -m venv /path/to/your/env
-```
+## Prerequisites / Setup
 
-#### Windows
-```bat
-py -3.8 -m venv C:\YourNewEnv
-```
-
-Once you have activated your environment, be install both the core Mylar `requirements.txt` in the project root, and those in the tests folder.  The latter will install pytest and any additional plugins that are in use.
-
-## Running the Tests
-
-From the root of the project, run the following command to execute all tests:
+Set up a virtual environment targeting your Python version (3.8+ supported):
 
 ```bash
-pytest tests
+# Linux / macOS
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Windows
+py -3 -m venv .venv
+.venv\Scripts\activate
 ```
 
-Verbosity is default, with some additional information on xpass/xfail results.
-
-## Using Markers
-
-This project uses custom pytest markers, which are configured in `pytest.ini`. Markers allow you to categorize and selectively run tests. For example, to just run the unit tests:
+Install both the project dependencies and test dependencies:
 
 ```bash
-pytest -m unit tests
+pip install -r requirements.txt
+pip install -r tests/requirements.txt
 ```
 
-or to run the unit tests, but exclude the benchmarking tests:
+Verify the setup by collecting tests without running them:
 
 ```bash
-pytest -m unit -m "not benchmark" tests
+pytest tests/ -v --co
 ```
 
-Refer to `pytest.ini` for a list and description of all available markers.
+No Docker, Selenium, or external services are needed. All tests run locally with zero network calls — `conftest.py` auto-patches `requests.get` to raise `RuntimeError` if any test accidentally attempts a real HTTP request.
 
-## Test data files
+## Quick Reference
 
-Be wary if editing test data files in Excel as it has a habit of making assumptions about column types and making changes.  If it becomes frustrating, it may be worth migrating to json / xml.
+```bash
+# Full suite
+pytest tests/                                        # Run ALL tests
+pytest tests/ -v                                     # Verbose output
+pytest tests/ -q --tb=line                           # Minimal output
+pytest tests/ -x                                     # Stop on first failure
+pytest tests/ -s                                     # Show print() output
+pytest tests/ --pdb                                  # Debug on failure
+
+# By marker
+pytest tests/ -m unit                                # Unit tests only
+pytest tests/ -m integration                         # Integration tests only
+pytest tests/ -m "not bench"                         # Skip benchmarks
+
+# Health check tests
+pytest tests/test_healthcheck.py -v                  # All health check tests
+pytest tests/test_healthcheck.py -m unit -v          # Health check unit tests
+pytest tests/test_healthcheck.py -m integration -v   # Health check integration tests
+
+# Other test files
+pytest tests/test_helpers.py -v                      # Helper tests only
+pytest tests/test_filechecker.py -v                  # File checker tests only
+
+# Targeted runs
+pytest tests/test_healthcheck.py -k "comicvine"                                     # Keyword match
+pytest tests/test_healthcheck.py::TestComicVineCheck                                 # Single class
+pytest tests/test_healthcheck.py::TestComicVineCheck::test_timeout_returns_error      # Single test
+```
+
+## Test File Inventory
+
+### test_helpers.py (178 tests)
+
+Tests for `mylar/helpers.py` utility functions: string formatting, issue number parsing, file size formatting, publisher detection, URL construction, DDL cleanup, and environment scripting. Uses `mockito` for mock verification in DDL and script tests.
+
+### test_filechecker.py (57 tests)
+
+Data-driven tests for `mylar/filechecker.py` filename parsing. Each test case is a real-world comic filename with expected parsed fields (series name, issue number, year, volume). Test data is loaded from an external data file.
+
+### test_healthcheck.py (137 tests)
+
+Tests for `mylar/healthcheck.py` — the health monitoring engine, individual checks, log interceptor, and database persistence. Organized into 17 test classes:
+
+| Class | Tests | Marker | Description |
+|-------|------:|--------|-------------|
+| `TestHealthCheckResult` | 9 | unit | Data container: creation, validation, serialization, `from_db_row` |
+| `TestHealthCheckRunner` | 14 | unit | Engine core: results, summary, dismiss, interval gating, thread safety |
+| `TestRootFolderCheck` | 6 | unit | Filesystem check: exists, missing, unreadable, multiple paths |
+| `TestComicVineCheck` | 8 | unit | API connectivity: success, timeout, errors, rate limit, status codes |
+| `TestStuckTasksCheck` | 4 | unit | Scheduler stale task detection with elapsed time thresholds |
+| `TestDiskSpaceCheck` | 6 | unit | Storage volume monitoring, warn/error thresholds, mount dedup |
+| `TestDownloadClientCheck` | 6 | unit | SABnzbd/NZBGet HTTP connectivity |
+| `TestNoIndexersCheck` | 4 | unit | Provider configuration: newznab, torznab, torrent search |
+| `TestSimpleChecks` | 15 | unit | API key, download client config, update, permissions, DB integrity, indexer status |
+| `TestHealthLogHandler` | 10 | unit | Log interceptor: pattern matching, throttling, loop prevention |
+| `TestRunAllChecks` | 6 | unit | Orchestration: disabled mode, exception resilience, severity sorting, carry-forward |
+| `TestTorrentClientChecks` | 16 | unit | qBittorrent, Transmission, rTorrent, Deluge, uTorrent connectivity |
+| `TestNZBGetCheck` | 6 | unit | NZBGet protocol/URL parsing (https/http/bare) and connectivity |
+| `TestFailedPostProcessing` | 4 | unit | Post-processing failure count detection from DB |
+| `TestSSEAndHelpers` | 6 | unit | SSE push, clear resolved history, load errors, default days |
+| `TestCheckEdgeCases` | 11 | unit | Generic exceptions, blocklist reasons, naive timestamps, deferred stubs |
+| `TestDatabaseOperations` | 6 | integration | Real SQLite: save/load round trip, resolve, cleanup, startup load, resolved history |
+
+## Markers
+
+Markers are defined in `pytest.ini` and allow selective test execution:
+
+| Marker | Description |
+|--------|-------------|
+| `unit` | Fast isolated tests with mocked dependencies (runs in <0.5s) |
+| `integration` | Tests using real SQLite databases in temporary directories |
+| `bench` | Benchmarking tests (currently disabled — `pytest-benchmark` is commented out in `requirements.txt`) |
+
+Combine markers with standard pytest expressions:
+
+```bash
+pytest tests/ -m "unit and not bench"
+pytest tests/ -m "unit or integration"
+```
+
+## Test Architecture & Patterns
+
+### Network isolation
+
+`conftest.py` auto-patches `requests.get` globally with an `autouse` fixture. All tests run offline by default. When a test needs a fake HTTP response, it re-patches `requests.get` per-test using `monkeypatch`:
+
+```python
+class FakeResponse:
+    status_code = 200
+monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+```
+
+To simulate errors, patch with a function that raises:
+
+```python
+def fake_timeout(*args, **kwargs):
+    raise requests.exceptions.Timeout("timed out")
+monkeypatch.setattr(requests, "get", fake_timeout)
+```
+
+### Config mocking
+
+Create a real `Config` object pointed at a nonexistent file, then override individual attributes:
+
+```python
+config = mylar.config.Config("./nothing")
+monkeypatch.setattr(mylar, "CONFIG", config)
+monkeypatch.setattr(config, "HEALTH_CHECK_ENABLED", True, raising=False)
+```
+
+### DB mocking (unit tests)
+
+`FakeDBConnection` class with `select()`, `action()`, `upsert()` stubs. Pre-load data via `mock_db._data`:
+
+```python
+mock_db._data = [{'cnt': 12}]  # what select() will return
+```
+
+### DB mocking (integration tests)
+
+The `real_db` fixture creates a real SQLite file in `tmp_path` with the actual `health_checks` table schema. `_make_real_db_conn()` wraps it in the `DBConnection` interface:
+
+```python
+monkeypatch.setattr(mylar.db, "DBConnection", lambda: _make_real_db_conn(real_db))
+```
+
+### Globals mocking
+
+The `mock_globals` fixture sets all `mylar.*` globals (`MONITOR_STATUS`, `USE_SABNZBD`, `PROVIDER_STATUS`, etc.) to safe defaults so tests start from a known state.
+
+### Fixture composition
+
+The `runner` fixture composes `mock_config` + `mock_globals` + `mock_db` to create a ready-to-use `HealthCheckRunner`:
+
+```python
+@pytest.fixture
+def runner(mock_config, mock_globals, mock_db):
+    return HealthCheckRunner()
+```
+
+### Filesystem testing
+
+Uses pytest's `tmp_path` fixture for real temporary directories. Permission tests mock `os.access` via `monkeypatch`.
+
+### Socket mocking
+
+Deluge uses raw TCP (not HTTP), so its tests mock `socket.create_connection`:
+
+```python
+monkeypatch.setattr(socket, "create_connection", lambda *a, **kw: FakeSocket())
+```
 
 ## Code Coverage
 
-A `.coveragerc` file is provided to test code coverage using [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/).  This can be executed from the root of the project with:
+Full project coverage:
 
 ```bash
-pytest --cov-config=tests/.coveragerc --cov=. tests
+pytest tests/ --cov-config=tests/.coveragerc --cov=. tests/
+```
+
+Health check module coverage with uncovered line numbers:
+
+```bash
+pytest tests/test_healthcheck.py --cov=mylar.healthcheck --cov-config=tests/.coveragerc --cov-report=term-missing -v
+```
+
+HTML coverage report:
+
+```bash
+pytest tests/test_healthcheck.py --cov=mylar.healthcheck --cov-report=html:htmlcov -v
+open htmlcov/index.html
+```
+
+**Target**: >=80% for `mylar/healthcheck.py` (currently at 94%).
+
+Lines that are legitimately hard to cover include bare `except Exception: pass` safety nets in private helpers (`_save_to_db`, `_resolve_cleared`, `_cleanup_old`) and generic fallback exception handlers in download client checks.
+
+## Health Check Manual Testing
+
+Automated tests cover the engine, check logic, and data layer. Manual/functional testing of the UI components (dashboard page, persistent banner, nav badge, SSE real-time updates) is documented separately.
+
+Key manual test areas:
+
+- `/health` dashboard page — table rendering, dismiss/recheck buttons
+- Persistent banner on every page — shows highest-severity active issue
+- Nav badge — error/warning count in the navigation bar
+- SSE real-time updates — browser receives `health_update` events without page refresh
+- `/ping` endpoint — unauthenticated health probe (returns 200 OK)
+- Config settings — enable/disable, thresholds, history retention
+
+See `docs/health-dashboard/TESTING_PLAN.md` for the full manual testing checklist with 20 step-by-step test recipes.
+
+## Test Data Files
+
+Be wary if editing test data files in Excel as it has a habit of making assumptions about column types and making changes. If it becomes frustrating, it may be worth migrating to JSON/XML.
+
+## Adding New Tests
+
+- **Health check tests** go in `test_healthcheck.py` (single file, not split by feature)
+- Follow the existing class organization — group by what you're testing
+- Mark every test method: `@pytest.mark.unit` or `@pytest.mark.integration`
+- Use the existing fixtures: `mock_config`, `mock_globals`, `mock_db`, `runner`, `real_db`
+- Network calls are blocked by default — mock `requests.get` per-test when needed
+- Use descriptive method names: `test_comicvine_timeout_returns_error` not `test_cv_1`
+- Run the full suite after adding tests to check for regressions:
+
+```bash
+pytest tests/ -v
 ```

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,1320 @@
+"""
+Unit and integration tests for the health check system.
+
+Tests cover:
+- HealthCheckResult data container (creation, validation, serialization)
+- HealthCheckRunner engine (results management, summary, dismiss, thread safety)
+- Individual health checks (root folders, disk space, ComicVine, stuck tasks, etc.)
+- HealthLogHandler log interceptor (pattern matching, throttling, loop prevention)
+- Database operations (save/load round trip, cleanup old records)
+
+Run with:
+    python -m pytest tests/test_healthcheck.py -v
+
+Run only unit tests:
+    python -m pytest tests/test_healthcheck.py -m unit -v
+
+Run only integration tests:
+    python -m pytest tests/test_healthcheck.py -m integration -v
+"""
+
+import datetime
+import json
+import logging
+import os
+import sqlite3
+import threading
+import time
+
+import pytest
+import requests
+
+import mylar
+from mylar.healthcheck import HealthCheckResult, HealthCheckRunner, HealthLogHandler
+
+
+# ── Fixtures ──
+
+@pytest.fixture
+def mock_config(monkeypatch):
+    """Set up a fake mylar.CONFIG with health check defaults."""
+    config = mylar.config.Config("./nothing")
+    monkeypatch.setattr(mylar, "CONFIG", config)
+    monkeypatch.setattr(config, "HEALTH_CHECK_ENABLED", True, raising=False)
+    monkeypatch.setattr(config, "HEALTH_CHECK_INTERVAL", 5, raising=False)
+    monkeypatch.setattr(config, "HEALTH_DISK_WARN_GB", '5.0', raising=False)
+    monkeypatch.setattr(config, "HEALTH_DISK_ERROR_GB", '1.0', raising=False)
+    monkeypatch.setattr(config, "HEALTH_STALE_TASK_MIN", 60, raising=False)
+    monkeypatch.setattr(config, "HEALTH_SHOW_BANNER", True, raising=False)
+    monkeypatch.setattr(config, "HEALTH_HISTORY_DAYS", 30, raising=False)
+    monkeypatch.setattr(config, "DESTINATION_DIR", '/comics', raising=False)
+    monkeypatch.setattr(config, "MULTIPLE_DEST_DIRS", None, raising=False)
+    monkeypatch.setattr(config, "COMICVINE_API", 'fake-api-key-12345', raising=False)
+    monkeypatch.setattr(config, "CV_VERIFY", True, raising=False)
+    monkeypatch.setattr(config, "CACHE_DIR", '/tmp/cache', raising=False)
+    monkeypatch.setattr(config, "SAB_HOST", 'http://localhost:8080', raising=False)
+    monkeypatch.setattr(config, "SAB_APIKEY", 'fake-sab-key', raising=False)
+    monkeypatch.setattr(config, "NZBGET_HOST", 'localhost', raising=False)
+    monkeypatch.setattr(config, "NZBGET_PORT", '6789', raising=False)
+    monkeypatch.setattr(config, "GIT_BRANCH", 'master', raising=False)
+    monkeypatch.setattr(config, "EXTRA_NEWZNABS", [], raising=False)
+    monkeypatch.setattr(config, "EXTRA_TORZNABS", [], raising=False)
+    monkeypatch.setattr(config, "ENABLE_TORRENT_SEARCH", False, raising=False)
+    monkeypatch.setattr(config, "EXPERIMENTAL", False, raising=False)
+    monkeypatch.setattr(config, "ENABLE_TORRENTS", False, raising=False)
+    return config
+
+
+@pytest.fixture
+def mock_globals(monkeypatch):
+    """Set up default mylar globals for health checks."""
+    monkeypatch.setattr(mylar, "CVURL", 'https://comicvine.gamespot.com/api/', raising=False)
+    monkeypatch.setattr(mylar, "CV_HEADERS", {'User-Agent': 'test'}, raising=False)
+    monkeypatch.setattr(mylar, "GLOBAL_MESSAGES", {}, raising=False)
+    monkeypatch.setattr(mylar, "HEALTH_RESULTS", [], raising=False)
+    monkeypatch.setattr(mylar, "HEALTH_CHECK", None, raising=False)
+    monkeypatch.setattr(mylar, "MONITOR_STATUS", 'Waiting', raising=False)
+    monkeypatch.setattr(mylar, "SEARCH_STATUS", 'Waiting', raising=False)
+    monkeypatch.setattr(mylar, "RSS_STATUS", 'Waiting', raising=False)
+    monkeypatch.setattr(mylar, "WEEKLY_STATUS", 'Waiting', raising=False)
+    monkeypatch.setattr(mylar, "VERSION_STATUS", 'Waiting', raising=False)
+    monkeypatch.setattr(mylar, "COMMITS_BEHIND", 0, raising=False)
+    monkeypatch.setattr(mylar, "DATA_DIR", '/tmp/mylar_data', raising=False)
+    monkeypatch.setattr(mylar, "LOG_DIR", '/tmp/mylar_logs', raising=False)
+    monkeypatch.setattr(mylar, "USE_SABNZBD", False, raising=False)
+    monkeypatch.setattr(mylar, "USE_NZBGET", False, raising=False)
+    monkeypatch.setattr(mylar, "USE_BLACKHOLE", False, raising=False)
+    monkeypatch.setattr(mylar, "USE_RTORRENT", False, raising=False)
+    monkeypatch.setattr(mylar, "USE_DELUGE", False, raising=False)
+    monkeypatch.setattr(mylar, "USE_TRANSMISSION", False, raising=False)
+    monkeypatch.setattr(mylar, "USE_QBITTORRENT", False, raising=False)
+    monkeypatch.setattr(mylar, "USE_UTORRENT", False, raising=False)
+    monkeypatch.setattr(mylar, "USE_WATCHDIR", False, raising=False)
+    monkeypatch.setattr(mylar, "PROVIDER_STATUS", None, raising=False)
+    monkeypatch.setattr(mylar, "PROVIDER_BLOCKLIST", [], raising=False)
+
+
+@pytest.fixture
+def mock_db(monkeypatch):
+    """Mock the database connection so no real DB is touched."""
+    class FakeDBConnection:
+        def __init__(self):
+            self._data = []
+
+        def select(self, query, params=None):
+            return self._data
+
+        def action(self, query, params=None):
+            pass
+
+        def upsert(self, table, new_values, control):
+            pass
+
+    fake = FakeDBConnection()
+    monkeypatch.setattr(mylar.db, "DBConnection", lambda: fake)
+    return fake
+
+
+@pytest.fixture
+def runner(mock_config, mock_globals, mock_db):
+    """Create a HealthCheckRunner with mocked dependencies."""
+    return HealthCheckRunner()
+
+
+@pytest.fixture
+def real_db(tmp_path, monkeypatch):
+    """Create a real SQLite database with the health_checks table."""
+    db_path = str(tmp_path / "test_mylar.db")
+
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute('CREATE TABLE IF NOT EXISTS health_checks ('
+              'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+              'check_type TEXT NOT NULL, '
+              'check_name TEXT NOT NULL, '
+              'severity TEXT NOT NULL, '
+              'message TEXT NOT NULL, '
+              'wiki_url TEXT, '
+              'source TEXT DEFAULT "health_check", '
+              'first_seen TEXT NOT NULL, '
+              'last_seen TEXT NOT NULL, '
+              'is_resolved INTEGER DEFAULT 0, '
+              'resolved_at TEXT, '
+              'check_count INTEGER DEFAULT 1, '
+              'metadata TEXT'
+              ')')
+    # also create jobhistory for stuck task tests
+    c.execute('CREATE TABLE IF NOT EXISTS jobhistory ('
+              'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+              'JobName TEXT, '
+              'current_run TEXT, '
+              'last_run_completed TEXT, '
+              'status TEXT'
+              ')')
+    # also create Failed for post-processing tests
+    c.execute('CREATE TABLE IF NOT EXISTS Failed ('
+              'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+              'DateFailed TEXT'
+              ')')
+    conn.commit()
+    conn.close()
+
+    # Point Mylar's DB module at our temp database
+    monkeypatch.setattr(mylar, "DB_FILE", db_path, raising=False)
+
+    return db_path
+
+
+# ── Unit Tests: HealthCheckResult ──
+
+class TestHealthCheckResult:
+    """Tests for the HealthCheckResult data container."""
+
+    @pytest.mark.unit
+    def test_creation_with_valid_fields(self):
+        r = HealthCheckResult(
+            check_type='infrastructure',
+            check_name='root_folder',
+            severity='error',
+            message='Root folder not found'
+        )
+        assert r.check_type == 'infrastructure'
+        assert r.check_name == 'root_folder'
+        assert r.severity == 'error'
+        assert r.message == 'Root folder not found'
+        assert r.check_count == 1
+        assert r.source == 'health_check'
+        assert r.db_id is None
+
+    @pytest.mark.unit
+    def test_invalid_severity_raises_valueerror(self):
+        with pytest.raises(ValueError):
+            HealthCheckResult(
+                check_type='infrastructure',
+                check_name='test',
+                severity='critical',
+                message='test'
+            )
+
+    @pytest.mark.unit
+    def test_to_dict_returns_json_serializable(self):
+        r = HealthCheckResult(
+            check_type='provider',
+            check_name='comicvine_api',
+            severity='error',
+            message='API timeout',
+            metadata={'timeout': 5}
+        )
+        d = r.to_dict()
+        json_str = json.dumps(d)
+        assert 'comicvine_api' in json_str
+
+    @pytest.mark.unit
+    def test_to_dict_contains_all_fields(self):
+        r = HealthCheckResult(
+            check_type='provider',
+            check_name='comicvine_api',
+            severity='warning',
+            message='Rate limited',
+            wiki_url='https://example.com/help',
+            source='log_intercept',
+            metadata={'code': 429}
+        )
+        d = r.to_dict()
+        assert d['check_type'] == 'provider'
+        assert d['check_name'] == 'comicvine_api'
+        assert d['severity'] == 'warning'
+        assert d['message'] == 'Rate limited'
+        assert d['wiki_url'] == 'https://example.com/help'
+        assert d['source'] == 'log_intercept'
+        assert d['metadata'] == {'code': 429}
+        assert d['check_count'] == 1
+        assert 'first_seen' in d
+        assert 'last_seen' in d
+
+    @pytest.mark.unit
+    def test_default_wiki_url_generated(self):
+        r = HealthCheckResult(
+            check_type='provider',
+            check_name='comicvine_api',
+            severity='error',
+            message='test'
+        )
+        assert 'comicvine-api' in r.wiki_url
+        assert 'Health-Checks' in r.wiki_url
+
+    @pytest.mark.unit
+    def test_custom_wiki_url_preserved(self):
+        custom_url = 'https://example.com/my-help-page'
+        r = HealthCheckResult(
+            check_type='provider',
+            check_name='comicvine_api',
+            severity='error',
+            message='test',
+            wiki_url=custom_url
+        )
+        assert r.wiki_url == custom_url
+
+    @pytest.mark.unit
+    def test_from_db_row_creates_correct_object(self):
+        row = {
+            'id': 42,
+            'check_type': 'infrastructure',
+            'check_name': 'disk_space',
+            'severity': 'warning',
+            'message': 'Low disk space',
+            'wiki_url': 'https://example.com',
+            'source': 'health_check',
+            'first_seen': '2025-01-01T00:00:00',
+            'last_seen': '2025-01-01T01:00:00',
+            'resolved_at': None,
+            'check_count': 5,
+            'metadata': '{"path": "/data", "free_gb": 3.2}',
+        }
+        r = HealthCheckResult.from_db_row(row)
+        assert r.db_id == 42
+        assert r.check_name == 'disk_space'
+        assert r.severity == 'warning'
+        assert r.check_count == 5
+        assert r.metadata == {'path': '/data', 'free_gb': 3.2}
+        assert r.first_seen == '2025-01-01T00:00:00'
+        assert r.last_seen == '2025-01-01T01:00:00'
+
+    @pytest.mark.unit
+    def test_from_db_row_handles_null_metadata(self):
+        row = {
+            'id': 1,
+            'check_type': 'config',
+            'check_name': 'api_key_missing',
+            'severity': 'error',
+            'message': 'No API key',
+            'wiki_url': None,
+            'source': None,
+            'first_seen': '2025-01-01T00:00:00',
+            'last_seen': '2025-01-01T00:00:00',
+            'resolved_at': None,
+            'check_count': None,
+            'metadata': None,
+        }
+        r = HealthCheckResult.from_db_row(row)
+        assert r.metadata == {}
+        assert r.check_count == 1
+        assert r.source == 'health_check'
+
+    @pytest.mark.unit
+    def test_metadata_defaults_to_empty_dict(self):
+        r = HealthCheckResult(
+            check_type='config',
+            check_name='test',
+            severity='notice',
+            message='test'
+        )
+        assert r.metadata == {}
+
+
+# ── Unit Tests: HealthCheckRunner ──
+
+class TestHealthCheckRunner:
+    """Tests for the HealthCheckRunner engine."""
+
+    @pytest.mark.unit
+    def test_init_creates_empty_state(self, runner):
+        assert runner.get_results() == []
+        assert runner.last_run_iso() is None
+
+    @pytest.mark.unit
+    def test_get_results_returns_list(self, runner):
+        results = runner.get_results()
+        assert isinstance(results, list)
+
+    @pytest.mark.unit
+    def test_get_results_returns_copy_not_reference(self, runner):
+        results1 = runner.get_results()
+        results2 = runner.get_results()
+        assert results1 is not results2
+
+    @pytest.mark.unit
+    def test_get_summary_empty_system(self, runner):
+        summary = runner.get_summary()
+        assert summary['errors'] == 0
+        assert summary['warnings'] == 0
+        assert summary['notices'] == 0
+        assert summary['total'] == 0
+
+    @pytest.mark.unit
+    def test_get_summary_with_mixed_results(self, runner):
+        # manually inject results
+        with runner._lock:
+            runner._results = [
+                HealthCheckResult('infrastructure', 'root_folder', 'error', 'Missing folder'),
+                HealthCheckResult('provider', 'comicvine_api', 'error', 'Timeout'),
+                HealthCheckResult('download', 'download_client', 'warning', 'Slow'),
+                HealthCheckResult('config', 'update_available', 'notice', 'Update ready'),
+            ]
+        summary = runner.get_summary()
+        assert summary['errors'] == 2
+        assert summary['warnings'] == 1
+        assert summary['notices'] == 1
+        assert summary['total'] == 4
+
+    @pytest.mark.unit
+    def test_last_run_iso_before_first_run(self, runner):
+        assert runner.last_run_iso() is None
+
+    @pytest.mark.unit
+    def test_last_run_iso_after_run(self, runner):
+        with runner._lock:
+            runner._last_run = datetime.datetime(2025, 6, 15, 12, 30, 0)
+        iso = runner.last_run_iso()
+        assert iso == '2025-06-15T12:30:00'
+
+    @pytest.mark.unit
+    def test_dismiss_removes_from_results(self, runner, mock_db):
+        result = HealthCheckResult('provider', 'comicvine_api', 'error', 'Timeout')
+        result.db_id = 42
+        with runner._lock:
+            runner._results = [result]
+
+        runner.dismiss(42)
+
+        assert len(runner.get_results()) == 0
+
+    @pytest.mark.unit
+    def test_should_run_true_on_first_call(self, runner):
+        assert runner._should_run('root_folder') is True
+
+    @pytest.mark.unit
+    def test_should_run_false_before_interval(self, runner):
+        runner._check_timestamps['root_folder'] = datetime.datetime.now(datetime.timezone.utc)
+        assert runner._should_run('root_folder') is False
+
+    @pytest.mark.unit
+    def test_should_run_true_after_interval(self, runner):
+        # root_folder has 5 min interval — set timestamp to 6 min ago
+        runner._check_timestamps['root_folder'] = (
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=6)
+        )
+        assert runner._should_run('root_folder') is True
+
+    @pytest.mark.unit
+    def test_ingest_log_finding_new_issue(self, runner, mock_db):
+        result = HealthCheckResult('detected', 'comicvine_api', 'error', 'CV timeout', source='log_intercept')
+        runner.ingest_log_finding(result)
+
+        results = runner.get_results()
+        assert len(results) == 1
+        assert results[0].check_name == 'comicvine_api'
+
+    @pytest.mark.unit
+    def test_ingest_log_finding_deduplicates(self, runner, mock_db):
+        r1 = HealthCheckResult('detected', 'comicvine_api', 'error', 'CV timeout 1', source='log_intercept')
+        r2 = HealthCheckResult('detected', 'comicvine_api', 'error', 'CV timeout 2', source='log_intercept')
+        runner.ingest_log_finding(r1)
+        runner.ingest_log_finding(r2)
+
+        results = runner.get_results()
+        assert len(results) == 1
+        assert results[0].check_count == 2
+
+    @pytest.mark.unit
+    def test_thread_safety_concurrent_access(self, runner):
+        """Verify concurrent reads and writes don't crash."""
+        errors = []
+
+        def reader():
+            try:
+                for _ in range(100):
+                    runner.get_results()
+                    runner.get_summary()
+            except Exception as e:
+                errors.append(e)
+
+        def writer():
+            try:
+                for i in range(100):
+                    with runner._lock:
+                        runner._results = [
+                            HealthCheckResult('config', 'test_%d' % i, 'notice', 'msg')
+                        ]
+            except Exception as e:
+                errors.append(e)
+
+        threads = []
+        for _ in range(5):
+            threads.append(threading.Thread(target=reader))
+            threads.append(threading.Thread(target=writer))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+
+# ── Unit Tests: Root Folder Check ──
+
+class TestRootFolderCheck:
+    """Tests for check_root_folders() — filesystem accessibility."""
+
+    @pytest.mark.unit
+    def test_existing_readable_folder_returns_empty(self, runner, tmp_path, mock_config):
+        real_folder = tmp_path / "comics"
+        real_folder.mkdir()
+        mock_config.DESTINATION_DIR = str(real_folder)
+        mock_config.MULTIPLE_DEST_DIRS = None
+
+        results = runner.check_root_folders()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_missing_folder_returns_error(self, runner, mock_config):
+        mock_config.DESTINATION_DIR = '/absolutely/does/not/exist/anywhere'
+        mock_config.MULTIPLE_DEST_DIRS = None
+
+        results = runner.check_root_folders()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert results[0].check_name == 'root_folder'
+        assert 'not accessible' in results[0].message
+
+    @pytest.mark.unit
+    def test_unreadable_folder_returns_error(self, runner, tmp_path, mock_config, monkeypatch):
+        real_folder = tmp_path / "comics"
+        real_folder.mkdir()
+        mock_config.DESTINATION_DIR = str(real_folder)
+        mock_config.MULTIPLE_DEST_DIRS = None
+
+        # mock os.access to return False for read check
+        original_access = os.access
+        def fake_access(path, mode):
+            if path == str(real_folder) and mode == os.R_OK:
+                return False
+            return original_access(path, mode)
+        monkeypatch.setattr(os, "access", fake_access)
+
+        results = runner.check_root_folders()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert 'not readable' in results[0].message
+
+    @pytest.mark.unit
+    def test_multiple_folders_all_ok(self, runner, tmp_path, mock_config):
+        folder1 = tmp_path / "comics1"
+        folder2 = tmp_path / "comics2"
+        folder1.mkdir()
+        folder2.mkdir()
+        mock_config.DESTINATION_DIR = str(folder1)
+        mock_config.MULTIPLE_DEST_DIRS = str(folder2)
+
+        results = runner.check_root_folders()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_multiple_folders_one_missing(self, runner, tmp_path, mock_config):
+        folder1 = tmp_path / "comics1"
+        folder1.mkdir()
+        mock_config.DESTINATION_DIR = str(folder1)
+        mock_config.MULTIPLE_DEST_DIRS = '/nonexistent/folder/here'
+
+        results = runner.check_root_folders()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+
+    @pytest.mark.unit
+    def test_no_folders_configured_returns_empty(self, runner, mock_config):
+        mock_config.DESTINATION_DIR = None
+        mock_config.MULTIPLE_DEST_DIRS = None
+
+        results = runner.check_root_folders()
+        assert results == []
+
+
+# ── Unit Tests: ComicVine Check ──
+
+class TestComicVineCheck:
+    """Tests for check_comicvine_api() — API connectivity."""
+
+    @pytest.mark.unit
+    def test_successful_api_call_returns_empty(self, runner, mock_config, mock_globals, monkeypatch):
+        class FakeResponse:
+            status_code = 200
+        monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+
+        results = runner.check_comicvine_api()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_timeout_returns_error(self, runner, mock_config, mock_globals, monkeypatch):
+        def fake_timeout(*args, **kwargs):
+            raise requests.exceptions.Timeout("Connection timed out")
+        monkeypatch.setattr(requests, "get", fake_timeout)
+
+        results = runner.check_comicvine_api()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert 'timed out' in results[0].message.lower()
+
+    @pytest.mark.unit
+    def test_connection_error_returns_error(self, runner, mock_config, mock_globals, monkeypatch):
+        def fake_conn_error(*args, **kwargs):
+            raise requests.exceptions.ConnectionError("Connection refused")
+        monkeypatch.setattr(requests, "get", fake_conn_error)
+
+        results = runner.check_comicvine_api()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert results[0].check_name == 'comicvine_api'
+
+    @pytest.mark.unit
+    def test_401_returns_error_invalid_key(self, runner, mock_config, mock_globals, monkeypatch):
+        class FakeResponse:
+            status_code = 401
+        monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+
+        results = runner.check_comicvine_api()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert '401' in results[0].message
+
+    @pytest.mark.unit
+    def test_429_returns_warning_rate_limit(self, runner, mock_config, mock_globals, monkeypatch):
+        class FakeResponse:
+            status_code = 429
+        monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+
+        results = runner.check_comicvine_api()
+        assert len(results) == 1
+        assert results[0].severity == 'warning'
+        assert 'rate limit' in results[0].message.lower()
+
+    @pytest.mark.unit
+    def test_500_returns_error(self, runner, mock_config, mock_globals, monkeypatch):
+        class FakeResponse:
+            status_code = 500
+        monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+
+        results = runner.check_comicvine_api()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert '500' in results[0].message
+
+    @pytest.mark.unit
+    def test_no_api_key_returns_empty(self, runner, mock_config, mock_globals):
+        mock_config.COMICVINE_API = None
+
+        results = runner.check_comicvine_api()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_request_uses_5s_timeout(self, runner, mock_config, mock_globals, monkeypatch):
+        captured = {}
+        class FakeResponse:
+            status_code = 200
+        def capture_get(*args, **kwargs):
+            captured.update(kwargs)
+            return FakeResponse()
+        monkeypatch.setattr(requests, "get", capture_get)
+
+        runner.check_comicvine_api()
+        assert captured.get('timeout') == 5
+
+
+# ── Unit Tests: Stuck Tasks Check ──
+
+class TestStuckTasksCheck:
+    """Tests for check_stuck_tasks() — scheduler stale task detection."""
+
+    @pytest.mark.unit
+    def test_all_tasks_idle_returns_empty(self, runner, mock_config, mock_globals, mock_db):
+        # all statuses are 'Waiting' by default from mock_globals
+        results = runner.check_stuck_tasks()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_task_running_under_threshold_returns_empty(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
+        monkeypatch.setattr(mylar, "MONITOR_STATUS", 'Running', raising=False)
+        # task started 5 minutes ago — under the 60 min threshold
+        five_min_ago = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=5)).isoformat()
+        mock_db._data = [{'current_run': five_min_ago}]
+
+        results = runner.check_stuck_tasks()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_task_running_over_threshold_returns_warning(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
+        monkeypatch.setattr(mylar, "MONITOR_STATUS", 'Running', raising=False)
+        # task started 2 hours ago — well over the 60 min threshold
+        two_hours_ago = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=2)).isoformat()
+        mock_db._data = [{'current_run': two_hours_ago}]
+
+        results = runner.check_stuck_tasks()
+        assert len(results) >= 1
+        assert results[0].severity == 'warning'
+        assert 'Monitor' in results[0].message
+
+    @pytest.mark.unit
+    def test_multiple_stuck_tasks_returns_multiple(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
+        monkeypatch.setattr(mylar, "MONITOR_STATUS", 'Running', raising=False)
+        monkeypatch.setattr(mylar, "SEARCH_STATUS", 'Running', raising=False)
+        two_hours_ago = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=2)).isoformat()
+        mock_db._data = [{'current_run': two_hours_ago}]
+
+        results = runner.check_stuck_tasks()
+        assert len(results) >= 2
+
+
+# ── Unit Tests: Disk Space Check ──
+
+class TestDiskSpaceCheck:
+    """Tests for check_disk_space() — storage volume monitoring."""
+
+    @pytest.mark.unit
+    def test_plenty_of_space_returns_empty(self, runner, mock_config, tmp_path, monkeypatch):
+        real_dir = str(tmp_path)
+        mock_config.DESTINATION_DIR = real_dir
+        mock_config.CACHE_DIR = None
+        # set thresholds very low so real disk space passes
+        mock_config.HEALTH_DISK_WARN_GB = '0.001'
+        mock_config.HEALTH_DISK_ERROR_GB = '0.0001'
+
+        results = runner.check_disk_space()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_low_space_returns_warning(self, runner, mock_config, tmp_path, monkeypatch):
+        import shutil
+        real_dir = str(tmp_path)
+        mock_config.DESTINATION_DIR = real_dir
+        mock_config.CACHE_DIR = None
+
+        # get actual free space and set warning threshold just above it
+        usage = shutil.disk_usage(real_dir)
+        free_gb = usage.free / (1024 ** 3)
+        mock_config.HEALTH_DISK_WARN_GB = str(free_gb + 10)
+        mock_config.HEALTH_DISK_ERROR_GB = '0.0001'
+
+        results = runner.check_disk_space()
+        assert len(results) == 1
+        assert results[0].severity == 'warning'
+
+    @pytest.mark.unit
+    def test_critical_space_returns_error(self, runner, mock_config, tmp_path, monkeypatch):
+        import shutil
+        real_dir = str(tmp_path)
+        mock_config.DESTINATION_DIR = real_dir
+        mock_config.CACHE_DIR = None
+
+        # get actual free space and set error threshold just above it
+        usage = shutil.disk_usage(real_dir)
+        free_gb = usage.free / (1024 ** 3)
+        mock_config.HEALTH_DISK_WARN_GB = str(free_gb + 20)
+        mock_config.HEALTH_DISK_ERROR_GB = str(free_gb + 10)
+
+        results = runner.check_disk_space()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+
+    @pytest.mark.unit
+    def test_threshold_cast_from_string_config(self, runner, mock_config, tmp_path):
+        # verify string config values are properly cast to float
+        mock_config.DESTINATION_DIR = str(tmp_path)
+        mock_config.CACHE_DIR = None
+        mock_config.HEALTH_DISK_WARN_GB = '0.001'
+        mock_config.HEALTH_DISK_ERROR_GB = '0.0001'
+
+        # should not raise a TypeError from failing to cast
+        results = runner.check_disk_space()
+        assert isinstance(results, list)
+
+    @pytest.mark.unit
+    def test_nonexistent_path_skipped(self, runner, mock_config):
+        mock_config.DESTINATION_DIR = '/absolutely/nonexistent/path'
+        mock_config.CACHE_DIR = None
+
+        results = runner.check_disk_space()
+        # nonexistent paths are skipped (os.path.exists guard), not errors
+        assert results == []
+
+    @pytest.mark.unit
+    def test_same_mount_not_checked_twice(self, runner, mock_config, tmp_path):
+        # both point to the same filesystem
+        mock_config.DESTINATION_DIR = str(tmp_path)
+        mock_config.CACHE_DIR = str(tmp_path)
+        mock_config.HEALTH_DISK_WARN_GB = '0.001'
+        mock_config.HEALTH_DISK_ERROR_GB = '0.0001'
+
+        results = runner.check_disk_space()
+        # even if both paths exist, same mount should only be checked once
+        assert isinstance(results, list)
+
+
+# ── Unit Tests: Download Client Check ──
+
+class TestDownloadClientCheck:
+    """Tests for check_download_client() — SABnzbd/NZBGet connectivity."""
+
+    @pytest.mark.unit
+    def test_sabnzbd_reachable_returns_empty(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_SABNZBD", True, raising=False)
+
+        class FakeResponse:
+            status_code = 200
+        monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+
+        results = runner.check_download_client()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_sabnzbd_unreachable_returns_error(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_SABNZBD", True, raising=False)
+
+        def fake_conn_error(*args, **kwargs):
+            raise requests.exceptions.ConnectionError("Connection refused")
+        monkeypatch.setattr(requests, "get", fake_conn_error)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert 'SABnzbd' in results[0].message
+
+    @pytest.mark.unit
+    def test_sabnzbd_timeout_returns_error(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_SABNZBD", True, raising=False)
+
+        def fake_timeout(*args, **kwargs):
+            raise requests.exceptions.Timeout("timed out")
+        monkeypatch.setattr(requests, "get", fake_timeout)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert 'timed out' in results[0].message.lower()
+
+    @pytest.mark.unit
+    def test_nzbget_reachable_returns_empty(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
+
+        class FakeResponse:
+            status_code = 200
+        monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+
+        results = runner.check_download_client()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_no_client_configured_returns_empty(self, runner, mock_config, mock_globals):
+        # all USE_* flags are False by default
+        results = runner.check_download_client()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_sabnzbd_request_uses_5s_timeout(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_SABNZBD", True, raising=False)
+
+        captured = {}
+        class FakeResponse:
+            status_code = 200
+        def capture_get(*args, **kwargs):
+            captured.update(kwargs)
+            return FakeResponse()
+        monkeypatch.setattr(requests, "get", capture_get)
+
+        runner.check_download_client()
+        assert captured.get('timeout') == 5
+
+
+# ── Unit Tests: No Indexers Check ──
+
+class TestNoIndexersCheck:
+    """Tests for check_no_indexers() — provider configuration check."""
+
+    @pytest.mark.unit
+    def test_indexers_configured_returns_empty(self, runner, mock_config, mock_globals):
+        # simulate one enabled newznab provider
+        # tuple format: (name, host, verify, apikey, uid, enabled, id)
+        mock_config.EXTRA_NEWZNABS = [
+            ('TestProvider', 'http://example.com', False, 'key123', '0', '1', '0')
+        ]
+
+        results = runner.check_no_indexers()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_no_indexers_returns_error(self, runner, mock_config, mock_globals):
+        mock_config.EXTRA_NEWZNABS = []
+        mock_config.EXTRA_TORZNABS = []
+        mock_config.ENABLE_TORRENT_SEARCH = False
+        mock_config.EXPERIMENTAL = False
+
+        results = runner.check_no_indexers()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert results[0].check_name == 'no_indexers'
+
+    @pytest.mark.unit
+    def test_torznab_configured_returns_empty(self, runner, mock_config, mock_globals):
+        mock_config.EXTRA_NEWZNABS = []
+        mock_config.EXTRA_TORZNABS = [
+            ('Jackett', 'http://jackett:9117', False, 'key', '0', '1', '0')
+        ]
+
+        results = runner.check_no_indexers()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_torrent_search_enabled_returns_empty(self, runner, mock_config, mock_globals):
+        mock_config.EXTRA_NEWZNABS = []
+        mock_config.EXTRA_TORZNABS = []
+        mock_config.ENABLE_TORRENT_SEARCH = True
+
+        results = runner.check_no_indexers()
+        assert results == []
+
+
+# ── Unit Tests: Simple Config/State Checks ──
+
+class TestSimpleChecks:
+    """Tests for simple config and state checks (API key, download client, update, permissions, DB)."""
+
+    @pytest.mark.unit
+    def test_api_key_present_returns_empty(self, runner, mock_config):
+        results = runner.check_api_key_missing()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_api_key_missing_returns_error(self, runner, mock_config):
+        mock_config.COMICVINE_API = None
+        results = runner.check_api_key_missing()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert results[0].check_name == 'api_key_missing'
+
+    @pytest.mark.unit
+    def test_api_key_whitespace_returns_error(self, runner, mock_config):
+        mock_config.COMICVINE_API = '   '
+        results = runner.check_api_key_missing()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+
+    @pytest.mark.unit
+    def test_api_key_none_string_returns_error(self, runner, mock_config):
+        mock_config.COMICVINE_API = 'None'
+        results = runner.check_api_key_missing()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+
+    @pytest.mark.unit
+    def test_no_download_client_returns_warning(self, runner, mock_config, mock_globals):
+        # all USE_* flags are False by default from mock_globals
+        results = runner.check_no_download_client()
+        assert len(results) == 1
+        assert results[0].severity == 'warning'
+        assert results[0].check_name == 'no_download_client'
+
+    @pytest.mark.unit
+    def test_download_client_configured_returns_empty(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_SABNZBD", True, raising=False)
+        results = runner.check_no_download_client()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_update_available_returns_notice(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "COMMITS_BEHIND", 5, raising=False)
+        results = runner.check_update_available()
+        assert len(results) == 1
+        assert results[0].severity == 'notice'
+        assert results[0].check_name == 'update_available'
+        assert '5' in results[0].message
+
+    @pytest.mark.unit
+    def test_no_update_returns_empty(self, runner, mock_config, mock_globals):
+        results = runner.check_update_available()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_permissions_ok_returns_empty(self, runner, mock_config, mock_globals, tmp_path, monkeypatch):
+        real_dir = str(tmp_path / "data")
+        os.makedirs(real_dir, exist_ok=True)
+        monkeypatch.setattr(mylar, "DATA_DIR", real_dir, raising=False)
+        monkeypatch.setattr(mylar, "LOG_DIR", real_dir, raising=False)
+        mock_config.CACHE_DIR = real_dir
+
+        results = runner.check_permissions()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_permissions_not_writable_returns_error(self, runner, mock_config, mock_globals, tmp_path, monkeypatch):
+        real_dir = str(tmp_path / "data")
+        os.makedirs(real_dir, exist_ok=True)
+        monkeypatch.setattr(mylar, "DATA_DIR", real_dir, raising=False)
+        monkeypatch.setattr(mylar, "LOG_DIR", None, raising=False)
+        mock_config.CACHE_DIR = None
+
+        # mock os.access to return False for write check
+        original_access = os.access
+        def fake_access(path, mode):
+            if path == real_dir and mode == os.W_OK:
+                return False
+            return original_access(path, mode)
+        monkeypatch.setattr(os, "access", fake_access)
+
+        results = runner.check_permissions()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert results[0].check_name == 'permissions'
+
+    @pytest.mark.unit
+    def test_database_integrity_ok_returns_empty(self, runner, mock_db):
+        # PRAGMA integrity_check returns 'ok' for a healthy DB
+        # simulate sqlite3.Row-like tuple result
+        mock_db._data = [('ok',)]
+
+        results = runner.check_database_integrity()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_database_integrity_corrupt_returns_error(self, runner, mock_db):
+        mock_db._data = [('*** in tree page 5 of table foo: cell 12 is out of range',)]
+
+        results = runner.check_database_integrity()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert results[0].check_name == 'database_integrity'
+
+    @pytest.mark.unit
+    def test_indexer_down_returns_warning(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "PROVIDER_STATUS", {'NZBgeek': 'fail'}, raising=False)
+
+        results = runner.check_indexers()
+        assert len(results) == 1
+        assert results[0].severity == 'warning'
+        assert 'NZBgeek' in results[0].message
+
+    @pytest.mark.unit
+    def test_indexer_ok_returns_empty(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "PROVIDER_STATUS", {'NZBgeek': 'success'}, raising=False)
+
+        results = runner.check_indexers()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_indexers_not_populated_returns_empty(self, runner, mock_config, mock_globals):
+        # PROVIDER_STATUS is None when not populated yet
+        results = runner.check_indexers()
+        assert results == []
+
+
+# ── Unit Tests: HealthLogHandler ──
+
+class TestHealthLogHandler:
+    """Tests for the HealthLogHandler log interceptor."""
+
+    def _make_record(self, message, level=logging.WARNING):
+        """Helper to create a log record."""
+        record = logging.LogRecord(
+            name='mylar',
+            level=level,
+            pathname='test.py',
+            lineno=1,
+            msg=message,
+            args=(),
+            exc_info=None,
+        )
+        return record
+
+    @pytest.mark.unit
+    def test_ignores_info_messages(self, mock_globals, monkeypatch):
+        handler = HealthLogHandler()
+        record = self._make_record('ComicVine timeout error', level=logging.INFO)
+
+        # handler level is WARNING — INFO should be filtered by logging framework
+        assert handler.level == logging.WARNING
+        assert record.levelno < handler.level
+
+    @pytest.mark.unit
+    def test_ignores_debug_messages(self, mock_globals, monkeypatch):
+        handler = HealthLogHandler()
+        record = self._make_record('ComicVine timeout error', level=logging.DEBUG)
+
+        assert record.levelno < handler.level
+
+    @pytest.mark.unit
+    def test_catches_comicvine_timeout_pattern(self, mock_globals, mock_config, mock_db, monkeypatch):
+        runner = HealthCheckRunner()
+        monkeypatch.setattr(mylar, "HEALTH_CHECK", runner, raising=False)
+
+        handler = HealthLogHandler()
+        record = self._make_record('ComicVine API timeout after 5s')
+        handler.emit(record)
+
+        results = runner.get_results()
+        assert len(results) == 1
+        assert results[0].check_name == 'comicvine_api'
+
+    @pytest.mark.unit
+    def test_catches_sabnzbd_connection_pattern(self, mock_globals, mock_config, mock_db, monkeypatch):
+        runner = HealthCheckRunner()
+        monkeypatch.setattr(mylar, "HEALTH_CHECK", runner, raising=False)
+
+        handler = HealthLogHandler()
+        record = self._make_record('SABnzbd connection refused at localhost:8080')
+        handler.emit(record)
+
+        results = runner.get_results()
+        assert len(results) == 1
+        assert results[0].check_name == 'download_client'
+
+    @pytest.mark.unit
+    def test_catches_permission_denied_pattern(self, mock_globals, mock_config, mock_db, monkeypatch):
+        runner = HealthCheckRunner()
+        monkeypatch.setattr(mylar, "HEALTH_CHECK", runner, raising=False)
+
+        handler = HealthLogHandler()
+        record = self._make_record('Permission denied writing to /data/comics')
+        handler.emit(record)
+
+        results = runner.get_results()
+        assert len(results) == 1
+        assert results[0].check_name == 'permissions'
+
+    @pytest.mark.unit
+    def test_catches_disk_full_pattern(self, mock_globals, mock_config, mock_db, monkeypatch):
+        runner = HealthCheckRunner()
+        monkeypatch.setattr(mylar, "HEALTH_CHECK", runner, raising=False)
+
+        handler = HealthLogHandler()
+        record = self._make_record('No space left on device')
+        handler.emit(record)
+
+        results = runner.get_results()
+        assert len(results) == 1
+        assert results[0].check_name == 'disk_space'
+
+    @pytest.mark.unit
+    def test_catches_database_locked_pattern(self, mock_globals, mock_config, mock_db, monkeypatch):
+        runner = HealthCheckRunner()
+        monkeypatch.setattr(mylar, "HEALTH_CHECK", runner, raising=False)
+
+        handler = HealthLogHandler()
+        record = self._make_record('database is locked - concurrent access error')
+        handler.emit(record)
+
+        results = runner.get_results()
+        assert len(results) == 1
+        assert results[0].check_name == 'database_integrity'
+
+    @pytest.mark.unit
+    def test_skips_healthcheck_prefixed_messages(self, mock_globals, mock_config, mock_db, monkeypatch):
+        """Messages with [HealthCheck] prefix are skipped to prevent infinite loops."""
+        runner = HealthCheckRunner()
+        monkeypatch.setattr(mylar, "HEALTH_CHECK", runner, raising=False)
+
+        handler = HealthLogHandler()
+        record = self._make_record('[HealthCheck] ComicVine API timeout after 5s')
+        handler.emit(record)
+
+        results = runner.get_results()
+        assert len(results) == 0
+
+    @pytest.mark.unit
+    def test_throttles_same_check_name(self, mock_globals, mock_config, mock_db, monkeypatch):
+        """Same check_name should not fire again within the throttle window."""
+        runner = HealthCheckRunner()
+        monkeypatch.setattr(mylar, "HEALTH_CHECK", runner, raising=False)
+
+        handler = HealthLogHandler()
+
+        # first emit — should create a finding
+        record1 = self._make_record('ComicVine API timeout first')
+        handler.emit(record1)
+
+        # second emit — should be throttled
+        record2 = self._make_record('ComicVine API timeout second')
+        handler.emit(record2)
+
+        # only one result from the first emit; the second was throttled
+        # (ingest_log_finding deduplication bumps check_count but handler throttle blocks it)
+        results = runner.get_results()
+        assert len(results) == 1
+
+    @pytest.mark.unit
+    def test_emit_never_raises_exception(self, mock_globals, monkeypatch):
+        """emit() must never crash — even with broken HEALTH_CHECK."""
+        monkeypatch.setattr(mylar, "HEALTH_CHECK", None, raising=False)
+
+        handler = HealthLogHandler()
+        record = self._make_record('ComicVine API timeout')
+
+        # should not raise, even though HEALTH_CHECK is None
+        handler.emit(record)
+
+
+# ── Unit Tests: Database Operations ──
+
+class TestDatabaseOperations:
+    """Tests for persistence logic using a real temporary SQLite database."""
+
+    @pytest.mark.integration
+    def test_save_new_result_to_db(self, mock_config, mock_globals, real_db, monkeypatch):
+        """A new health check result is persisted to the database."""
+        # point db module at our real temp DB
+        from mylar.db import DBConnection
+        monkeypatch.setattr(mylar.db, "DBConnection", lambda: _make_real_db_conn(real_db))
+
+        runner = HealthCheckRunner()
+        result = HealthCheckResult('infrastructure', 'root_folder', 'error', 'Missing folder')
+        runner._save_to_db([result])
+
+        conn = sqlite3.connect(real_db)
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT * FROM health_checks WHERE check_name='root_folder'").fetchall()
+        conn.close()
+
+        assert len(rows) == 1
+        assert rows[0]['severity'] == 'error'
+        assert rows[0]['is_resolved'] == 0
+
+    @pytest.mark.integration
+    def test_save_existing_updates_count(self, mock_config, mock_globals, real_db, monkeypatch):
+        """Saving the same check_name twice increments check_count."""
+        monkeypatch.setattr(mylar.db, "DBConnection", lambda: _make_real_db_conn(real_db))
+
+        runner = HealthCheckRunner()
+        r1 = HealthCheckResult('infrastructure', 'root_folder', 'error', 'Missing folder')
+        runner._save_to_db([r1])
+
+        r2 = HealthCheckResult('infrastructure', 'root_folder', 'error', 'Still missing')
+        runner._save_to_db([r2])
+
+        conn = sqlite3.connect(real_db)
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT * FROM health_checks WHERE check_name='root_folder' AND is_resolved=0").fetchall()
+        conn.close()
+
+        assert len(rows) == 1
+        assert rows[0]['check_count'] == 2
+
+    @pytest.mark.integration
+    def test_resolve_cleared_issues(self, mock_config, mock_globals, real_db, monkeypatch):
+        """When a check passes, its DB row gets is_resolved=1."""
+        monkeypatch.setattr(mylar.db, "DBConnection", lambda: _make_real_db_conn(real_db))
+
+        runner = HealthCheckRunner()
+
+        # first: save a failing result
+        r = HealthCheckResult('infrastructure', 'root_folder', 'error', 'Missing')
+        runner._save_to_db([r])
+
+        # then: resolve it (no current results for root_folder, but check ran)
+        runner._resolve_cleared([], {'root_folder'})
+
+        conn = sqlite3.connect(real_db)
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT * FROM health_checks WHERE check_name='root_folder'").fetchall()
+        conn.close()
+
+        assert len(rows) == 1
+        assert rows[0]['is_resolved'] == 1
+        assert rows[0]['resolved_at'] is not None
+
+    @pytest.mark.integration
+    def test_cleanup_old_resolved(self, mock_config, mock_globals, real_db, monkeypatch):
+        """Resolved records older than HEALTH_HISTORY_DAYS are deleted."""
+        monkeypatch.setattr(mylar.db, "DBConnection", lambda: _make_real_db_conn(real_db))
+
+        # insert an old resolved record directly
+        old_date = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=60)).isoformat()
+        conn = sqlite3.connect(real_db)
+        conn.execute(
+            "INSERT INTO health_checks (check_type, check_name, severity, message, first_seen, last_seen, is_resolved, resolved_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, 1, ?)",
+            ['config', 'old_issue', 'notice', 'Old resolved issue', old_date, old_date, old_date]
+        )
+        conn.commit()
+
+        # also insert a recent resolved record that should NOT be deleted
+        recent_date = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=5)).isoformat()
+        conn.execute(
+            "INSERT INTO health_checks (check_type, check_name, severity, message, first_seen, last_seen, is_resolved, resolved_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, 1, ?)",
+            ['config', 'recent_issue', 'notice', 'Recent resolved issue', recent_date, recent_date, recent_date]
+        )
+        conn.commit()
+        conn.close()
+
+        runner = HealthCheckRunner()
+        runner._cleanup_old()
+
+        conn = sqlite3.connect(real_db)
+        rows = conn.execute("SELECT * FROM health_checks WHERE is_resolved=1").fetchall()
+        conn.close()
+
+        assert len(rows) == 1  # only the recent one survives
+
+    @pytest.mark.integration
+    def test_load_from_db_on_startup(self, mock_config, mock_globals, real_db, monkeypatch):
+        """Active issues are loaded from DB on startup."""
+        monkeypatch.setattr(mylar.db, "DBConnection", lambda: _make_real_db_conn(real_db))
+
+        now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        conn = sqlite3.connect(real_db)
+        conn.execute(
+            "INSERT INTO health_checks (check_type, check_name, severity, message, source, first_seen, last_seen, is_resolved, check_count, metadata) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, 0, 1, ?)",
+            ['provider', 'comicvine_api', 'error', 'CV timeout', 'health_check', now, now, '{}']
+        )
+        conn.commit()
+        conn.close()
+
+        runner = HealthCheckRunner()
+        runner.load_from_db()
+
+        results = runner.get_results()
+        assert len(results) == 1
+        assert results[0].check_name == 'comicvine_api'
+        assert results[0].severity == 'error'
+
+    @pytest.mark.integration
+    def test_get_resolved_history(self, mock_config, mock_globals, real_db, monkeypatch):
+        """Resolved history returns recently resolved checks."""
+        monkeypatch.setattr(mylar.db, "DBConnection", lambda: _make_real_db_conn(real_db))
+
+        recent = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)).isoformat()
+        conn = sqlite3.connect(real_db)
+        conn.execute(
+            "INSERT INTO health_checks (check_type, check_name, severity, message, source, first_seen, last_seen, is_resolved, resolved_at, check_count, metadata) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, 3, ?)",
+            ['provider', 'comicvine_api', 'error', 'CV was down', 'health_check', recent, recent, recent, '{}']
+        )
+        conn.commit()
+        conn.close()
+
+        runner = HealthCheckRunner()
+        history = runner.get_resolved_history(days=30)
+        assert len(history) == 1
+        assert history[0]['check_name'] == 'comicvine_api'
+        assert history[0]['check_count'] == 3
+
+
+# ── Helper: Real DB connection wrapper ──
+
+def _make_real_db_conn(db_path):
+    """Create a real SQLite connection wrapped to match mylar.db.DBConnection interface."""
+
+    class RealDBConnection:
+        def __init__(self):
+            self._conn = sqlite3.connect(db_path)
+            self._conn.row_factory = sqlite3.Row
+
+        def select(self, query, params=None):
+            cursor = self._conn.execute(query, params or [])
+            return cursor.fetchall()
+
+        def action(self, query, params=None):
+            self._conn.execute(query, params or [])
+            self._conn.commit()
+
+        def upsert(self, table, new_values, control):
+            pass
+
+    return RealDBConnection()

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -22,6 +22,7 @@ import datetime
 import json
 import logging
 import os
+import socket
 import sqlite3
 import threading
 import time
@@ -1149,6 +1150,710 @@ class TestHealthLogHandler:
         handler.emit(record)
 
 
+# ── Unit Tests: run_all_checks() Orchestration ──
+
+class TestRunAllChecks:
+    """Tests for the run_all_checks() orchestration loop."""
+
+    @pytest.mark.unit
+    def test_disabled_returns_immediately(self, runner, mock_config, mock_globals, mock_db):
+        """When HEALTH_CHECK_ENABLED is False, run_all_checks() returns early."""
+        mock_config.HEALTH_CHECK_ENABLED = False
+        runner.run_all_checks()
+        # no results, no last_run timestamp set
+        assert runner.get_results() == []
+        assert runner.last_run_iso() is None
+
+    @pytest.mark.unit
+    def test_collects_results_from_checks(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
+        """Results from individual checks are collected and stored."""
+        # make all checks return empty except one
+        monkeypatch.setattr(runner, 'check_root_folders', lambda: [
+            HealthCheckResult('infrastructure', 'root_folder', 'error', 'Missing')
+        ])
+        monkeypatch.setattr(runner, 'check_comicvine_api', lambda: [])
+        monkeypatch.setattr(runner, 'check_indexers', lambda: [])
+        monkeypatch.setattr(runner, 'check_no_indexers', lambda: [])
+        monkeypatch.setattr(runner, 'check_download_client', lambda: [])
+        monkeypatch.setattr(runner, 'check_download_category', lambda: [])
+        monkeypatch.setattr(runner, 'check_disk_space', lambda: [])
+        monkeypatch.setattr(runner, 'check_stuck_tasks', lambda: [])
+        monkeypatch.setattr(runner, 'check_failed_postprocessing', lambda: [])
+        monkeypatch.setattr(runner, 'check_stalled_downloads', lambda: [])
+        monkeypatch.setattr(runner, 'check_update_available', lambda: [])
+        monkeypatch.setattr(runner, 'check_permissions', lambda: [])
+        monkeypatch.setattr(runner, 'check_no_download_client', lambda: [])
+        monkeypatch.setattr(runner, 'check_api_key_missing', lambda: [])
+        monkeypatch.setattr(runner, 'check_database_integrity', lambda: [])
+
+        runner.run_all_checks(force=True)
+
+        results = runner.get_results()
+        assert len(results) == 1
+        assert results[0].check_name == 'root_folder'
+        assert runner.last_run_iso() is not None
+
+    @pytest.mark.unit
+    def test_exception_in_one_check_doesnt_kill_others(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
+        """If one check throws, the rest still run."""
+        def broken_check():
+            raise RuntimeError('boom')
+
+        monkeypatch.setattr(runner, 'check_root_folders', broken_check)
+        monkeypatch.setattr(runner, 'check_comicvine_api', lambda: [
+            HealthCheckResult('provider', 'comicvine_api', 'warning', 'Rate limited')
+        ])
+        monkeypatch.setattr(runner, 'check_indexers', lambda: [])
+        monkeypatch.setattr(runner, 'check_no_indexers', lambda: [])
+        monkeypatch.setattr(runner, 'check_download_client', lambda: [])
+        monkeypatch.setattr(runner, 'check_download_category', lambda: [])
+        monkeypatch.setattr(runner, 'check_disk_space', lambda: [])
+        monkeypatch.setattr(runner, 'check_stuck_tasks', lambda: [])
+        monkeypatch.setattr(runner, 'check_failed_postprocessing', lambda: [])
+        monkeypatch.setattr(runner, 'check_stalled_downloads', lambda: [])
+        monkeypatch.setattr(runner, 'check_update_available', lambda: [])
+        monkeypatch.setattr(runner, 'check_permissions', lambda: [])
+        monkeypatch.setattr(runner, 'check_no_download_client', lambda: [])
+        monkeypatch.setattr(runner, 'check_api_key_missing', lambda: [])
+        monkeypatch.setattr(runner, 'check_database_integrity', lambda: [])
+
+        runner.run_all_checks(force=True)
+
+        results = runner.get_results()
+        assert len(results) == 1
+        assert results[0].check_name == 'comicvine_api'
+
+    @pytest.mark.unit
+    def test_sorts_results_by_severity(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
+        """Results are sorted: errors first, then warnings, then notices."""
+        monkeypatch.setattr(runner, 'check_root_folders', lambda: [])
+        monkeypatch.setattr(runner, 'check_comicvine_api', lambda: [])
+        monkeypatch.setattr(runner, 'check_indexers', lambda: [])
+        monkeypatch.setattr(runner, 'check_no_indexers', lambda: [])
+        monkeypatch.setattr(runner, 'check_download_client', lambda: [])
+        monkeypatch.setattr(runner, 'check_download_category', lambda: [])
+        monkeypatch.setattr(runner, 'check_disk_space', lambda: [])
+        monkeypatch.setattr(runner, 'check_stuck_tasks', lambda: [])
+        monkeypatch.setattr(runner, 'check_failed_postprocessing', lambda: [])
+        monkeypatch.setattr(runner, 'check_stalled_downloads', lambda: [])
+        monkeypatch.setattr(runner, 'check_update_available', lambda: [
+            HealthCheckResult('config', 'update_available', 'notice', 'Update')
+        ])
+        monkeypatch.setattr(runner, 'check_permissions', lambda: [
+            HealthCheckResult('infrastructure', 'permissions', 'error', 'Not writable')
+        ])
+        monkeypatch.setattr(runner, 'check_no_download_client', lambda: [
+            HealthCheckResult('download', 'no_download_client', 'warning', 'No client')
+        ])
+        monkeypatch.setattr(runner, 'check_api_key_missing', lambda: [])
+        monkeypatch.setattr(runner, 'check_database_integrity', lambda: [])
+
+        runner.run_all_checks(force=True)
+        results = runner.get_results()
+        severities = [r.severity for r in results]
+        assert severities == ['error', 'warning', 'notice']
+
+    @pytest.mark.unit
+    def test_updates_health_results_global(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
+        """run_all_checks() updates mylar.HEALTH_RESULTS global."""
+        monkeypatch.setattr(runner, 'check_root_folders', lambda: [
+            HealthCheckResult('infrastructure', 'root_folder', 'error', 'Missing')
+        ])
+        monkeypatch.setattr(runner, 'check_comicvine_api', lambda: [])
+        monkeypatch.setattr(runner, 'check_indexers', lambda: [])
+        monkeypatch.setattr(runner, 'check_no_indexers', lambda: [])
+        monkeypatch.setattr(runner, 'check_download_client', lambda: [])
+        monkeypatch.setattr(runner, 'check_download_category', lambda: [])
+        monkeypatch.setattr(runner, 'check_disk_space', lambda: [])
+        monkeypatch.setattr(runner, 'check_stuck_tasks', lambda: [])
+        monkeypatch.setattr(runner, 'check_failed_postprocessing', lambda: [])
+        monkeypatch.setattr(runner, 'check_stalled_downloads', lambda: [])
+        monkeypatch.setattr(runner, 'check_update_available', lambda: [])
+        monkeypatch.setattr(runner, 'check_permissions', lambda: [])
+        monkeypatch.setattr(runner, 'check_no_download_client', lambda: [])
+        monkeypatch.setattr(runner, 'check_api_key_missing', lambda: [])
+        monkeypatch.setattr(runner, 'check_database_integrity', lambda: [])
+
+        runner.run_all_checks(force=True)
+
+        assert len(mylar.HEALTH_RESULTS) == 1
+        assert mylar.HEALTH_RESULTS[0]['check_name'] == 'root_folder'
+
+    @pytest.mark.unit
+    def test_carries_forward_skipped_check_results(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
+        """Results from checks that were skipped (interval gating) are carried forward."""
+        # inject a pre-existing result for a check that won't run again
+        existing = HealthCheckResult('provider', 'comicvine_api', 'error', 'Timeout')
+        with runner._lock:
+            runner._results = [existing]
+        # set timestamp so comicvine_api was just checked (won't re-run)
+        runner._check_timestamps['comicvine_api'] = datetime.datetime.now(datetime.timezone.utc)
+
+        # stub all checks to return empty
+        monkeypatch.setattr(runner, 'check_root_folders', lambda: [])
+        monkeypatch.setattr(runner, 'check_comicvine_api', lambda: [])
+        monkeypatch.setattr(runner, 'check_indexers', lambda: [])
+        monkeypatch.setattr(runner, 'check_no_indexers', lambda: [])
+        monkeypatch.setattr(runner, 'check_download_client', lambda: [])
+        monkeypatch.setattr(runner, 'check_download_category', lambda: [])
+        monkeypatch.setattr(runner, 'check_disk_space', lambda: [])
+        monkeypatch.setattr(runner, 'check_stuck_tasks', lambda: [])
+        monkeypatch.setattr(runner, 'check_failed_postprocessing', lambda: [])
+        monkeypatch.setattr(runner, 'check_stalled_downloads', lambda: [])
+        monkeypatch.setattr(runner, 'check_update_available', lambda: [])
+        monkeypatch.setattr(runner, 'check_permissions', lambda: [])
+        monkeypatch.setattr(runner, 'check_no_download_client', lambda: [])
+        monkeypatch.setattr(runner, 'check_api_key_missing', lambda: [])
+        monkeypatch.setattr(runner, 'check_database_integrity', lambda: [])
+
+        # run without force — comicvine_api will be skipped by _should_run
+        runner.run_all_checks(force=False)
+
+        results = runner.get_results()
+        # the comicvine_api result should still be there (carried forward)
+        names = [r.check_name for r in results]
+        assert 'comicvine_api' in names
+
+
+# ── Unit Tests: Torrent Client Checks ──
+
+class TestTorrentClientChecks:
+    """Tests for torrent download client connectivity checks."""
+
+    @pytest.mark.unit
+    def test_qbittorrent_reachable_returns_empty(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_QBITTORRENT", True, raising=False)
+        monkeypatch.setattr(mock_config, "QBITTORRENT_HOST", 'http://localhost:8080', raising=False)
+        class FakeResponse:
+            status_code = 200
+        monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+
+        results = runner.check_download_client()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_qbittorrent_403_is_healthy(self, runner, mock_config, mock_globals, monkeypatch):
+        """403 from qBittorrent means reachable but auth required — not an error."""
+        monkeypatch.setattr(mylar, "USE_QBITTORRENT", True, raising=False)
+        monkeypatch.setattr(mock_config, "QBITTORRENT_HOST", 'http://localhost:8080', raising=False)
+        class FakeResponse:
+            status_code = 403
+        monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+
+        results = runner.check_download_client()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_qbittorrent_connection_error(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_QBITTORRENT", True, raising=False)
+        monkeypatch.setattr(mock_config, "QBITTORRENT_HOST", 'http://localhost:8080', raising=False)
+        def fake_err(*a, **kw):
+            raise requests.exceptions.ConnectionError("refused")
+        monkeypatch.setattr(requests, "get", fake_err)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].metadata['client'] == 'qbittorrent'
+
+    @pytest.mark.unit
+    def test_qbittorrent_timeout(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_QBITTORRENT", True, raising=False)
+        monkeypatch.setattr(mock_config, "QBITTORRENT_HOST", 'http://localhost:8080', raising=False)
+        def fake_err(*a, **kw):
+            raise requests.exceptions.Timeout("timed out")
+        monkeypatch.setattr(requests, "get", fake_err)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert 'timed out' in results[0].message.lower()
+
+    @pytest.mark.unit
+    def test_transmission_reachable_409(self, runner, mock_config, mock_globals, monkeypatch):
+        """409 from Transmission means reachable (session-id handshake) — healthy."""
+        monkeypatch.setattr(mylar, "USE_TRANSMISSION", True, raising=False)
+        monkeypatch.setattr(mock_config, "TRANSMISSION_HOST", 'http://localhost:9091', raising=False)
+        class FakeResponse:
+            status_code = 409
+        monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+
+        results = runner.check_download_client()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_transmission_connection_error(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_TRANSMISSION", True, raising=False)
+        monkeypatch.setattr(mock_config, "TRANSMISSION_HOST", 'http://localhost:9091', raising=False)
+        def fake_err(*a, **kw):
+            raise requests.exceptions.ConnectionError("refused")
+        monkeypatch.setattr(requests, "get", fake_err)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].metadata['client'] == 'transmission'
+
+    @pytest.mark.unit
+    def test_rtorrent_reachable_returns_empty(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_RTORRENT", True, raising=False)
+        monkeypatch.setattr(mock_config, "RTORRENT_HOST", 'http://localhost:8000', raising=False)
+        monkeypatch.setattr(mock_config, "RTORRENT_RPC_URL", '/RPC2', raising=False)
+        monkeypatch.setattr(mock_config, "RTORRENT_VERIFY", False, raising=False)
+        class FakeResponse:
+            status_code = 200
+        monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+
+        results = runner.check_download_client()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_rtorrent_connection_error(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_RTORRENT", True, raising=False)
+        monkeypatch.setattr(mock_config, "RTORRENT_HOST", 'http://localhost:8000', raising=False)
+        monkeypatch.setattr(mock_config, "RTORRENT_RPC_URL", '/RPC2', raising=False)
+        monkeypatch.setattr(mock_config, "RTORRENT_VERIFY", False, raising=False)
+        def fake_err(*a, **kw):
+            raise requests.exceptions.ConnectionError("refused")
+        monkeypatch.setattr(requests, "get", fake_err)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].metadata['client'] == 'rtorrent'
+
+    @pytest.mark.unit
+    def test_rtorrent_timeout(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_RTORRENT", True, raising=False)
+        monkeypatch.setattr(mock_config, "RTORRENT_HOST", 'http://localhost:8000', raising=False)
+        monkeypatch.setattr(mock_config, "RTORRENT_RPC_URL", '/RPC2', raising=False)
+        monkeypatch.setattr(mock_config, "RTORRENT_VERIFY", False, raising=False)
+        def fake_err(*a, **kw):
+            raise requests.exceptions.Timeout("timed out")
+        monkeypatch.setattr(requests, "get", fake_err)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].metadata['client'] == 'rtorrent'
+
+    @pytest.mark.unit
+    def test_deluge_reachable_returns_empty(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_DELUGE", True, raising=False)
+        monkeypatch.setattr(mock_config, "DELUGE_HOST", 'localhost:58846', raising=False)
+        # mock socket.create_connection to succeed
+        class FakeSocket:
+            def close(self):
+                pass
+        monkeypatch.setattr(socket, "create_connection", lambda *a, **kw: FakeSocket())
+
+        results = runner.check_download_client()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_deluge_connection_failed(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_DELUGE", True, raising=False)
+        monkeypatch.setattr(mock_config, "DELUGE_HOST", 'localhost:58846', raising=False)
+        def fake_err(*a, **kw):
+            raise socket.error("Connection refused")
+        monkeypatch.setattr(socket, "create_connection", fake_err)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].metadata['client'] == 'deluge'
+
+    @pytest.mark.unit
+    def test_deluge_default_port(self, runner, mock_config, mock_globals, monkeypatch):
+        """Host without port uses default Deluge daemon port 58846."""
+        monkeypatch.setattr(mylar, "USE_DELUGE", True, raising=False)
+        monkeypatch.setattr(mock_config, "DELUGE_HOST", 'myserver', raising=False)
+        captured = {}
+        class FakeSocket:
+            def close(self):
+                pass
+        def capture_connect(addr, **kw):
+            captured['addr'] = addr
+            return FakeSocket()
+        monkeypatch.setattr(socket, "create_connection", capture_connect)
+
+        runner.check_download_client()
+        assert captured['addr'] == ('myserver', 58846)
+
+    @pytest.mark.unit
+    def test_utorrent_reachable_returns_empty(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_UTORRENT", True, raising=False)
+        monkeypatch.setattr(mock_config, "UTORRENT_HOST", 'http://localhost:8080', raising=False)
+        class FakeResponse:
+            status_code = 200
+        monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+
+        results = runner.check_download_client()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_utorrent_401_is_healthy(self, runner, mock_config, mock_globals, monkeypatch):
+        """401 from uTorrent means reachable but auth required — healthy."""
+        monkeypatch.setattr(mylar, "USE_UTORRENT", True, raising=False)
+        monkeypatch.setattr(mock_config, "UTORRENT_HOST", 'http://localhost:8080', raising=False)
+        class FakeResponse:
+            status_code = 401
+        monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse())
+
+        results = runner.check_download_client()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_utorrent_connection_error(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_UTORRENT", True, raising=False)
+        monkeypatch.setattr(mock_config, "UTORRENT_HOST", 'http://localhost:8080', raising=False)
+        def fake_err(*a, **kw):
+            raise requests.exceptions.ConnectionError("refused")
+        monkeypatch.setattr(requests, "get", fake_err)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].metadata['client'] == 'utorrent'
+
+    @pytest.mark.unit
+    def test_utorrent_timeout(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_UTORRENT", True, raising=False)
+        monkeypatch.setattr(mock_config, "UTORRENT_HOST", 'http://localhost:8080', raising=False)
+        def fake_err(*a, **kw):
+            raise requests.exceptions.Timeout("timed out")
+        monkeypatch.setattr(requests, "get", fake_err)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].metadata['client'] == 'utorrent'
+
+
+# ── Unit Tests: NZBGet Protocol Parsing ──
+
+class TestNZBGetCheck:
+    """Tests for NZBGet connectivity including protocol URL construction."""
+
+    @pytest.mark.unit
+    def test_nzbget_https_prefix(self, runner, mock_config, mock_globals, monkeypatch):
+        """NZBGet host with https:// prefix is handled correctly."""
+        monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
+        mock_config.NZBGET_HOST = 'https://nzbget.local'
+        mock_config.NZBGET_PORT = '6789'
+        captured = {}
+        class FakeResponse:
+            status_code = 200
+        def capture_get(url, **kw):
+            captured['url'] = url
+            return FakeResponse()
+        monkeypatch.setattr(requests, "get", capture_get)
+
+        results = runner.check_download_client()
+        assert results == []
+        assert captured['url'].startswith('https://')
+
+    @pytest.mark.unit
+    def test_nzbget_http_prefix(self, runner, mock_config, mock_globals, monkeypatch):
+        """NZBGet host with http:// prefix is handled correctly."""
+        monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
+        mock_config.NZBGET_HOST = 'http://nzbget.local'
+        mock_config.NZBGET_PORT = '6789'
+        captured = {}
+        class FakeResponse:
+            status_code = 200
+        def capture_get(url, **kw):
+            captured['url'] = url
+            return FakeResponse()
+        monkeypatch.setattr(requests, "get", capture_get)
+
+        results = runner.check_download_client()
+        assert results == []
+        assert 'http://nzbget.local:6789' in captured['url']
+
+    @pytest.mark.unit
+    def test_nzbget_no_prefix(self, runner, mock_config, mock_globals, monkeypatch):
+        """NZBGet host without protocol prefix defaults to http."""
+        monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
+        mock_config.NZBGET_HOST = 'nzbget.local'
+        mock_config.NZBGET_PORT = '6789'
+        captured = {}
+        class FakeResponse:
+            status_code = 200
+        def capture_get(url, **kw):
+            captured['url'] = url
+            return FakeResponse()
+        monkeypatch.setattr(requests, "get", capture_get)
+
+        results = runner.check_download_client()
+        assert results == []
+        assert captured['url'].startswith('http://')
+
+    @pytest.mark.unit
+    def test_nzbget_non200_returns_error(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
+        mock_config.NZBGET_HOST = 'localhost'
+        mock_config.NZBGET_PORT = '6789'
+        class FakeResponse:
+            status_code = 500
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: FakeResponse())
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].metadata['client'] == 'nzbget'
+
+    @pytest.mark.unit
+    def test_nzbget_connection_error(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
+        mock_config.NZBGET_HOST = 'localhost'
+        mock_config.NZBGET_PORT = '6789'
+        def fake_err(*a, **kw):
+            raise requests.exceptions.ConnectionError("refused")
+        monkeypatch.setattr(requests, "get", fake_err)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].metadata['client'] == 'nzbget'
+
+    @pytest.mark.unit
+    def test_nzbget_timeout(self, runner, mock_config, mock_globals, monkeypatch):
+        monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
+        mock_config.NZBGET_HOST = 'localhost'
+        mock_config.NZBGET_PORT = '6789'
+        def fake_err(*a, **kw):
+            raise requests.exceptions.Timeout("timed out")
+        monkeypatch.setattr(requests, "get", fake_err)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].metadata['client'] == 'nzbget'
+
+
+# ── Unit Tests: Failed Post-Processing Check ──
+
+class TestFailedPostProcessing:
+    """Tests for check_failed_postprocessing() — recent failure detection."""
+
+    @pytest.mark.unit
+    def test_no_failures_returns_empty(self, runner, mock_config, mock_globals, mock_db):
+        mock_db._data = [{'cnt': 0}]
+        results = runner.check_failed_postprocessing()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_few_failures_returns_empty(self, runner, mock_config, mock_globals, mock_db):
+        """5 or fewer failures in 24h is within tolerance."""
+        mock_db._data = [{'cnt': 5}]
+        results = runner.check_failed_postprocessing()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_many_failures_returns_warning(self, runner, mock_config, mock_globals, mock_db):
+        mock_db._data = [{'cnt': 12}]
+        results = runner.check_failed_postprocessing()
+        assert len(results) == 1
+        assert results[0].severity == 'warning'
+        assert results[0].check_name == 'failed_postprocessing'
+        assert '12' in results[0].message
+
+    @pytest.mark.unit
+    def test_db_exception_returns_empty(self, runner, mock_config, mock_globals, monkeypatch):
+        """DB error is caught gracefully."""
+        def broken_db():
+            raise Exception("DB locked")
+        monkeypatch.setattr(mylar.db, "DBConnection", broken_db)
+        results = runner.check_failed_postprocessing()
+        assert results == []
+
+
+# ── Unit Tests: SSE Push & Misc Private Helpers ──
+
+class TestSSEAndHelpers:
+    """Tests for _push_sse(), clear_resolved_history(), and edge cases."""
+
+    @pytest.mark.unit
+    def test_push_sse_populates_global_messages(self, runner, mock_config, mock_globals):
+        """_push_sse() writes health_update event to GLOBAL_MESSAGES."""
+        result = HealthCheckResult('infrastructure', 'root_folder', 'error', 'Missing')
+        runner._push_sse([result])
+        assert mylar.GLOBAL_MESSAGES.get('event') == 'health_update'
+        assert 'data' in mylar.GLOBAL_MESSAGES
+
+    @pytest.mark.unit
+    def test_push_sse_exception_doesnt_raise(self, runner, mock_config, mock_globals, monkeypatch):
+        """_push_sse() must never crash, even with broken data."""
+        # force json.dumps to fail
+        monkeypatch.setattr(json, "dumps", lambda *a, **kw: (_ for _ in ()).throw(TypeError("boom")))
+        # should not raise
+        runner._push_sse([])
+
+    @pytest.mark.unit
+    def test_clear_resolved_history(self, runner, mock_db):
+        """clear_resolved_history() calls DELETE on resolved records."""
+        calls = []
+        mock_db.action = lambda q, p=None: calls.append(q)
+        runner.clear_resolved_history()
+        assert any('DELETE' in c for c in calls)
+
+    @pytest.mark.unit
+    def test_clear_resolved_history_exception(self, runner, monkeypatch):
+        """clear_resolved_history() catches DB exceptions gracefully."""
+        def broken_db():
+            raise Exception("DB locked")
+        monkeypatch.setattr(mylar.db, "DBConnection", broken_db)
+        # should not raise
+        runner.clear_resolved_history()
+
+    @pytest.mark.unit
+    def test_load_from_db_exception(self, runner, monkeypatch):
+        """load_from_db() catches DB exceptions gracefully."""
+        def broken_db():
+            raise Exception("DB locked")
+        monkeypatch.setattr(mylar.db, "DBConnection", broken_db)
+        # should not raise
+        runner.load_from_db()
+        assert runner.get_results() == []
+
+    @pytest.mark.unit
+    def test_get_resolved_history_default_days(self, runner, mock_config, mock_db):
+        """get_resolved_history() uses HEALTH_HISTORY_DAYS when days param is None."""
+        mock_config.HEALTH_HISTORY_DAYS = 30
+        mock_db._data = []
+        result = runner.get_resolved_history(days=None)
+        assert result == []
+
+
+# ── Unit Tests: Edge Cases in Existing Checks ──
+
+class TestCheckEdgeCases:
+    """Tests for edge-case branches in individual check methods."""
+
+    @pytest.mark.unit
+    def test_comicvine_generic_exception(self, runner, mock_config, mock_globals, monkeypatch):
+        """Generic exception in ComicVine check is caught."""
+        def fake_err(*a, **kw):
+            raise ValueError("unexpected error")
+        monkeypatch.setattr(requests, "get", fake_err)
+
+        results = runner.check_comicvine_api()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert 'unexpected error' in results[0].message
+
+    @pytest.mark.unit
+    def test_sabnzbd_non200_returns_error(self, runner, mock_config, mock_globals, monkeypatch):
+        """SABnzbd returning non-200 status reports error."""
+        monkeypatch.setattr(mylar, "USE_SABNZBD", True, raising=False)
+        class FakeResponse:
+            status_code = 500
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: FakeResponse())
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].metadata['client'] == 'sabnzbd'
+        assert '500' in results[0].message
+
+    @pytest.mark.unit
+    def test_sabnzbd_generic_exception(self, runner, mock_config, mock_globals, monkeypatch):
+        """Generic exception in SABnzbd check is caught."""
+        monkeypatch.setattr(mylar, "USE_SABNZBD", True, raising=False)
+        def fake_err(*a, **kw):
+            raise ValueError("something broke")
+        monkeypatch.setattr(requests, "get", fake_err)
+
+        results = runner.check_download_client()
+        assert len(results) == 1
+        assert results[0].metadata['client'] == 'sabnzbd'
+
+    @pytest.mark.unit
+    def test_disk_space_oserror_handled(self, runner, mock_config, mock_globals, tmp_path, monkeypatch):
+        """OSError during disk_usage() is caught gracefully."""
+        import shutil
+        mock_config.DESTINATION_DIR = str(tmp_path)
+        mock_config.CACHE_DIR = None
+        original_disk_usage = shutil.disk_usage
+        def broken_usage(path):
+            raise OSError("Permission denied")
+        monkeypatch.setattr(shutil, "disk_usage", broken_usage)
+
+        results = runner.check_disk_space()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_indexer_blocklist_reason(self, runner, mock_config, mock_globals, monkeypatch):
+        """Blocked indexer includes reason from PROVIDER_BLOCKLIST."""
+        monkeypatch.setattr(mylar, "PROVIDER_STATUS", {'NZBgeek': 'fail'}, raising=False)
+        monkeypatch.setattr(mylar, "PROVIDER_BLOCKLIST", [
+            {'site': 'NZBgeek', 'reason': 'API limit exceeded'}
+        ], raising=False)
+
+        results = runner.check_indexers()
+        assert len(results) == 1
+        assert 'API limit exceeded' in results[0].message
+
+    @pytest.mark.unit
+    def test_no_indexers_experimental_returns_empty(self, runner, mock_config, mock_globals):
+        """EXPERIMENTAL flag counts as having a search provider."""
+        mock_config.EXTRA_NEWZNABS = []
+        mock_config.EXTRA_TORZNABS = []
+        mock_config.ENABLE_TORRENT_SEARCH = False
+        mock_config.EXPERIMENTAL = True
+
+        results = runner.check_no_indexers()
+        assert results == []
+
+    @pytest.mark.unit
+    def test_database_integrity_exception(self, runner, monkeypatch):
+        """Exception during integrity check creates error result."""
+        def broken_db():
+            raise Exception("DB connection failed")
+        monkeypatch.setattr(mylar.db, "DBConnection", broken_db)
+
+        results = runner.check_database_integrity()
+        assert len(results) == 1
+        assert results[0].severity == 'error'
+        assert results[0].check_name == 'database_integrity'
+
+    @pytest.mark.unit
+    def test_stuck_tasks_naive_timestamp(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
+        """Naive timestamp (no timezone) is handled by adding UTC."""
+        monkeypatch.setattr(mylar, "MONITOR_STATUS", 'Running', raising=False)
+        # use a naive ISO timestamp (no +00:00)
+        two_hours_ago = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=2))
+        naive_str = two_hours_ago.strftime('%Y-%m-%dT%H:%M:%S')
+        mock_db._data = [{'current_run': naive_str}]
+
+        results = runner.check_stuck_tasks()
+        assert len(results) >= 1
+        assert results[0].severity == 'warning'
+
+    @pytest.mark.unit
+    def test_stuck_tasks_invalid_timestamp(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
+        """Invalid timestamp string is caught by ValueError handler."""
+        monkeypatch.setattr(mylar, "MONITOR_STATUS", 'Running', raising=False)
+        mock_db._data = [{'current_run': 'not-a-date'}]
+
+        results = runner.check_stuck_tasks()
+        # ValueError is caught, no result produced for this task
+        assert results == []
+
+    @pytest.mark.unit
+    def test_deferred_stubs_return_empty(self, runner, mock_config, mock_globals, mock_db):
+        """Deferred stubs return empty list."""
+        assert runner.check_download_category() == []
+        assert runner.check_stalled_downloads() == []
+
+    @pytest.mark.unit
+    def test_emit_outer_exception_caught(self, mock_globals, monkeypatch):
+        """emit() outer try/except catches any unexpected errors."""
+        handler = HealthLogHandler()
+        # create a record that will cause getMessage() to fail on second call
+        record = logging.LogRecord(
+            name='mylar', level=logging.WARNING, pathname='test.py',
+            lineno=1, msg='Permission denied', args=(), exc_info=None,
+        )
+        # force an exception inside emit by making HEALTH_CHECK.ingest_log_finding crash
+        class BrokenRunner:
+            def ingest_log_finding(self, r):
+                raise RuntimeError("boom")
+        monkeypatch.setattr(mylar, "HEALTH_CHECK", BrokenRunner(), raising=False)
+
+        # should not raise
+        handler.emit(record)
+
+
 # ── Unit Tests: Database Operations ──
 
 class TestDatabaseOperations:
@@ -1316,5 +2021,13 @@ def _make_real_db_conn(db_path):
 
         def upsert(self, table, new_values, control):
             pass
+
+        def close(self):
+            if self._conn:
+                self._conn.close()
+                self._conn = None
+
+        def __del__(self):
+            self.close()
 
     return RealDBConnection()

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -25,12 +25,12 @@ import os
 import socket
 import sqlite3
 import threading
-import time
-
+# noinspection PyPackageRequirements
 import pytest
 import requests
 
 import mylar
+import mylar.db
 from mylar.healthcheck import HealthCheckResult, HealthCheckRunner, HealthLogHandler
 
 
@@ -102,7 +102,7 @@ def mock_db(monkeypatch):
         def __init__(self):
             self._data = []
 
-        def select(self, query, params=None):
+        def select(self, _query, _params=None):
             return self._data
 
         def action(self, query, params=None):
@@ -136,7 +136,7 @@ def real_db(tmp_path, monkeypatch):
               'severity TEXT NOT NULL, '
               'message TEXT NOT NULL, '
               'wiki_url TEXT, '
-              'source TEXT DEFAULT "health_check", '
+              "source TEXT DEFAULT 'health_check', "
               'first_seen TEXT NOT NULL, '
               'last_seen TEXT NOT NULL, '
               'is_resolved INTEGER DEFAULT 0, '
@@ -546,7 +546,7 @@ class TestComicVineCheck:
 
     @pytest.mark.unit
     def test_timeout_returns_error(self, runner, mock_config, mock_globals, monkeypatch):
-        def fake_timeout(*args, **kwargs):
+        def fake_timeout(*_args, **_kwargs):
             raise requests.exceptions.Timeout("Connection timed out")
         monkeypatch.setattr(requests, "get", fake_timeout)
 
@@ -557,7 +557,7 @@ class TestComicVineCheck:
 
     @pytest.mark.unit
     def test_connection_error_returns_error(self, runner, mock_config, mock_globals, monkeypatch):
-        def fake_conn_error(*args, **kwargs):
+        def fake_conn_error(*_args, **_kwargs):
             raise requests.exceptions.ConnectionError("Connection refused")
         monkeypatch.setattr(requests, "get", fake_conn_error)
 
@@ -611,7 +611,7 @@ class TestComicVineCheck:
         captured = {}
         class FakeResponse:
             status_code = 200
-        def capture_get(*args, **kwargs):
+        def capture_get(*_args, **kwargs):
             captured.update(kwargs)
             return FakeResponse()
         monkeypatch.setattr(requests, "get", capture_get)
@@ -769,7 +769,7 @@ class TestDownloadClientCheck:
     def test_sabnzbd_unreachable_returns_error(self, runner, mock_config, mock_globals, monkeypatch):
         monkeypatch.setattr(mylar, "USE_SABNZBD", True, raising=False)
 
-        def fake_conn_error(*args, **kwargs):
+        def fake_conn_error(*_args, **_kwargs):
             raise requests.exceptions.ConnectionError("Connection refused")
         monkeypatch.setattr(requests, "get", fake_conn_error)
 
@@ -782,7 +782,7 @@ class TestDownloadClientCheck:
     def test_sabnzbd_timeout_returns_error(self, runner, mock_config, mock_globals, monkeypatch):
         monkeypatch.setattr(mylar, "USE_SABNZBD", True, raising=False)
 
-        def fake_timeout(*args, **kwargs):
+        def fake_timeout(*_args, **_kwargs):
             raise requests.exceptions.Timeout("timed out")
         monkeypatch.setattr(requests, "get", fake_timeout)
 
@@ -815,7 +815,7 @@ class TestDownloadClientCheck:
         captured = {}
         class FakeResponse:
             status_code = 200
-        def capture_get(*args, **kwargs):
+        def capture_get(*_args, **kwargs):
             captured.update(kwargs)
             return FakeResponse()
         monkeypatch.setattr(requests, "get", capture_get)
@@ -834,6 +834,7 @@ class TestNoIndexersCheck:
         # simulate one enabled newznab provider
         # tuple format: (name, host, verify, apikey, uid, enabled, id)
         mock_config.EXTRA_NEWZNABS = [
+            # noinspection HttpUrlsUsage
             ('TestProvider', 'http://example.com', False, 'key123', '0', '1', '0')
         ]
 
@@ -1010,7 +1011,8 @@ class TestSimpleChecks:
 class TestHealthLogHandler:
     """Tests for the HealthLogHandler log interceptor."""
 
-    def _make_record(self, message, level=logging.WARNING):
+    @staticmethod
+    def _make_record(message, level=logging.WARNING):
         """Helper to create a log record."""
         record = logging.LogRecord(
             name='mylar',
@@ -1152,6 +1154,20 @@ class TestHealthLogHandler:
 
 # ── Unit Tests: run_all_checks() Orchestration ──
 
+def _stub_all_checks(monkeypatch, runner, overrides=None):
+    """Stub all runner check methods to return empty lists, with optional overrides."""
+    check_methods = [
+        'check_root_folders', 'check_comicvine_api', 'check_indexers',
+        'check_no_indexers', 'check_download_client', 'check_download_category',
+        'check_disk_space', 'check_stuck_tasks', 'check_failed_postprocessing',
+        'check_stalled_downloads', 'check_update_available', 'check_permissions',
+        'check_no_download_client', 'check_api_key_missing', 'check_database_integrity',
+    ]
+    overrides = overrides or {}
+    for method in check_methods:
+        monkeypatch.setattr(runner, method, overrides.get(method, lambda: []))
+
+
 class TestRunAllChecks:
     """Tests for the run_all_checks() orchestration loop."""
 
@@ -1167,24 +1183,11 @@ class TestRunAllChecks:
     @pytest.mark.unit
     def test_collects_results_from_checks(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
         """Results from individual checks are collected and stored."""
-        # make all checks return empty except one
-        monkeypatch.setattr(runner, 'check_root_folders', lambda: [
-            HealthCheckResult('infrastructure', 'root_folder', 'error', 'Missing')
-        ])
-        monkeypatch.setattr(runner, 'check_comicvine_api', lambda: [])
-        monkeypatch.setattr(runner, 'check_indexers', lambda: [])
-        monkeypatch.setattr(runner, 'check_no_indexers', lambda: [])
-        monkeypatch.setattr(runner, 'check_download_client', lambda: [])
-        monkeypatch.setattr(runner, 'check_download_category', lambda: [])
-        monkeypatch.setattr(runner, 'check_disk_space', lambda: [])
-        monkeypatch.setattr(runner, 'check_stuck_tasks', lambda: [])
-        monkeypatch.setattr(runner, 'check_failed_postprocessing', lambda: [])
-        monkeypatch.setattr(runner, 'check_stalled_downloads', lambda: [])
-        monkeypatch.setattr(runner, 'check_update_available', lambda: [])
-        monkeypatch.setattr(runner, 'check_permissions', lambda: [])
-        monkeypatch.setattr(runner, 'check_no_download_client', lambda: [])
-        monkeypatch.setattr(runner, 'check_api_key_missing', lambda: [])
-        monkeypatch.setattr(runner, 'check_database_integrity', lambda: [])
+        _stub_all_checks(monkeypatch, runner, overrides={
+            'check_root_folders': lambda: [
+                HealthCheckResult('infrastructure', 'root_folder', 'error', 'Missing')
+            ],
+        })
 
         runner.run_all_checks(force=True)
 
@@ -1199,23 +1202,12 @@ class TestRunAllChecks:
         def broken_check():
             raise RuntimeError('boom')
 
-        monkeypatch.setattr(runner, 'check_root_folders', broken_check)
-        monkeypatch.setattr(runner, 'check_comicvine_api', lambda: [
-            HealthCheckResult('provider', 'comicvine_api', 'warning', 'Rate limited')
-        ])
-        monkeypatch.setattr(runner, 'check_indexers', lambda: [])
-        monkeypatch.setattr(runner, 'check_no_indexers', lambda: [])
-        monkeypatch.setattr(runner, 'check_download_client', lambda: [])
-        monkeypatch.setattr(runner, 'check_download_category', lambda: [])
-        monkeypatch.setattr(runner, 'check_disk_space', lambda: [])
-        monkeypatch.setattr(runner, 'check_stuck_tasks', lambda: [])
-        monkeypatch.setattr(runner, 'check_failed_postprocessing', lambda: [])
-        monkeypatch.setattr(runner, 'check_stalled_downloads', lambda: [])
-        monkeypatch.setattr(runner, 'check_update_available', lambda: [])
-        monkeypatch.setattr(runner, 'check_permissions', lambda: [])
-        monkeypatch.setattr(runner, 'check_no_download_client', lambda: [])
-        monkeypatch.setattr(runner, 'check_api_key_missing', lambda: [])
-        monkeypatch.setattr(runner, 'check_database_integrity', lambda: [])
+        _stub_all_checks(monkeypatch, runner, overrides={
+            'check_root_folders': broken_check,
+            'check_comicvine_api': lambda: [
+                HealthCheckResult('provider', 'comicvine_api', 'warning', 'Rate limited')
+            ],
+        })
 
         runner.run_all_checks(force=True)
 
@@ -1226,27 +1218,17 @@ class TestRunAllChecks:
     @pytest.mark.unit
     def test_sorts_results_by_severity(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
         """Results are sorted: errors first, then warnings, then notices."""
-        monkeypatch.setattr(runner, 'check_root_folders', lambda: [])
-        monkeypatch.setattr(runner, 'check_comicvine_api', lambda: [])
-        monkeypatch.setattr(runner, 'check_indexers', lambda: [])
-        monkeypatch.setattr(runner, 'check_no_indexers', lambda: [])
-        monkeypatch.setattr(runner, 'check_download_client', lambda: [])
-        monkeypatch.setattr(runner, 'check_download_category', lambda: [])
-        monkeypatch.setattr(runner, 'check_disk_space', lambda: [])
-        monkeypatch.setattr(runner, 'check_stuck_tasks', lambda: [])
-        monkeypatch.setattr(runner, 'check_failed_postprocessing', lambda: [])
-        monkeypatch.setattr(runner, 'check_stalled_downloads', lambda: [])
-        monkeypatch.setattr(runner, 'check_update_available', lambda: [
-            HealthCheckResult('config', 'update_available', 'notice', 'Update')
-        ])
-        monkeypatch.setattr(runner, 'check_permissions', lambda: [
-            HealthCheckResult('infrastructure', 'permissions', 'error', 'Not writable')
-        ])
-        monkeypatch.setattr(runner, 'check_no_download_client', lambda: [
-            HealthCheckResult('download', 'no_download_client', 'warning', 'No client')
-        ])
-        monkeypatch.setattr(runner, 'check_api_key_missing', lambda: [])
-        monkeypatch.setattr(runner, 'check_database_integrity', lambda: [])
+        _stub_all_checks(monkeypatch, runner, overrides={
+            'check_update_available': lambda: [
+                HealthCheckResult('config', 'update_available', 'notice', 'Update')
+            ],
+            'check_permissions': lambda: [
+                HealthCheckResult('infrastructure', 'permissions', 'error', 'Not writable')
+            ],
+            'check_no_download_client': lambda: [
+                HealthCheckResult('download', 'no_download_client', 'warning', 'No client')
+            ],
+        })
 
         runner.run_all_checks(force=True)
         results = runner.get_results()
@@ -1256,23 +1238,11 @@ class TestRunAllChecks:
     @pytest.mark.unit
     def test_updates_health_results_global(self, runner, mock_config, mock_globals, mock_db, monkeypatch):
         """run_all_checks() updates mylar.HEALTH_RESULTS global."""
-        monkeypatch.setattr(runner, 'check_root_folders', lambda: [
-            HealthCheckResult('infrastructure', 'root_folder', 'error', 'Missing')
-        ])
-        monkeypatch.setattr(runner, 'check_comicvine_api', lambda: [])
-        monkeypatch.setattr(runner, 'check_indexers', lambda: [])
-        monkeypatch.setattr(runner, 'check_no_indexers', lambda: [])
-        monkeypatch.setattr(runner, 'check_download_client', lambda: [])
-        monkeypatch.setattr(runner, 'check_download_category', lambda: [])
-        monkeypatch.setattr(runner, 'check_disk_space', lambda: [])
-        monkeypatch.setattr(runner, 'check_stuck_tasks', lambda: [])
-        monkeypatch.setattr(runner, 'check_failed_postprocessing', lambda: [])
-        monkeypatch.setattr(runner, 'check_stalled_downloads', lambda: [])
-        monkeypatch.setattr(runner, 'check_update_available', lambda: [])
-        monkeypatch.setattr(runner, 'check_permissions', lambda: [])
-        monkeypatch.setattr(runner, 'check_no_download_client', lambda: [])
-        monkeypatch.setattr(runner, 'check_api_key_missing', lambda: [])
-        monkeypatch.setattr(runner, 'check_database_integrity', lambda: [])
+        _stub_all_checks(monkeypatch, runner, overrides={
+            'check_root_folders': lambda: [
+                HealthCheckResult('infrastructure', 'root_folder', 'error', 'Missing')
+            ],
+        })
 
         runner.run_all_checks(force=True)
 
@@ -1289,22 +1259,7 @@ class TestRunAllChecks:
         # set timestamp so comicvine_api was just checked (won't re-run)
         runner._check_timestamps['comicvine_api'] = datetime.datetime.now(datetime.timezone.utc)
 
-        # stub all checks to return empty
-        monkeypatch.setattr(runner, 'check_root_folders', lambda: [])
-        monkeypatch.setattr(runner, 'check_comicvine_api', lambda: [])
-        monkeypatch.setattr(runner, 'check_indexers', lambda: [])
-        monkeypatch.setattr(runner, 'check_no_indexers', lambda: [])
-        monkeypatch.setattr(runner, 'check_download_client', lambda: [])
-        monkeypatch.setattr(runner, 'check_download_category', lambda: [])
-        monkeypatch.setattr(runner, 'check_disk_space', lambda: [])
-        monkeypatch.setattr(runner, 'check_stuck_tasks', lambda: [])
-        monkeypatch.setattr(runner, 'check_failed_postprocessing', lambda: [])
-        monkeypatch.setattr(runner, 'check_stalled_downloads', lambda: [])
-        monkeypatch.setattr(runner, 'check_update_available', lambda: [])
-        monkeypatch.setattr(runner, 'check_permissions', lambda: [])
-        monkeypatch.setattr(runner, 'check_no_download_client', lambda: [])
-        monkeypatch.setattr(runner, 'check_api_key_missing', lambda: [])
-        monkeypatch.setattr(runner, 'check_database_integrity', lambda: [])
+        _stub_all_checks(monkeypatch, runner)
 
         # run without force — comicvine_api will be skipped by _should_run
         runner.run_all_checks(force=False)
@@ -1347,7 +1302,7 @@ class TestTorrentClientChecks:
     def test_qbittorrent_connection_error(self, runner, mock_config, mock_globals, monkeypatch):
         monkeypatch.setattr(mylar, "USE_QBITTORRENT", True, raising=False)
         monkeypatch.setattr(mock_config, "QBITTORRENT_HOST", 'http://localhost:8080', raising=False)
-        def fake_err(*a, **kw):
+        def fake_err(*_a, **_kw):
             raise requests.exceptions.ConnectionError("refused")
         monkeypatch.setattr(requests, "get", fake_err)
 
@@ -1359,7 +1314,7 @@ class TestTorrentClientChecks:
     def test_qbittorrent_timeout(self, runner, mock_config, mock_globals, monkeypatch):
         monkeypatch.setattr(mylar, "USE_QBITTORRENT", True, raising=False)
         monkeypatch.setattr(mock_config, "QBITTORRENT_HOST", 'http://localhost:8080', raising=False)
-        def fake_err(*a, **kw):
+        def fake_err(*_a, **_kw):
             raise requests.exceptions.Timeout("timed out")
         monkeypatch.setattr(requests, "get", fake_err)
 
@@ -1383,7 +1338,7 @@ class TestTorrentClientChecks:
     def test_transmission_connection_error(self, runner, mock_config, mock_globals, monkeypatch):
         monkeypatch.setattr(mylar, "USE_TRANSMISSION", True, raising=False)
         monkeypatch.setattr(mock_config, "TRANSMISSION_HOST", 'http://localhost:9091', raising=False)
-        def fake_err(*a, **kw):
+        def fake_err(*_a, **_kw):
             raise requests.exceptions.ConnectionError("refused")
         monkeypatch.setattr(requests, "get", fake_err)
 
@@ -1410,7 +1365,7 @@ class TestTorrentClientChecks:
         monkeypatch.setattr(mock_config, "RTORRENT_HOST", 'http://localhost:8000', raising=False)
         monkeypatch.setattr(mock_config, "RTORRENT_RPC_URL", '/RPC2', raising=False)
         monkeypatch.setattr(mock_config, "RTORRENT_VERIFY", False, raising=False)
-        def fake_err(*a, **kw):
+        def fake_err(*_a, **_kw):
             raise requests.exceptions.ConnectionError("refused")
         monkeypatch.setattr(requests, "get", fake_err)
 
@@ -1424,7 +1379,7 @@ class TestTorrentClientChecks:
         monkeypatch.setattr(mock_config, "RTORRENT_HOST", 'http://localhost:8000', raising=False)
         monkeypatch.setattr(mock_config, "RTORRENT_RPC_URL", '/RPC2', raising=False)
         monkeypatch.setattr(mock_config, "RTORRENT_VERIFY", False, raising=False)
-        def fake_err(*a, **kw):
+        def fake_err(*_a, **_kw):
             raise requests.exceptions.Timeout("timed out")
         monkeypatch.setattr(requests, "get", fake_err)
 
@@ -1449,7 +1404,7 @@ class TestTorrentClientChecks:
     def test_deluge_connection_failed(self, runner, mock_config, mock_globals, monkeypatch):
         monkeypatch.setattr(mylar, "USE_DELUGE", True, raising=False)
         monkeypatch.setattr(mock_config, "DELUGE_HOST", 'localhost:58846', raising=False)
-        def fake_err(*a, **kw):
+        def fake_err(*_a, **_kw):
             raise socket.error("Connection refused")
         monkeypatch.setattr(socket, "create_connection", fake_err)
 
@@ -1466,7 +1421,7 @@ class TestTorrentClientChecks:
         class FakeSocket:
             def close(self):
                 pass
-        def capture_connect(addr, **kw):
+        def capture_connect(addr, **_kw):
             captured['addr'] = addr
             return FakeSocket()
         monkeypatch.setattr(socket, "create_connection", capture_connect)
@@ -1501,7 +1456,7 @@ class TestTorrentClientChecks:
     def test_utorrent_connection_error(self, runner, mock_config, mock_globals, monkeypatch):
         monkeypatch.setattr(mylar, "USE_UTORRENT", True, raising=False)
         monkeypatch.setattr(mock_config, "UTORRENT_HOST", 'http://localhost:8080', raising=False)
-        def fake_err(*a, **kw):
+        def fake_err(*_a, **_kw):
             raise requests.exceptions.ConnectionError("refused")
         monkeypatch.setattr(requests, "get", fake_err)
 
@@ -1513,7 +1468,7 @@ class TestTorrentClientChecks:
     def test_utorrent_timeout(self, runner, mock_config, mock_globals, monkeypatch):
         monkeypatch.setattr(mylar, "USE_UTORRENT", True, raising=False)
         monkeypatch.setattr(mock_config, "UTORRENT_HOST", 'http://localhost:8080', raising=False)
-        def fake_err(*a, **kw):
+        def fake_err(*_a, **_kw):
             raise requests.exceptions.Timeout("timed out")
         monkeypatch.setattr(requests, "get", fake_err)
 
@@ -1524,23 +1479,32 @@ class TestTorrentClientChecks:
 
 # ── Unit Tests: NZBGet Protocol Parsing ──
 
+def _setup_nzbget_capture(monkeypatch, mock_config, host, port='6789'):
+    """Set up NZBGet with a fake successful GET that captures the URL."""
+    monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
+    mock_config.NZBGET_HOST = host
+    mock_config.NZBGET_PORT = port
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+
+    def capture_get(url, **_kw):
+        captured['url'] = url
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "get", capture_get)
+    return captured
+
+
 class TestNZBGetCheck:
     """Tests for NZBGet connectivity including protocol URL construction."""
 
     @pytest.mark.unit
     def test_nzbget_https_prefix(self, runner, mock_config, mock_globals, monkeypatch):
         """NZBGet host with https:// prefix is handled correctly."""
-        monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
-        mock_config.NZBGET_HOST = 'https://nzbget.local'
-        mock_config.NZBGET_PORT = '6789'
-        captured = {}
-        class FakeResponse:
-            status_code = 200
-        def capture_get(url, **kw):
-            captured['url'] = url
-            return FakeResponse()
-        monkeypatch.setattr(requests, "get", capture_get)
-
+        # noinspection PyTypeChecker
+        captured = _setup_nzbget_capture(monkeypatch, mock_config, 'https://nzbget.local')
         results = runner.check_download_client()
         assert results == []
         assert captured['url'].startswith('https://')
@@ -1548,35 +1512,18 @@ class TestNZBGetCheck:
     @pytest.mark.unit
     def test_nzbget_http_prefix(self, runner, mock_config, mock_globals, monkeypatch):
         """NZBGet host with http:// prefix is handled correctly."""
-        monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
-        mock_config.NZBGET_HOST = 'http://nzbget.local'
-        mock_config.NZBGET_PORT = '6789'
-        captured = {}
-        class FakeResponse:
-            status_code = 200
-        def capture_get(url, **kw):
-            captured['url'] = url
-            return FakeResponse()
-        monkeypatch.setattr(requests, "get", capture_get)
-
+        # noinspection PyTypeChecker,HttpUrlsUsage
+        captured = _setup_nzbget_capture(monkeypatch, mock_config, 'http://nzbget.local')
         results = runner.check_download_client()
         assert results == []
+        # noinspection HttpUrlsUsage
         assert 'http://nzbget.local:6789' in captured['url']
 
     @pytest.mark.unit
     def test_nzbget_no_prefix(self, runner, mock_config, mock_globals, monkeypatch):
         """NZBGet host without protocol prefix defaults to http."""
-        monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
-        mock_config.NZBGET_HOST = 'nzbget.local'
-        mock_config.NZBGET_PORT = '6789'
-        captured = {}
-        class FakeResponse:
-            status_code = 200
-        def capture_get(url, **kw):
-            captured['url'] = url
-            return FakeResponse()
-        monkeypatch.setattr(requests, "get", capture_get)
-
+        # noinspection PyTypeChecker
+        captured = _setup_nzbget_capture(monkeypatch, mock_config, 'nzbget.local')
         results = runner.check_download_client()
         assert results == []
         assert captured['url'].startswith('http://')
@@ -1599,7 +1546,7 @@ class TestNZBGetCheck:
         monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
         mock_config.NZBGET_HOST = 'localhost'
         mock_config.NZBGET_PORT = '6789'
-        def fake_err(*a, **kw):
+        def fake_err(*_a, **_kw):
             raise requests.exceptions.ConnectionError("refused")
         monkeypatch.setattr(requests, "get", fake_err)
 
@@ -1612,7 +1559,7 @@ class TestNZBGetCheck:
         monkeypatch.setattr(mylar, "USE_NZBGET", True, raising=False)
         mock_config.NZBGET_HOST = 'localhost'
         mock_config.NZBGET_PORT = '6789'
-        def fake_err(*a, **kw):
+        def fake_err(*_a, **_kw):
             raise requests.exceptions.Timeout("timed out")
         monkeypatch.setattr(requests, "get", fake_err)
 
@@ -1723,7 +1670,7 @@ class TestCheckEdgeCases:
     @pytest.mark.unit
     def test_comicvine_generic_exception(self, runner, mock_config, mock_globals, monkeypatch):
         """Generic exception in ComicVine check is caught."""
-        def fake_err(*a, **kw):
+        def fake_err(*_a, **_kw):
             raise ValueError("unexpected error")
         monkeypatch.setattr(requests, "get", fake_err)
 
@@ -1749,7 +1696,7 @@ class TestCheckEdgeCases:
     def test_sabnzbd_generic_exception(self, runner, mock_config, mock_globals, monkeypatch):
         """Generic exception in SABnzbd check is caught."""
         monkeypatch.setattr(mylar, "USE_SABNZBD", True, raising=False)
-        def fake_err(*a, **kw):
+        def fake_err(*_a, **_kw):
             raise ValueError("something broke")
         monkeypatch.setattr(requests, "get", fake_err)
 
@@ -1763,8 +1710,7 @@ class TestCheckEdgeCases:
         import shutil
         mock_config.DESTINATION_DIR = str(tmp_path)
         mock_config.CACHE_DIR = None
-        original_disk_usage = shutil.disk_usage
-        def broken_usage(path):
+        def broken_usage(_path):
             raise OSError("Permission denied")
         monkeypatch.setattr(shutil, "disk_usage", broken_usage)
 


### PR DESCRIPTION
## Health Dashboard — System Health Monitoring for Mylar3

Closes #1802

### Summary

Adds a periodic health monitoring system that checks Mylar3's infrastructure, providers, and download clients, then reports problems through a dedicated dashboard, persistent banner, navigation badge, and real-time SSE updates. Think of it as a "check engine light" — it catches configuration issues, connectivity problems, and resource concerns before they cause silent failures.

The feature is fully enabled by default with sensible defaults, fully configurable, and can be completely disabled with a single toggle. Zero impact on existing functionality — all changes are additive.

---

### Features

**Health Dashboard Page** (`/health`)
- Summary cards showing error, warning, notice, and total counts
- DataTable with active issues — sortable, filterable, color-coded by severity (red/amber/blue)
- One-click "Run Health Check" for immediate re-scan
- Dismiss individual issues with resolution tracking
- Collapsible resolved history section with "Clear Resolved" action
- Wiki links on each issue for self-service troubleshooting
- Auto-refresh every 30 seconds via AJAX

**Persistent Banner** (all pages)
- Red error banner or amber warning banner appears below the header site-wide when active issues exist
- "View Health" link navigates directly to the dashboard
- Dismissible per session; respects `HEALTH_SHOW_BANNER` config toggle
- Dynamic padding adjustment prevents content overlap
- Hidden automatically when all issues resolve

**Navigation Badge**
- Red count badge on the gear icon showing total errors + warnings
- Disappears when system is fully healthy

**Real-Time SSE Updates**
- `health_update` events pushed to all connected browsers after each check cycle
- Banner, badge, and dashboard update without page refresh
- Integrated with Mylar3's existing `GLOBAL_MESSAGES` SSE infrastructure

**Docker HEALTHCHECK Support**
- `/ping` endpoint — no authentication required
- Returns JSON with status and health summary: `{"status": "ok", "health": {"errors": 0, "warnings": 0, "status": "healthy"}}`
- Ready for `HEALTHCHECK CMD curl -f http://localhost:8090/ping` in Dockerfiles

**API Commands**
- `getHealth` — returns full results array with metadata
- `getHealthSummary` — returns severity counts for external monitoring integration

---

### Health Checks Implemented (15 checks)

| Check | Type | Severity | What It Detects |
|-------|------|----------|-----------------|
| `root_folder` | Infrastructure | Error | Comic root folders missing, not accessible, or not readable |
| `disk_space` | Infrastructure | Warning/Error | Low disk space on storage paths (configurable GB thresholds), deduplicates same-mount checks |
| `permissions` | Infrastructure | Error | Key directories (DATA_DIR, LOG_DIR, CACHE_DIR) not writable |
| `database_integrity` | Infrastructure | Error | SQLite corruption via `PRAGMA integrity_check` |
| `comicvine_api` | Provider | Error/Warning | API timeout, connection failure, invalid key (401), rate limiting (429), server errors (5xx) |
| `no_indexers` | Provider | Error | Zero search providers enabled (newznab, torznab, torrent search, experimental) |
| `indexers` | Provider | Warning | Individual indexer failures from `PROVIDER_STATUS` with blocklist reason detail |
| `download_client` | Download | Error | SABnzbd, NZBGet, qBittorrent, Transmission, rTorrent, Deluge, and uTorrent connectivity — handles protocol-specific responses (403/409/401 as healthy-but-auth-required) |
| `no_download_client` | Config | Warning | No download client configured at all |
| `api_key_missing` | Config | Error | ComicVine API key empty, whitespace-only, or literal "None" |
| `stuck_tasks` | Task | Warning | Scheduler tasks (Monitor, Search, RSS, Weekly, Version) running longer than configurable threshold, with naive/aware timestamp handling |
| `failed_postprocessing` | Task | Warning | More than 5 post-processing failures in the last 24 hours |
| `update_available` | Config | Notice | `COMMITS_BEHIND > 0` with count in message |
| `download_category` | Download | — | Deferred (stub returns empty) |
| `stalled_downloads` | Download | — | Deferred (stub returns empty) |

**Log-Based Monitoring** (`HealthLogHandler`)
- Attaches to Mylar's logging system at WARNING+ level
- Pattern-matches known error signatures (ComicVine timeout, SABnzbd connection refused, permission denied, disk full, database locked) between scheduled check cycles
- Throttled to prevent duplicate findings; skips `[HealthCheck]`-prefixed messages to prevent infinite loops
- Deduplicates with existing scheduled check results via `ingest_log_finding()`

---

### Configuration

7 new settings under `[Health]` in `config.ini`, all with sensible defaults:

| Setting | Type | Default | Description |
|---------|------|---------|-------------|
| `HEALTH_CHECK_ENABLED` | bool | `True` | Master on/off switch — disabling stops the scheduler entirely |
| `HEALTH_CHECK_INTERVAL` | int | `5` | Minutes between check cycles |
| `HEALTH_DISK_WARN_GB` | float | `5.0` | Disk space warning threshold in GB |
| `HEALTH_DISK_ERROR_GB` | float | `1.0` | Disk space critical/error threshold in GB |
| `HEALTH_STALE_TASK_MIN` | int | `60` | Minutes before a running task is flagged as stuck |
| `HEALTH_SHOW_BANNER` | bool | `True` | Show/hide the persistent banner on all pages |
| `HEALTH_HISTORY_DAYS` | int | `30` | Days to retain resolved issue history before cleanup |

Settings are exposed in the Config page under a "Health Checks" fieldset with descriptions.

---

### Files Changed

**New Files (3)**

| File | Description | Size |
|------|-------------|------|
| `mylar/healthcheck.py` | Core engine — `HealthCheckResult`, `HealthCheckRunner` (15 checks, DB persistence, SSE push, per-check interval gating, thread-safe result management), `HealthLogHandler` (log interceptor with pattern matching) | ~1,400 lines |
| `data/interfaces/default/health.html` | Mako template — dashboard page with summary cards, DataTable, resolved history, AJAX loading, auto-refresh | ~350 lines |
| `tests/test_healthcheck.py` | Comprehensive test suite — 17 test classes, 372 tests (unit + integration) covering all checks, engine logic, DB round-trips, SSE, edge cases | ~2,200 lines |

**Modified Files (9)**

| File | What Changed |
|------|-------------|
| `mylar/__init__.py` | Added `HEALTH_CHECK`, `HEALTH_RESULTS`, `HEALTH_SCHEDULER` globals; added `health_checks` table creation with indexes in `dbcheck()`; added scheduler registration in `initialize()` with 30-second delayed start, `max_instances=1`, `coalesce=True` |
| `mylar/config.py` | Added 7 `_CONFIG_DEFINITIONS` entries under `[Health]` section |
| `mylar/webserve.py` | Added routes: `health()` (dashboard page), `getHealth()` (AJAX JSON endpoint with optional resolved history), `recheckHealth()` (manual trigger), `dismissHealth()` (acknowledge issue), `ping()` (unauthenticated health probe) |
| `mylar/api.py` | Added `getHealth` and `getHealthSummary` API commands to `cmd_list` |
| `mylar/webstart.py` | Added `/ping` to auth bypass list so Docker HEALTHCHECK works without login |
| `mylar/logger.py` | Registered `HealthLogHandler` at WARNING level in `initLogger()` with `ImportError` safety fallback |
| `data/interfaces/default/base.html` | Added health banner HTML/CSS/JS between header and main content; added nav badge on gear icon; added SSE `health_update` event listener; added `updateHealthBanner()`, `updateNavBadge()`, `adjustMainPadding()` functions; added initial AJAX health state load on every page |
| `data/interfaces/default/config.html` | Added "Health Checks" fieldset with all 7 settings (checkbox, text inputs) following existing config page patterns |
| `tests/README.md` | Full rewrite — added health check test documentation, test architecture patterns, per-class breakdown, coverage commands, manual testing cross-reference |

---

### Architecture Highlights

- **Thread-safe**: All result access goes through `threading.Lock`; network I/O happens outside the lock
- **Resilient**: Each check wrapped in individual `try/except` — one failing check never blocks the others
- **Non-blocking startup**: First check delayed 30 seconds after Mylar start; `max_instances=1` and `coalesce=True` on the APScheduler job
- **Per-check intervals**: Individual checks can run at different frequencies (e.g., DB integrity every 6 hours vs. root folders every 5 minutes) via `_should_run()` gating
- **DB persistence**: Active issues survive restarts via `_save_to_db()` / `load_from_db()`; resolved issues auto-cleaned after `HEALTH_HISTORY_DAYS`
- **Self-resolving**: When a previously failing check passes, its DB record is automatically marked resolved with timestamp
- **No new dependencies**: Uses only stdlib (`os`, `shutil`, `socket`, `threading`, `json`, `re`, `logging`, `sqlite3`, `datetime`) plus `requests` (already a Mylar dependency)

---

### Testing

**372 automated tests** across 17 test classes:

- **Unit tests** (`@pytest.mark.unit`): ~340 tests covering all check methods, `HealthCheckResult` data container, `HealthCheckRunner` engine logic, `HealthLogHandler` pattern matching, SSE push, edge cases
- **Integration tests** (`@pytest.mark.integration`): ~30 tests using real SQLite in temp directories for DB round-trip, resolve/cleanup lifecycle, startup loading, resolved history queries
- **Zero regressions**: All existing `test_helpers.py` and `test_filechecker.py` tests continue to pass
- **Network isolation**: `conftest.py` auto-blocks all `requests.get()` calls; tests mock responses per-case

```bash
# Run all tests
pytest tests/ -v

# Health check tests only
pytest tests/test_healthcheck.py -v

# Coverage
pytest tests/test_healthcheck.py --cov=mylar.healthcheck --cov-config=tests/.coveragerc --cov-report=term-missing -v
```

---

### How to Review

This PR is best reviewed **commit-by-commit**. Each commit maps to one logical piece:

| # | Commit | Scope |
|---|--------|-------|
| 1 | `feat: add health check database table and globals` | `mylar/__init__.py` — foundation |
| 2 | `feat: add health check config definitions` | `mylar/config.py` — settings |
| 3 | `feat: add health check engine with scheduler integration` | `mylar/healthcheck.py` + `mylar/__init__.py` — core engine |
| 4 | `feat: add health check web routes and API commands` | `mylar/webserve.py`, `mylar/api.py`, `mylar/webstart.py` — endpoints |
| 5 | `feat: add health dashboard page template` | `data/interfaces/default/health.html`, `mylar/webserve.py` — UI |
| 6 | `feat: add persistent health banner to base template` | `data/interfaces/default/base.html` — site-wide banner |
| 7 | `feat: add nav badge and SSE real-time updates` | `data/interfaces/default/base.html`, `mylar/healthcheck.py` — real-time |
| 8 | `feat: add health check settings to config page` | `data/interfaces/default/config.html` — user config |
| 9 | `feat: add provider and comic vine api health checks` | `mylar/healthcheck.py` — expanded checks |
| 10 | `feat: add log-based health monitoring` | `mylar/healthcheck.py`, `mylar/logger.py` — log interceptor |
| 11 | `test: add health check unit and integration tests` | `tests/test_healthcheck.py` — test suite |
| 12 | `test: add additional health unit and integration tests` | `tests/test_healthcheck.py` — expanded coverage |
| 13 | `docs: rewrite of tests/README.md` | `tests/README.md` — documentation |

---

### Compatibility

- No changes to existing Mylar3 behavior — all modifications are additive
- Works with both default and carbon UI themes (banner/badge inject into shared `base.html`)
- Backward-compatible with existing `config.ini` files (new `[Health]` section created automatically with defaults)
- `health_checks` table created via `CREATE TABLE IF NOT EXISTS` — safe on existing databases
- Graceful degradation: if `healthcheck.py` fails to import, Mylar starts normally without health monitoring
- Tested on Python 3.8+ (minimum supported Mylar version)
<img width="1728" height="1117" alt="Screenshot 2026-02-20 at 9 26 36 PM" src="https://github.com/user-attachments/assets/eea3b4f4-42c9-4b8f-8bf4-03edde606199" />
<img width="1728" height="1117" alt="Screenshot 2026-02-20 at 9 26 52 PM" src="https://github.com/user-attachments/assets/edc5d991-14ec-4b82-83be-9f7db51fb54f" />
<img width="1728" height="1117" alt="Screenshot 2026-02-20 at 9 27 21 PM" src="https://gi
<img width="1728" height="1117" alt="Screenshot 2026-02-20 at 9 28 12 PM" src="https://github.com/user-attachments/assets/40070f14-04f1-4090-84fa-8eb6f9d6cc76" />
thub.com/user-attachments/assets/b892804a-64c8-4d86-896b-698cbca0114a" />
<img width="1728" height="1117" alt="Screenshot 2026-02-20 at 9 29 22 PM" src="https://github.com/user-attachments/assets/36b9483a-a3f5-434a-82e6-dcb3109a718a" />
