### PR TITLE
feat: improve manage comics and manage issues pages

### DIFF
--- a/data/interfaces/carbon/css/managecomics.css
+++ b/data/interfaces/carbon/css/managecomics.css
@@ -1,0 +1,105 @@
+#markcomics .action-buttons,
+#markissues .action-buttons {
+    margin-bottom: 12px;
+}
+#markcomics .action-label,
+#markissues .action-label {
+    display: block;
+    font-weight: bold;
+    margin-bottom: 6px;
+}
+#markcomics .action-button-group,
+#markissues .action-button-group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+#markcomics .action-row,
+#markissues .action-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+#markcomics .manage-action,
+#markissues .manage-action {
+    flex: 1;
+    min-width: 160px;
+    padding: 10px 16px;
+    font-size: 0.95em;
+    border-radius: 4px;
+    border: 1px solid #2c2c2c;
+    background-color: #3b3b3b;
+    color: #fff;
+    cursor: pointer;
+    transition: background-color 0.15s ease, transform 0.1s ease;
+}
+#markcomics .manage-action:hover,
+#markissues .manage-action:hover {
+    background-color: #4a4a4a;
+}
+#markcomics .manage-action:active,
+#markissues .manage-action:active {
+    transform: scale(0.98);
+}
+#markcomics .manage-action[data-action="delete"] {
+    background-color: #a94442;
+    border-color: #842d2b;
+}
+#markcomics .manage-action[data-action="delete"]:hover {
+    background-color: #c25552;
+}
+#markcomics .selected-counter,
+#markissues .selected-counter {
+    margin-top: 10px;
+    font-weight: bold;
+}
+#action-confirm,
+#issue-action-confirm {
+    margin-top: 12px;
+    padding: 10px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.08);
+}
+#action-confirm.hidden,
+#issue-action-confirm.hidden {
+    display: none;
+}
+#action-confirm .action-confirm-buttons,
+#issue-action-confirm .action-confirm-buttons {
+    margin-top: 8px;
+    display: flex;
+    gap: 10px;
+}
+#action-confirm .action-confirm-buttons button,
+#issue-action-confirm .action-confirm-buttons button {
+    flex: 0 0 120px;
+    padding: 8px 0;
+    border-radius: 4px;
+    border: 1px solid #2c2c2c;
+    background: #2d7bf4;
+    color: #fff;
+    font-weight: bold;
+    cursor: pointer;
+}
+#action-confirm .action-confirm-buttons button#action-confirm-no,
+#issue-action-confirm .action-confirm-buttons button#issue-action-confirm-no {
+    background: #a94442;
+}
+
+.manage-switch-links {
+    margin-top: 10px;
+}
+
+.manage-switch-links a {
+    display: inline-block;
+    padding: 6px 10px;
+    background: #2d7bf4;
+    color: #fff;
+    border-radius: 3px;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.manage-switch-links a:hover {
+    background: #1e5ec0;
+}

--- a/data/interfaces/default/css/managecomics.css
+++ b/data/interfaces/default/css/managecomics.css
@@ -1,0 +1,105 @@
+#markcomics .action-buttons,
+#markissues .action-buttons {
+    margin-bottom: 12px;
+}
+#markcomics .action-label,
+#markissues .action-label {
+    display: block;
+    font-weight: bold;
+    margin-bottom: 6px;
+}
+#markcomics .action-button-group,
+#markissues .action-button-group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+#markcomics .action-row,
+#markissues .action-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+#markcomics .manage-action,
+#markissues .manage-action {
+    flex: 1;
+    min-width: 160px;
+    padding: 10px 16px;
+    font-size: 0.95em;
+    border-radius: 4px;
+    border: 1px solid #2c2c2c;
+    background-color: #3b3b3b;
+    color: #fff;
+    cursor: pointer;
+    transition: background-color 0.15s ease, transform 0.1s ease;
+}
+#markcomics .manage-action:hover,
+#markissues .manage-action:hover {
+    background-color: #4a4a4a;
+}
+#markcomics .manage-action:active,
+#markissues .manage-action:active {
+    transform: scale(0.98);
+}
+#markcomics .manage-action[data-action="delete"] {
+    background-color: #a94442;
+    border-color: #842d2b;
+}
+#markcomics .manage-action[data-action="delete"]:hover {
+    background-color: #c25552;
+}
+#markcomics .selected-counter,
+#markissues .selected-counter {
+    margin-top: 10px;
+    font-weight: bold;
+}
+#action-confirm,
+#issue-action-confirm {
+    margin-top: 12px;
+    padding: 10px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.08);
+}
+#action-confirm.hidden,
+#issue-action-confirm.hidden {
+    display: none;
+}
+#action-confirm .action-confirm-buttons,
+#issue-action-confirm .action-confirm-buttons {
+    margin-top: 8px;
+    display: flex;
+    gap: 10px;
+}
+#action-confirm .action-confirm-buttons button,
+#issue-action-confirm .action-confirm-buttons button {
+    flex: 0 0 120px;
+    padding: 8px 0;
+    border-radius: 4px;
+    border: 1px solid #2c2c2c;
+    background: #2d7bf4;
+    color: #fff;
+    font-weight: bold;
+    cursor: pointer;
+}
+#action-confirm .action-confirm-buttons button#action-confirm-no,
+#issue-action-confirm .action-confirm-buttons button#issue-action-confirm-no {
+    background: #a94442;
+}
+
+.manage-switch-links {
+    margin-top: 10px;
+}
+
+.manage-switch-links a {
+    display: inline-block;
+    padding: 6px 10px;
+    background: #2d7bf4;
+    color: #fff;
+    border-radius: 3px;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.manage-switch-links a:hover {
+    background: #1e5ec0;
+}

--- a/data/interfaces/default/managecomics.html
+++ b/data/interfaces/default/managecomics.html
@@ -17,27 +17,40 @@
 	<div id="manageheader" class="title">
 		<h1 class="clearfix">Manage comics</h1>
 	</div>
-	<form action="markComics" method="post" id="markComics">
-        <div id="markcomics" style="top:0;">
-		<select name="action" onChange="doAjaxCall('markComics',$(this),'table',true,'post');" data-error="You didn't select any comics">
-  			<option disabled="disabled" selected="selected">Choose...</option>
-  			<option value="delete">Delete Series</option>
-                        <option value="metatag">MetaTag Series</option>
-                        <option value="pause">Pause Series</option>
-  			<option value="recheck">Recheck Files</option>
-  			<option value="refresh">Refresh Series</option>
-			<option value="rename">Rename Series</option>
-  			<option value="resume">Resume Series</option>
-		</select>
-		selected comics
-		<input type="hidden" value="Go">
+	<form action="markComics" method="post" id="markComics" data-success="Action submitted. Watch the logs for progress." data-error="You didn't select any comics.">
+	        <div id="markcomics" style="top:0;">
+        <div class="action-buttons" aria-live="polite">
+            <span class="action-label">Choose an action for your selected comics:</span>
+            <div class="action-button-group">
+                <div class="action-row">
+                    <button type="button" class="manage-action" data-action="metatag" data-label="MetaTag Series">MetaTag Series</button>
+                    <button type="button" class="manage-action" data-action="pause" data-label="Pause Series">Pause Series</button>
+                    <button type="button" class="manage-action" data-action="recheck" data-label="Recheck Files">Recheck Files</button>
+                    <button type="button" class="manage-action" data-action="refresh" data-label="Refresh Series">Refresh Series</button>
+                </div>
+                <div class="action-row">
+                    <button type="button" class="manage-action" data-action="rename" data-label="Rename Series">Rename Series</button>
+                    <button type="button" class="manage-action" data-action="resume" data-label="Resume Series">Resume Series</button>
+                    <button type="button" class="manage-action" data-action="delete" data-label="Delete Series">Delete Series</button>
+                </div>
+            </div>
+        </div>
+	        <div id="action-confirm" class="action-confirm hidden">
+	            <span id="action-confirm-message"></span>
+	            <div class="action-confirm-buttons">
+	                <button type="button" id="action-confirm-yes">Yes</button>
+	                <button type="button" id="action-confirm-no">No</button>
+	            </div>
+	        </div>
+	        <div class="selected-counter">Selected comics: <span id="selected-count">0</span></div>
+		<input type="hidden" name="action" id="manage_action" value="">
 	</div>
 	<div class="table_wrapper">
 
 	<table class="display" id="manage_comic">
 		<thead>
 			<tr>
-				<th id="select"><input type="checkbox" onClick="toggle(this)" /></th>
+				<th id="select"><input type="checkbox" onClick="toggle(this);updateSelectedCount();" /></th>
 				<th id="albumart"></th>
 				<th id="name">Comic Name</th>
 				<th id="status">Status</th>
@@ -70,7 +83,7 @@
                                         grade = 'A'
                         %>
 			<tr>
-				<td id="select"><input type="checkbox" name="${comic['ComicName']}[${comic['ComicYear']}]" value="${comic['ComicID']}" class="checkbox" /></td>
+				<td id="select"><input type="checkbox" name="${comic['ComicName']}[${comic['ComicYear']}]" value="${comic['ComicID']}" class="checkbox" onchange="updateSelectedCount()" /></td>
 				<td id="albumart"><div><img src="${comic['ComicImage']}" height="75" width="50"></div></td>
 				<td id="name"><span title="${comic['ComicSortName']}"></span><a href="comicDetails?ComicID=${comic['ComicID']}">${comic['ComicName']} (${comic['ComicYear']})</a></td>
 				<td id="status">${comic['recentstatus']}</td>
@@ -100,6 +113,7 @@
 
 <%def name="headIncludes()">
 	<link rel="stylesheet" href="interfaces/${interface}/css/data_table.css">
+        <link rel="stylesheet" href="interfaces/${interface}/css/managecomics.css">
 </%def>
 
 <%def name="javascriptIncludes()">
@@ -108,6 +122,42 @@
 	<script>
 
         var lastChecked = null;
+        var pendingAction = null;
+
+        function updateSelectedCount() {
+                var count = $("#manage_comic input.checkbox:checked").length;
+                $("#selected-count").text(count);
+                return count;
+        }
+
+        function showConfirm(action, label) {
+                var count = updateSelectedCount();
+                if (count === 0) {
+                        var errorMsg = $(".action-buttons").attr('data-error') || "Pick at least one comic first.";
+                        alert(errorMsg);
+                        pendingAction = null;
+                        return;
+                }
+                pendingAction = action;
+                var message = label + '? You selected ' + count + (count === 1 ? ' series.' : ' series.');
+                $('#action-confirm-message').text(message);
+                $('#action-confirm').removeClass('hidden');
+        }
+
+        function hideConfirm() {
+                pendingAction = null;
+                $('#action-confirm').addClass('hidden');
+        }
+
+        function submitAction() {
+                if (!pendingAction) {
+                        return;
+                }
+                $('#manage_action').val(pendingAction);
+                doAjaxCall('markComics',$('#markComics'),'table',true,'post');
+                hideConfirm();
+        }
+
         function initThisPage() {
                 $.fn.DataTable.ext.pager.numbers_length = 5;
                 $('#manage_comic').dataTable( {
@@ -118,7 +168,7 @@
                             { 'bSortable': false, 'aTargets': [ 0, 1 ] },
                             { 'order': [[2, 'desc'],[3, 'desc']] }
                         ],
-                        "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, 'All' ]],
+                        "lengthMenu": [[10, 25, 50, 100, 200, 500, -1], [10, 25, 50, 100, 200, 500, 'All' ]],
                         "language": {
                                 "lengthMenu":"Show _MENU_ results per page",
                                 "emptyTable": "No results",
@@ -154,7 +204,21 @@
                                 lastChecked = this;
                             }
                         }
+                        updateSelectedCount();
                     });
