### PR TITLE
DEV: Add extra smoke tests, support alpine image for 3.12 testing

### DIFF
--- a/.github/workflows/build_feature_container.yml
+++ b/.github/workflows/build_feature_container.yml
@@ -1,7 +1,7 @@
 # Build a LSIO compatible container for dev branches
 name: Build & Publish Feature Container
 
-# Run on any branch that isn't master or p3-dev
+# Run on any branch that isn't master or a dev branch
 on:
     push:
         branches-ignore:
@@ -20,6 +20,7 @@ env:
 
 jobs:
     push_to_registry:
+        if: ${{ github.repository != 'mylar3/mylar3' }}
         name: Build Docker image and push to GHCR
         runs-on: ubuntu-latest
         permissions:
@@ -28,17 +29,17 @@ jobs:
           attestations: write
           id-token: write
         steps:
-          - name: Checkout LSIO mylar3 repository (nightly)
+          - name: Checkout LSIO mylar3 repository (unstable)
             uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
             with:
               repository: 'linuxserver/docker-mylar3'
-              ref: 'nightly'
+              ref: 'unstable'
 
           - name: Edit Dockerfile for current repo/branch
             run: |
               sed -i "s@mylar3/mylar3@${{github.repository}}@g" Dockerfile
-              sed -i "s@commits/python3-dev@commits/${{github.ref_name}}@g" Dockerfile
-              sed -i "/requirements.txt/a\ \ pip install --no-cache-dir --find-links https://wheel-index.linuxserver.io/ubuntu/ debugpy && \\\\" Dockerfile
+              sed -i "s@commits/1000papercuts@commits/${{github.ref_name}}@g" Dockerfile
+              sed -i "/requirements.txt/a\ \ pip install --no-cache-dir --find-links https://wheel-index.linuxserver.io/alpine-3.23/ debugpy && \\\\" Dockerfile
               sed -i "/EXPOSE 8090/aEXPOSE 5678" Dockerfile
               sed -i "s@python3 /app/mylar3/Mylar.py@python3 -m debugpy --listen 0.0.0.0:5678 /app/mylar3/Mylar.py@g" ./root/etc/s6-overlay/s6-rc.d/svc-mylar3/run
 

--- a/.github/workflows/mylar_build_deploy_test.yml
+++ b/.github/workflows/mylar_build_deploy_test.yml
@@ -36,9 +36,13 @@ on:
           required: false
           type: string
 
+env:
+  smoke_text_urls: ".github/workflows/smoke_test_urls.txt"
+
 jobs:
     build:
         runs-on: ${{ inputs.os }}
+        
         steps:
           - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
           - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
@@ -63,16 +67,34 @@ jobs:
               brew update
               brew install rar
             if: ${{ runner.os == 'macOS' }}
-          - uses: JarvusInnovations/background-action@v1.0.7
-            name: Launch Mylar & Test Start
-            with:
-              run: |
-                python Mylar.py &
-              wait-on: |
-                http://localhost:8090/home
-              tail: true
-              wait-for: 2m
-            if: ${{ inputs.run_basic }}
+          # Custom shell entries used to avoid fail-fast and test all URLs in smoke tests
+          - name: Smoke test Mylar pages (Linux)
+            # Initial connection test will retry for 120s, early exit if fails
+            shell: bash {0}
+            run: |
+              set -x
+              python Mylar.py &
+              curl -sS -o /dev/null --retry 12 --retry-delay 10 --retry-all-errors --fail http://127.0.0.1:8090/home
+              if [ $? -eq 7 ]; then echo Mylar did not start && exit 1; fi
+              declare -i RESULT=0
+              while read URL; do curl -sS -o /dev/null --retry 5 --retry-delay 2 --retry-all-errors --fail $URL; RESULT+=$?; done < ${{ env.smoke_text_urls }}
+              exit $RESULT
+            if: ${{ inputs.run_basic && (runner.os == 'Linux') }}
+          - name: Smoke test Mylar pages (Windows)
+            # Initial connection test will retry for 120s
+            shell: pwsh -File {0}
+            run: |
+              Set-PSDebug -Trace 2
+              python Mylar.py &
+              curl -sS -o nul --retry 12 --retry-delay 10 --retry-all-errors --fail http://127.0.0.1:8090/home
+              if ( $LASTEXITCODE -eq 7 ) {exit 1}
+              $ERRORCOUNT=0
+              foreach($line in Get-Content ${{ env.smoke_text_urls }}) {
+                curl -sS -o nul --retry 5 --retry-delay 2 --retry-all-errors --fail $line
+                if ($LASTEXITCODE -ne 0) { $ERRORCOUNT++ }
+              }
+              exit $ERRORCOUNT
+            if: ${{ inputs.run_basic && (runner.os == 'Windows') }}
           - name: Launch pytest
             run: |
               python -m pip install -r tests/requirements.txt

--- a/.github/workflows/push_to_feature_branch.yml
+++ b/.github/workflows/push_to_feature_branch.yml
@@ -23,10 +23,10 @@ jobs:
     build_and_test:
         if: ${{ github.repository != 'mylar3/mylar3' }}
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
                 os: [ubuntu-22.04, windows-latest]
-                python-version: ["3.8", "3.9", "3.10","3.11"]        
+                python-version: ["3.8", "3.14"]        
         uses: ./.github/workflows/mylar_build_deploy_test.yml
         with:
           os: ${{ matrix.os }}

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -20,7 +20,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-22.04, windows-latest]
-                python-version: ["3.8", "3.11"]        
+                python-version: ["3.8", "3.14"]
         uses: ./.github/workflows/mylar_build_deploy_test.yml
         with:
           os: ${{ matrix.os }}

--- a/.github/workflows/smoke_test_urls.txt
+++ b/.github/workflows/smoke_test_urls.txt
@@ -1,0 +1,13 @@
+http://127.0.0.1:8090/home
+http://127.0.0.1:8090/upcoming
+http://127.0.0.1:8090/pullist
+http://127.0.0.1:8090/manage
+http://127.0.0.1:8090/storyarc_main
+http://127.0.0.1:8090/history
+http://127.0.0.1:8090/config
+http://127.0.0.1:8090/manageComics
+http://127.0.0.1:8090/manageIssues?status=Wanted
+http://127.0.0.1:8090/manageFailed
+http://127.0.0.1:8090/queueManage
+http://127.0.0.1:8090/cblimport
+http://127.0.0.1:8090/searchit?name=abracadabra


### PR DESCRIPTION
@barbequesauce Can push this one whenever as it only touches the github workflows.
- Realigned the dev image build with the unstable LSIO container (so alpine based for 3.12 support)
- Added some expanded smoke testing for checking that pages return a good HTTP response on a fresh mylar deployment for a range of different pages in the app.
- Changed the matrix for testing on push to be Windows & Linux, Python 3.8 and 3.14 (to cover new min/max).  If we do decide we want to write off 3.8 at some point we can do so down the line.
- I hate powershell