### PR TITLE
Better exposure for current 'stable' github page

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -125,7 +125,7 @@
                           <figcaption class="caption">Forums</caption>
                         </figure>
                         <figure class="item">
-                          <a href="https://github.com/mylar3/mylar3" target="_blank"><img src="${icons['github-icon']}" title="https://github.com/mylar3/mylar3" /></a>
+                          <a href="https://github.com/mylar3/mylar3/tree/python3-dev" target="_blank"><img src="${icons['github-icon']}" title="https://github.com/mylar3/mylar3/tree/python3-dev" /></a>
                           <figcaption class="caption">GitHub</caption>
                         </figure>
                         <figure class="item">


### PR DESCRIPTION
I ran through the UI to find what links back to https://github.com/mylar3/mylar3 - config.html seemed the only one worth updating - and replaced it with https://github.com/mylar3/mylar3/tree/python3-dev

With this change + a pre-existing change to README.md, (adding Development section), I think we will have a better chance of getting the attention of people who are clicking the Mylar git link in-app (communicating temporary changes to the publishing/deployment cycle, etc), given we can make changes to the python3-dev README.

The only other places I could see updating (but am not sure they're worthwhile/workable) to support this change:
- README.md: 
   - the SemVer badge URL seems pretty hardcoded into releases/tags, and I don't think we can touch any of those from dev branches?
   - a more explicit note in the Development section to speak to someone and ask questions first for (non-trivial?) PRs
- notifiers.py: 
   - I don't use notifications, so I'm not sure how meaningful it'd be to change the URL in these
 - config.html:
    - some other kind of static comment on this page to make it clear that python3-dev is the new main

FWIW VSC was bitching about this, but I'm not qualified to say if it's meaningful:
<img width="377" height="77" alt="image" src="https://github.com/user-attachments/assets/d311e750-3a45-4055-82dd-7fe69eef9e85" />
