### PR TITLE
feat(qbittorrent): add Ignore SSL warnings option for self-signed certificates

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -766,6 +766,12 @@
                                         <label>qBittorrent Host:Port </label>
                                         <input type="text" name="qbittorrent_host" id="qbittorrent_host" value="${config['qbittorrent_host']}" size="30">
                                 </div>
+                                <div class="config">
+                                    <div class="row checkbox left clearfix">
+                                        <input id="qbittorrent_ignore_ssl" type="checkbox" name="qbittorrent_ignore_ssl" value="1" ${config['qbittorrent_ignore_ssl']} /><label>Ignore SSL warnings</label>
+                                        <small>(enable to allow self-signed certificates)</small>
+                                    </div>
+                                </div>
                                 <div class="row">
                                         <label>qBittorrent Username</label>
                                         <input type="text" name="qbittorrent_username" id="qbittorrent_username" value="${config['qbittorrent_username']}" size="30">
@@ -2881,8 +2887,9 @@
                     var host = document.getElementById("qbittorrent_host").value;
                     var username = document.getElementById("qbittorrent_username").value;
                     var password = document.getElementById("qbittorrent_password").value;
+                    var ignore_ssl = document.getElementById("qbittorrent_ignore_ssl").checked;
                     $.get("testqbit",
-                        { host: host, username: username, password: password },
+                        { host: host, username: username, password: password, ignore_ssl: ignore_ssl },
                         function(data){
                             if (data.error != undefined) {
                                 alert(data.error);

--- a/lib/qbittorrent/client.py
+++ b/lib/qbittorrent/client.py
@@ -8,13 +8,14 @@ class LoginRequired(Exception):
 
 class Client(object):
     """class to interact with qBittorrent WEB API"""
-    def __init__(self, url):
+    def __init__(self, url, verify=True):
         if not url.endswith('/'):
             url += '/'
         self.url = url
+        self.verify = verify
 
         session = requests.Session()
-        check_prefs = session.get(url+'api/v2/app/preferences')
+        check_prefs = session.get(url+'api/v2/app/preferences', verify=self.verify)
 
         if check_prefs.status_code == 200:
             self._is_authenticated = True
@@ -72,9 +73,9 @@ class Client(object):
 
         rq = self.session
         if method == 'get':
-            request = rq.get(final_url, **kwargs)
+            request = rq.get(final_url, verify=self.verify, **kwargs)
         else:
-            request = rq.post(final_url, data, **kwargs)
+            request = rq.post(final_url, data, verify=self.verify, **kwargs)
 
         request.raise_for_status()
         request.encoding = 'utf_8'
@@ -105,7 +106,8 @@ class Client(object):
         self.session = requests.Session()
         login = self.session.post(self.url+'api/v2/auth/login',
                                   data={'username': username,
-                                        'password': password})
+                                        'password': password},
+                                  verify=self.verify)
         if login.text == 'Ok.':
             self._is_authenticated = True
         else:

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -438,6 +438,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'QBITTORRENT_LABEL': (str, 'qBittorrent', None),
     'QBITTORRENT_FOLDER': (str, 'qBittorrent', None),
     'QBITTORRENT_LOADACTION': (str, 'qBittorrent', 'default'),   #default, force_start, paused
+    'QBITTORRENT_IGNORE_SSL': (bool, 'qBittorrent', False),
 
     'OPDS_ENABLE': (bool, 'OPDS', False),
     'OPDS_AUTHENTICATION': (bool, 'OPDS', False),

--- a/mylar/torrent/clients/qbittorrent.py
+++ b/mylar/torrent/clients/qbittorrent.py
@@ -11,15 +11,18 @@ class TorrentClient(object):
     def __init__(self):
         self.conn = None
 
-    def connect(self, host, username, password, test=False):
+    def connect(self, host, username, password, ignore_ssl=None, test=False):
         if self.conn is not None:
             return self.connect
 
         if not host:
             return {'status': False, 'error': 'host not specified'}
 
+        if ignore_ssl is None:
+            ignore_ssl = mylar.CONFIG.QBITTORRENT_IGNORE_SSL
+
         try:
-            self.client = Client(host)
+            self.client = Client(host, verify=not ignore_ssl)
         except Exception as e:
             logger.error('Could not create qBittorrent Object %s' % e)
             return {'status': False, 'error': e}

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -6799,6 +6799,7 @@ class WebInterface(object):
                     "torrent_downloader_transmission": helpers.radio(int(mylar.CONFIG.TORRENT_DOWNLOADER), 3),
                     "torrent_downloader_deluge": helpers.radio(int(mylar.CONFIG.TORRENT_DOWNLOADER), 4),
                     "torrent_downloader_qbittorrent": helpers.radio(int(mylar.CONFIG.TORRENT_DOWNLOADER), 5),
+                    "qbittorrent_ignore_ssl": helpers.checked(mylar.CONFIG.QBITTORRENT_IGNORE_SSL),
                     "utorrent_host": mylar.CONFIG.UTORRENT_HOST,
                     "utorrent_username": mylar.CONFIG.UTORRENT_USERNAME,
                     "utorrent_password": mylar.CONFIG.UTORRENT_PASSWORD,
@@ -7320,7 +7321,7 @@ class WebInterface(object):
 
     def configUpdate(self, **kwargs):
         checked_configs = ['enable_https', 'launch_browser', 'backup_on_start', 'syno_fix', 'auto_update', 'annuals_on', 'api_enabled', 'nzb_startup_search',
-                           'enforce_perms', 'sab_to_mylar', 'torrent_local', 'torrent_seedbox', 'rtorrent_ssl', 'rtorrent_verify', 'rtorrent_startonload',
+                           'enforce_perms', 'sab_to_mylar', 'torrent_local', 'torrent_seedbox', 'rtorrent_ssl', 'rtorrent_verify', 'rtorrent_startonload', 'qbittorrent_ignore_ssl',
                            'enable_torrents', 'enable_rss', 'experimental', 'enable_torrent_search', 'enable_32p', 'enable_torznab',
                            'newznab', 'use_minsize', 'use_maxsize', 'ddump', 'failed_download_handling', 'sab_client_post_processing', 'nzbget_client_post_processing',
                            'failed_auto', 'post_processing', 'enable_check_folder', 'enable_pre_scripts', 'enable_snatch_script', 'enable_extra_scripts',
@@ -8342,10 +8343,14 @@ class WebInterface(object):
                 return 'Successfully validated rTorrent connection'
     testrtorrent.exposed = True
 
-    def testqbit(self, host, username, password):
+    def testqbit(self, host, username, password, ignore_ssl='false'):
+        if ignore_ssl == 'true':
+            ignore_ssl = True
+        elif ignore_ssl == 'false':
+            ignore_ssl = False
         from mylar.torrent.clients import qbittorrent as QbitClient
         qc = QbitClient.TorrentClient()
-        qclient = qc.connect(host, username, password, True)
+        qclient = qc.connect(host, username, password, ignore_ssl=ignore_ssl, test=True)
         if not qclient:
             logger.warn('[qBittorrent] Could not establish connection to %s' % host)
             return 'Error establishing connection to Qbittorrent'


### PR DESCRIPTION
Closes #1830

## Summary

Adds a `QBITTORRENT_IGNORE_SSL` config key and a UI checkbox ("Ignore SSL warnings")
under the qBittorrent Host field in Settings. When enabled, SSL certificate validation
is bypassed, allowing connections to qBittorrent instances using self-signed HTTPS
certificates.

Default is unchecked (off), so certificate validation is enforced by default — the
safe behaviour for most deployments.

## Changes

- `lib/qbittorrent/client.py`: accept `verify` kwarg in `__init__`, `login`, and
  `_request`; propagate it to every `requests` call
- `mylar/torrent/clients/qbittorrent.py`: accept `ignore_ssl` override in `connect()`;
  fall back to `mylar.CONFIG.QBITTORRENT_IGNORE_SSL` when not provided
- `mylar/config.py`: register `QBITTORRENT_IGNORE_SSL` (bool, default `False`)
- `data/interfaces/default/config.html`: add checkbox after Host field; pass live
  checkbox state to the Test endpoint so the test reflects the unsaved UI value
- `mylar/webserve.py`: expose key in config dict and `checked_configs` list; update
  `testqbit` to accept and honour the `ignore_ssl` parameter

## Behaviour

| Checkbox | Effective `verify` | Use case |
|---|---|---|
| Unchecked (default) | `True` | Publicly trusted certificate |
| Checked | `False` | Self-signed / private CA certificate |

Follows the existing `RTORRENT_VERIFY` / `rtorrent_verify` pattern.