+                $('.manage-action').on('click', function(){
+                        var action = $(this).data('action');
+                        var label = $(this).data('label') || $(this).text();
+                        showConfirm(action, label);
+                });
+
+                $('#action-confirm-yes').on('click', function(){
+                        submitAction();
+                });
+
+                $('#action-confirm-no').on('click', function(){
+                        hideConfirm();
+                });
         }
 
         $(document).ready(function(){

--- a/data/interfaces/default/manageissues.html
+++ b/data/interfaces/default/manageissues.html
@@ -34,18 +34,30 @@
                 <input type="submit" value="Manage">
         </div>
         </form>
-        </br></br>
-	<form action="markissues" method="post" id="markissues">
-        <div id="markissues" style="top:0;">
-		<select name="action" onChange="doAjaxCall('markissues',$(this),'table',true,'post');" data-error="You didn't select any issues">
-  			<option disabled="disabled" selected="selected">Choose...</option>
-  			<option value="Wanted">Wanted</option>
-  			<option value="Archived">Archived</option>
-  			<option value="Skipped">Skipped</option>
-  			<option value="Ignored">Ignored</option>
-		</select>
-                selected issues
-		<input type="hidden" value="Go">
+	<form action="markissues" method="post" id="markissues" data-success="Updated issue status successfully." data-error="You didn't select any issues.">
+        <div id="markissues_container" style="top:0;">
+        <div class="action-buttons" aria-live="polite">
+            <span class="action-label">Choose what to do with your selected issues:</span>
+            <div class="action-button-group">
+                <div class="action-row">
+                    <button type="button" class="manage-action issue-action" data-action="Wanted" data-label="Mark as Wanted">Mark as Wanted</button>
+                    <button type="button" class="manage-action issue-action" data-action="Archived" data-label="Mark as Archived">Mark as Archived</button>
+                </div>
+                <div class="action-row">
+                    <button type="button" class="manage-action issue-action" data-action="Skipped" data-label="Mark as Skipped">Mark as Skipped</button>
+                    <button type="button" class="manage-action issue-action" data-action="Ignored" data-label="Mark as Ignored">Mark as Ignored</button>
+                </div>
+            </div>
+        </div>
+        <div id="issue-action-confirm" class="action-confirm hidden">
+            <span id="issue-action-confirm-message"></span>
+            <div class="action-confirm-buttons">
+                <button type="button" id="issue-action-confirm-yes">Yes</button>
+                <button type="button" id="issue-action-confirm-no">No</button>
+            </div>
+        </div>
+        <div class="selected-counter">Selected issues: <span id="issue-selected-count">0</span></div>
+        <input type="hidden" name="action" id="manage_issue_action" value="">
 	</div>
         
 	<div class="table_wrapper">
@@ -53,7 +65,7 @@
 	<table class="display" id="manage_issues">
 		<thead>
 			<tr>
-				<th id="select"><input type="checkbox" onClick="toggle(this)" class="checkbox" align="left" /></th>
+				<th id="select"><input type="checkbox" onClick="toggle(this);updateIssueSelectedCount();" class="checkbox" align="left" /></th>
 				<th id="name">Series</th>
                                 <th id="int_issue">Int_Issue</th>
 				<th id="issue">Issue</th>
@@ -66,7 +78,7 @@
 		<tbody>
 		%for issue in issues:
 			<tr>
-				<td id="select"><input type="checkbox" name="${issue['IssueID']}" class="checkbox" /></td>
+				<td id="select"><input type="checkbox" name="${issue['IssueID']}" class="checkbox" onchange="updateIssueSelectedCount()" /></td>
                                 <% 
                                      try:
                                          if issue['ReleaseComicName']:
@@ -107,15 +119,52 @@
 
 <%def name="headIncludes()">
 	<link rel="stylesheet" href="interfaces/${interface}/css/data_table.css">
+        <link rel="stylesheet" href="interfaces/${interface}/css/managecomics.css">
 </%def>
 
 <%def name="javascriptIncludes()">
 	<script src="js/libs/jquery.dataTables.min.js"></script>
-        <script>
-        
+	<script>
+
         var lastChecked = null;
+        var issuePendingAction = null;
+
+        function updateIssueSelectedCount() {
+                var count = $("#manage_issues input.checkbox:checked").length;
+                $("#issue-selected-count").text(count);
+                return count;
+        }
+
+        function showIssueConfirm(action, label) {
+                var count = updateIssueSelectedCount();
+                if (count === 0) {
+                        var errorMsg = $("#markissues .action-buttons").attr('data-error') || "Select at least one issue.";
+                        alert(errorMsg);
+                        issuePendingAction = null;
+                        return;
+                }
+                issuePendingAction = action;
+                var msg = label + ' (' + count + (count === 1 ? ' issue selected)' : ' issues selected)');
+                $('#issue-action-confirm-message').text(msg);
+                $('#issue-action-confirm').removeClass('hidden');
+        }
+
+        function hideIssueConfirm() {
+                issuePendingAction = null;
+                $('#issue-action-confirm').addClass('hidden');
+        }
+
+        function submitIssueAction() {
+                if (!issuePendingAction) {
+                        return;
+                }
+                $('#manage_issue_action').val(issuePendingAction);
+                doAjaxCall('markissues',$('#markissues'),'table',true,'post');
+                hideIssueConfirm();
+        }
         
         function initThisPage() {
+                updateIssueSelectedCount();
                 $('#manage_issues').dataTable(
                         {
                                 "bDestroy": true,
@@ -125,7 +174,7 @@
                                   { 'sType': 'numeric', 'aTargets': [2] },
                                   { 'columns.orderData': [2], 'aTargets': [3] }
                                 ],
-                                "aLengthMenu": [[10, 25, 50, -1], [10, 25, 50, 'All' ]],
+                                "aLengthMenu": [[10, 25, 50, 100, 200, 500, -1], [10, 25, 50, 100, 200, 500, 'All' ]],
                                 "oLanguage": {
                                         "sLengthMenu":"Show _MENU_ results per page",
                                         "sEmptyTable": "No results",
@@ -161,7 +210,19 @@
                                 lastChecked = this;
                                 }
                         }
+                        updateIssueSelectedCount();
                         });
+                $('.issue-action').on('click', function(){
+                        var action = $(this).data('action');
+                        var label = $(this).data('label') || $(this).text();
+                        showIssueConfirm(action, label);
+                });
+                $('#issue-action-confirm-yes').on('click', function(){
+                        submitIssueAction();
+                });
+                $('#issue-action-confirm-no').on('click', function(){
+                        hideIssueConfirm();
+                });
         }
 
         $(document).ready(function(){


### PR DESCRIPTION
Replaces dropdown actions to buttons with confirmation and adds more options to the amount dropdown: 100, 200, 500, All
<img width="1102" height="322" alt="image" src="https://github.com/user-attachments/assets/c597e9a9-a0db-44bc-8c0c-fbf2daeb73b5" />

This is for both Manage Comics and Manage Issues pages