### PR TITLE
FIX: Fix to improve reliability of metatagging under python 3.12

### DIFF
--- a/.github/workflows/build_feature_container.yml
+++ b/.github/workflows/build_feature_container.yml
@@ -37,6 +37,7 @@ jobs:
 
           - name: Edit Dockerfile for current repo/branch
             run: |
+              sed -i "/ARG MYLAR3_RELEASE/aENV PYDEVD_DISABLE_FILE_VALIDATION=1" Dockerfile
               sed -i "s@mylar3/mylar3@${{github.repository}}@g" Dockerfile
               sed -i "s@commits/1000papercuts@commits/${{github.ref_name}}@g" Dockerfile
               sed -i "/requirements.txt/a\ \ pip install --no-cache-dir --find-links https://wheel-index.linuxserver.io/alpine-3.23/ debugpy && \\\\" Dockerfile

--- a/lib/comictaggerlib/comicapi/filenameparser.py
+++ b/lib/comictaggerlib/comicapi/filenameparser.py
@@ -48,13 +48,13 @@ class FileNameParser:
         tmpstr = self.fixSpaces(filename)
         found = False
 
-        match = re.search('(?<=\sof\s)\d+(?=\s)', tmpstr, re.IGNORECASE)
+        match = re.search(r'(?<=\sof\s)\d+(?=\s)', tmpstr, re.IGNORECASE)
         if match:
             count = match.group()
             found = True
 
         if not found:
-            match = re.search('(?<=\(of\s)\d+(?=\))', tmpstr, re.IGNORECASE)
+            match = re.search(r'(?<=\(of\s)\d+(?=\))', tmpstr, re.IGNORECASE)
             if match:
                 count = match.group()
                 found = True
@@ -78,25 +78,25 @@ class FileNameParser:
         if "--" in filename:
             # the pattern seems to be that anything to left of the first "--"
             # is the series name followed by issue
-            filename = re.sub("--.*", self.repl, filename)
+            filename = re.sub(r"--.*", self.repl, filename)
 
         elif "__" in filename:
             # the pattern seems to be that anything to left of the first "__"
             # is the series name followed by issue
-            filename = re.sub("__.*", self.repl, filename)
+            filename = re.sub(r"__.*", self.repl, filename)
 
         filename = filename.replace("+", " ")
 
         # replace parenthetical phrases with spaces
-        filename = re.sub("\(.*?\)", self.repl, filename)
-        filename = re.sub("\[.*?\]", self.repl, filename)
+        filename = re.sub(r"\(.*?\)", self.repl, filename)
+        filename = re.sub(r"\[.*?\]", self.repl, filename)
 
         # replace any name separators with spaces
         filename = self.fixSpaces(filename)
 
         # remove any "of NN" phrase with spaces (problem: this could break on
         # some titles)
-        filename = re.sub("of [\d]+", self.repl, filename)
+        filename = re.sub(r"of [\d]+", self.repl, filename)
 
         # print u"[{0}]".format(filename)
 
@@ -105,7 +105,7 @@ class FileNameParser:
 
         # make a list of each word and its position
         word_list = list()
-        for m in re.finditer("\S+", filename):
+        for m in re.finditer(r"\S+", filename):
             word_list.append((m.group(0), m.start(), m.end()))
 
         # remove the first word, since it can't be the issue number
@@ -120,7 +120,7 @@ class FileNameParser:
         # first look for a word with "#" followed by digits with optional suffix
         # this is almost certainly the issue number
         for w in reversed(word_list):
-            if re.match("#[-]?(([0-9]*\.[0-9]+|[0-9]+)(\w*))", w[0]):
+            if re.match(r"#[-]?(([0-9]*\.[0-9]+|[0-9]+)(\w*))", w[0]):
                 found = True
                 break
 
@@ -128,13 +128,13 @@ class FileNameParser:
         # list
         if not found:
             w = word_list[-1]
-            if re.match("[-]?(([0-9]*\.[0-9]+|[0-9]+)(\w*))", w[0]):
+            if re.match(r"[-]?(([0-9]*\.[0-9]+|[0-9]+)(\w*))", w[0]):
                 found = True
 
         # now try to look for a # followed by any characters
         if not found:
             for w in reversed(word_list):
-                if re.match("#\S+", w[0]):
+                if re.match(r"#\S+", w[0]):
                     found = True
                     break
 
@@ -157,12 +157,12 @@ class FileNameParser:
         if "--" in filename:
             # the pattern seems to be that anything to left of the first "--"
             # is the series name followed by issue
-            filename = re.sub("--.*", self.repl, filename)
+            filename = re.sub(r"--.*", self.repl, filename)
 
         elif "__" in filename:
             # the pattern seems to be that anything to left of the first "__"
             # is the series name followed by issue
-            filename = re.sub("__.*", self.repl, filename)
+            filename = re.sub(r"__.*", self.repl, filename)
 
         filename = filename.replace("+", " ")
         tmpstr = self.fixSpaces(filename, remove_dashes=False)
@@ -177,10 +177,10 @@ class FileNameParser:
             last_word = ""
 
         # remove any parenthetical phrases
-        series = re.sub("\(.*?\)", "", series)
+        series = re.sub(r"\(.*?\)", "", series)
 
         # search for volume number
-        match = re.search('(.+)([vV]|[Vv][oO][Ll]\.?\s?)(\d+)\s*$', series)
+        match = re.search(r'(.+)([vV]|[Vv][oO][Ll]\.?\s?)(\d+)\s*$', series)
         if match:
             series = match.group(1)
             volume = match.group(3)
@@ -189,7 +189,7 @@ class FileNameParser:
         # since that's a common way to designate the volume
         if volume == "":
             # match either (YEAR), (YEAR-), or (YEAR-YEAR2)
