### PR TITLE
Optionally use curl_cffi instead of requests

### DIFF
--- a/mylar/config.py
+++ b/mylar/config.py
@@ -380,6 +380,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'JD2_ENABLE': (bool, 'DDL', False),
     'JD2_DEST_DIR': (str, 'DDL', None),
     'JD2_URL': (str, 'DDL', None),
+    'USE_CURL_CFFI': (bool, 'DDL', True),
 
     'ENABLE_AIRDCPP': (bool, 'DCPP', False),
     'AIRDCPP_HOST': (str, 'DCPP', ""),

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -380,7 +380,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'JD2_ENABLE': (bool, 'DDL', False),
     'JD2_DEST_DIR': (str, 'DDL', None),
     'JD2_URL': (str, 'DDL', None),
-    'USE_CURL_CFFI': (bool, 'DDL', True),
+    'USE_CURL_CFFI': (bool, 'DDL', False),
 
     'ENABLE_AIRDCPP': (bool, 'DCPP', False),
     'AIRDCPP_HOST': (str, 'DCPP', ""),

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -25,13 +25,13 @@ import re
 import time
 import datetime
 from bs4 import BeautifulSoup
-import requests
 import zipfile
 import json
 import mylar
 from operator import itemgetter
 from mylar import db, logger, helpers, search_filer
 from mylar.downloaders.jdownloader2 import JDownloader2
+import curl_cffi
 
 class GC(object):
 
@@ -134,7 +134,11 @@ class GC(object):
             'Referer': mylar.GC_URL,
         }
 
-        self.session = requests.Session()
+        if mylar.CONFIG.USE_CURL_CFFI:
+            logger.fdebug('[DDL] Using curl_cffi for GetComics')
+            self.session = curl_cffi.Session(impersonate="chrome")
+        else:
+            self.session = requests.Session()
 
         if mylar.CONFIG.ENABLE_PROXY:
             self.session.proxies.update({

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ tenacity>=8.2.3
 tzlocal>=2.0.0
 urllib3<2
 user_agent2>=2021.12.11
+curl_cffi>=0.14.0


### PR DESCRIPTION
Add an option to use `curl_cffi` instead of `requests`. Option is enabled by default.

`curl_cffi` has built in anti-bot evasion, which should make Flaresolverr unnecessary in most cases. It does use a binary, which means it may not be available for all platforms; hence why it's an option.