### PR TITLE
AirDC++ Download update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,11 @@ It will also allow you to monitor weekly pull-lists for items belonging to said 
 Install it via git clone or via [Docker](https://hub.docker.com/r/linuxserver/mylar3)
 
 ## Documentation
-Check out our [website](https://mylarcomics.com) for documentation!
+Check out our [website](https://mylar.nerdfirehurricane.com) for documentation!
 
 ## Support & Discussion
 Please try to limit Github issues to bugs & enhancement requests ONLY
 - [Github](https://github.com/mylar3/mylar3/issues) (Bug & Feature requests only)
-- [Forums](https://forum.mylarcomics.com)
 
 ## Development
 We welcome contributions! At present we ask that you submit changes to the 1000papercuts branch. 
@@ -28,11 +27,11 @@ basis once given changes have been proven.
 
 ## Live Support / Conversation
 - [Discord](https://discord.gg/6UG94R7E8T)
-- [IRC](https://web.libera.chat/?channels=#mylar)
 
 ## Features
 - Abliity to be run on various OS' (windows, linux, macOS, Raspberry Pi, etc)
 - Support for SABnzbd, NZBGet and various torrent clients (as well as Blackhole)
+- AirDC++ Support for pulling releases from your favorite hubs
 - Multiple newznabs support, as well including a raw indexer and direct download being available
 - Ability to see upcoming new releases for a particular week and take action on them if required
 - View pullists up to 4 weeks in advance, or several months prior
@@ -50,7 +49,7 @@ basis once given changes have been proven.
 AND SO MUCH MORE!
 
 ## Contributing
-If you wish to help out, please see our website: [contributing](https://mylarcomics.com/docs/contributing)
+If you wish to help out, please see our website: [contributing](https://mylar.nerdfirehurricane.com/docs/contributing)
  
-<p align="center">This project exists thanks to all the people who contribute - whether by code, assisting others or financial donations.</br> 
+<p align="center">This project exists thanks to all the people who contribute - whether by code, or assisting others</br> 
 To all those who have contributed, we thank you for your support.</p>

--- a/mylar/downloaders/airdcpp.py
+++ b/mylar/downloaders/airdcpp.py
@@ -404,8 +404,6 @@ class AirDCPP(object):
                 search_instance_id = self.current_search_instance_id
 
             payload = {
-                "target_directory": dl_location,
-                "target_name": filename,
                 "priority": 4
             }
 


### PR DESCRIPTION
Current implementation passes the AirDC++ download location to AirDC++ manually, this causes pathing issues with Windows installs of AirDC (see discord conversation in #support on April 6th 2026). The two payload attributes `target_name` and `target_directory` are optional and default to using `filename` and `dl_location` by default. With the translation via API of `/` to `_` this results in the first image below as filename and attempt to create an invalid file on the windows install.
 
<img width="882" height="50" alt="image" src="https://github.com/user-attachments/assets/d3550a23-bc4a-40b3-b378-136b0b478e00" />

By leaving these payload items out, we're allowing AirDC to manage where the files go within its system and to pass along the resulting file to Mylar where we already account for the system path differences in the function `download` on what is now line `391`.

Reference docs/endpoint screenshot for easy verification.
[API Doc on endpoint](https://airdcpp.docs.apiary.io/#reference/search-instances/results/download-result)
<img width="847" height="645" alt="Screenshot_20260406_102443" src="https://github.com/user-attachments/assets/f2aa8bf7-e1d4-48de-ae0b-d563ec0df6a0" />