-            match = re.search("(\()(\d{4})(-(\d{4}|)|)(\))", last_word)
+            match = re.search(r"(\()(\d{4})(-(\d{4}|)|)(\))", last_word)
             if match:
                 volume = match.group(2)
 
@@ -215,11 +215,11 @@ class FileNameParser:
 
         year = ""
         # look for four digit number with "(" ")" or "--" around it
-        match = re.search('(\(\d\d\d\d\))|(--\d\d\d\d--)', filename)
+        match = re.search(r'(\(\d\d\d\d\))|(--\d\d\d\d--)', filename)
         if match:
             year = match.group()
             # remove non-digits
-            year = re.sub("[^0-9]", "", year)
+            year = re.sub(r"[^0-9]", "", year)
         return year
 
     def getRemainder(self, filename, year, count, volume, issue_end):

--- a/lib/comictaggerlib/filerenamer.py
+++ b/lib/comictaggerlib/filerenamer.py
@@ -123,20 +123,20 @@ class FileRenamer:
         if self.smart_cleanup:
 
             # remove empty braces,brackets, parentheses
-            new_name = re.sub("\(\s*[-:]*\s*\)", "", new_name)
-            new_name = re.sub("\[\s*[-:]*\s*\]", "", new_name)
-            new_name = re.sub("\{\s*[-:]*\s*\}", "", new_name)
+            new_name = re.sub(r"\(\s*[-:]*\s*\)", "", new_name)
+            new_name = re.sub(r"\[\s*[-:]*\s*\]", "", new_name)
+            new_name = re.sub(r"\{\s*[-:]*\s*\}", "", new_name)
 
             # remove duplicate spaces
             new_name = " ".join(new_name.split())
 
             # remove remove duplicate -, _,
-            new_name = re.sub("[-_]{2,}\s+", "-- ", new_name)
-            new_name = re.sub("(\s--)+", " --", new_name)
-            new_name = re.sub("(\s-)+", " -", new_name)
+            new_name = re.sub(r"[-_]{2,}\s+", "-- ", new_name)
+            new_name = re.sub(r"(\s--)+", " --", new_name)
+            new_name = re.sub(r"(\s-)+", " -", new_name)
 
             # remove dash or double dash at end of line
-            new_name = re.sub("[-]{1,2}\s*$", "", new_name)
+            new_name = re.sub(r"[-]{1,2}\s*$", "", new_name)
 
             # remove duplicate spaces (again!)
             new_name = " ".join(new_name.split())

--- a/lib/comictaggerlib/settings.py
+++ b/lib/comictaggerlib/settings.py
@@ -156,10 +156,10 @@ class ComicTaggerSettings:
         if self.rar_exe_path == "":
             if platform.system() == "Windows":
                 # look in some likely places for Windows machines
-                if os.path.exists("C:\Program Files\WinRAR\Rar.exe"):
-                    self.rar_exe_path = "C:\Program Files\WinRAR\Rar.exe"
-                elif os.path.exists("C:\Program Files (x86)\WinRAR\Rar.exe"):
-                    self.rar_exe_path = "C:\Program Files (x86)\WinRAR\Rar.exe"
+                if os.path.exists(r"C:\Program Files\WinRAR\Rar.exe"):
+                    self.rar_exe_path = r"C:\Program Files\WinRAR\Rar.exe"
+                elif os.path.exists(r"C:\Program Files (x86)\WinRAR\Rar.exe"):
+                    self.rar_exe_path = r"C:\Program Files (x86)\WinRAR\Rar.exe"
             else:
                 # see if it's in the path of unix user
                 if utils.which("rar") is not None:

--- a/mylar/cmtagmylar.py
+++ b/mylar/cmtagmylar.py
@@ -264,7 +264,7 @@ def run(dirName, nzbName=None, issueid=None, comversion=None, manual=None, filen
                 else:
                     tmpfilename = re.sub('Archive exported successfully to: ', '', out.rstrip())
                 if mylar.CONFIG.FILE_OPTS == 'move':
-                    tmpfilename = re.sub('\(Original deleted\)', '', tmpfilename).strip()
+                    tmpfilename = re.sub(r'\(Original deleted\)', '', tmpfilename).strip()
                 tmpf = tmpfilename
                 filepath = os.path.join(comicpath, tmpf)
                 if filename.lower() != tmpf.lower() and tmpf.endswith('(1).cbz'):
@@ -279,6 +279,8 @@ def run(dirName, nzbName=None, issueid=None, comversion=None, manual=None, filen
                 if not os.path.isfile(filepath):
                     logger.fdebug('%s Trying utf-8 conversion.' % module)
                     tmpf = tmpfilename.encode('utf-8')
+                    # TODO: This needs fixing to avoid it throwing errors joining string and bytes, but first we stop getting here
+                    # in the first place
                     filepath = os.path.join(comicpath, tmpf)
                     if not os.path.isfile(filepath):
                         logger.fdebug('%s Trying latin-1 conversion.' % module)


### PR DESCRIPTION
Fixes the metatagging failures under unstable.  The problem was that Syntaxwarnings are now present on regex patterns with escapes, combined with the way comictagger is called as a process which then eats all of stdout and stderr for feedback.  It meant bogus strings were ending up in the "filename" output (which is a problem in itself) and then punting it down a codepath that is broken (trying to use a decoded byte string in a path).  The whole thing really needs a good look at and refactor, but this quick fix resolves that polluted filename string problem.

There are going to be lots of other gotchas elsewhere in the codebase that might not have been caught by the first pass on regex strings.  Needs a manual review across `re\.([a-z]*)\((["'])` at minimum, plus anywhere that might have the pattern as a kwarg or passed in as a variable.

We may still have a lot of special cases of 3.12 problems left to find unfortunately.